### PR TITLE
examples: add a command-backed provider extension

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Added
 
 - `/usage` now shows prepaid credit balances (e.g. Charm Hyper's `100 credits left`) on the provider cards and account summaries instead of `no data` ([#11656](https://github.com/can1357/oh-my-pi/pull/11656) by [@oldschoola](https://github.com/oldschoola)).
-- Added `examples/extensions/command-provider.ts`, a worked command-backed provider: one child process per request, JSONL on stdout, thinking levels mapped onto the CLI's own effort flag, an allowlisted child environment so OMP's provider keys never reach it, and cancellation, timeouts, and non-zero exits surfaced as stream errors ([#11838](https://github.com/can1357/oh-my-pi/pull/11838) by [@aminamos](https://github.com/aminamos)).
 - Added `examples/extensions/command-provider.ts`, a command-backed provider that runs a local CLI (`muse exec --json`) as an OMP provider: the prompt travels through the command's prompt-file flag, a new child session is seeded with the retained context, each provider registers its own API id, and a stock Windows Muse install resolves to the versioned executable its shim selects ([#11838](https://github.com/can1357/oh-my-pi/pull/11838) by [@aminamos](https://github.com/aminamos)).
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - `/usage` now shows prepaid credit balances (e.g. Charm Hyper's `100 credits left`) on the provider cards and account summaries instead of `no data` ([#11656](https://github.com/can1357/oh-my-pi/pull/11656) by [@oldschoola](https://github.com/oldschoola)).
+- Added `examples/extensions/command-provider.ts`, a worked command-backed provider: one child process per request, JSONL on stdout, thinking levels mapped onto the CLI's own effort flag, an allowlisted child environment so OMP's provider keys never reach it, and cancellation, timeouts, and non-zero exits surfaced as stream errors ([#11838](https://github.com/can1357/oh-my-pi/pull/11838) by [@aminamos](https://github.com/aminamos)).
+- Added `examples/extensions/command-provider.ts`, a command-backed provider that runs a local CLI (`muse exec --json`) as an OMP provider: the prompt travels through the command's prompt-file flag, a new child session is seeded with the retained context, each provider registers its own API id, and a stock Windows Muse install resolves to the versioned executable its shim selects ([#11838](https://github.com/can1357/oh-my-pi/pull/11838) by [@aminamos](https://github.com/aminamos)).
 
 ### Fixed
 

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -34,15 +34,15 @@ cp permission-gate.ts ~/.omp/agent/extensions/
 
 ### Commands & UI
 
-| Extension        | Description                                                                    |
-| ---------------- | ------------------------------------------------------------------------------ |
-| `plan-mode.ts`   | Claude Code-style plan mode for read-only exploration with `/plan` command     |
-| `tools.ts`       | Interactive `/tools` command to enable/disable tools with session persistence  |
-| `handoff.ts`     | Transfer context to a new focused session via `/handoff <goal>`                |
-| `qna.ts`         | Extracts questions from last response into editor via `ctx.ui.setEditorText()` |
-| `status-line.ts` | Shows turn progress in footer via `ctx.ui.setStatus()` with themed colors      |
+| Extension          | Description                                                                    |
+| ------------------ | ------------------------------------------------------------------------------ |
+| `plan-mode.ts`     | Claude Code-style plan mode for read-only exploration with `/plan` command     |
+| `tools.ts`         | Interactive `/tools` command to enable/disable tools with session persistence  |
+| `handoff.ts`       | Transfer context to a new focused session via `/handoff <goal>`                |
+| `qna.ts`           | Extracts questions from last response into editor via `ctx.ui.setEditorText()` |
+| `status-line.ts`   | Shows turn progress in footer via `ctx.ui.setStatus()` with themed colors      |
 | `thinking-note.ts` | Adds display-only supplemental UI below assistant thinking blocks              |
-| `snake.ts`       | Snake game with custom UI, keyboard handling, and session persistence          |
+| `snake.ts`         | Snake game with custom UI, keyboard handling, and session persistence          |
 
 ### Git Integration
 
@@ -115,6 +115,7 @@ export default function (pi: ExtensionAPI) {
 	});
 }
 ```
+
 ## Key Patterns
 
 **Use `z.enum` for discriminated string tool args:**

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -66,6 +66,12 @@ cp permission-gate.ts ~/.omp/agent/extensions/
 | `with-deps/`      | Extension with its own package.json and dependencies                      |
 | `file-trigger.ts` | Watches a trigger file and injects contents into conversation             |
 
+### Model Providers
+
+| Extension             | Description                                                                                                            |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `command-provider.ts` | Runs a local CLI as a model provider (`muse exec --json`), so a subscription CLI serves requests instead of an API key |
+
 ## Writing Extensions
 
 See [docs/extensions.md](../../docs/extensions.md) for full documentation.

--- a/packages/coding-agent/examples/extensions/command-provider.ts
+++ b/packages/coding-agent/examples/extensions/command-provider.ts
@@ -11,45 +11,58 @@
  *
  * Features:
  * - maps OMP thinking levels onto the command's own effort flag
+ * - hands the prompt to the child through its prompt-file flag, so prompt size
+ *   is bounded by the filesystem instead of the OS command line (32767
+ *   characters on Windows) and prompt text never appears in a process listing;
+ *   `promptTransport: "argv"` covers commands that only take a positional
+ *   prompt
+ * - seeds the child conversation with the retained context when a session id
+ *   is new to this process, so switching models or forking a session does not
+ *   drop the transcript, then sends only the new turn
  * - spawns one child per request and streams its output as canonical assistant
  *   events, with `options.signal`, `options.cwd`, and `options.sessionId`
- *   forwarded so cancellation, the working directory, and one child
- *   conversation per stable session id all behave
+ *   forwarded. The canonical `AssistantMessageEventStream` settles `result()`
+ *   with the error message for a terminal failure rather than rejecting, which
+ *   is what the agent loop reads back after observing the error event
  * - builds the child environment from an allowlist: platform basics, proxy/TLS
  *   settings, XDG locations, and the child's own MUSE_* switches. OMP's
  *   provider keys are never inherited, so the child authenticates the way it
  *   normally does on this machine (for Muse: its own login/session)
- * - converts a hung command into a timeout and a non-zero exit into a stream
- *   error instead of an empty success
+ * - gives every provider its own API id: custom APIs live in one global
+ *   registry keyed by id, so a shared default would let a second command
+ *   provider take over the first one's requests
+ * - keeps a hung command from wedging a turn (timeout), turns a non-zero exit
+ *   into an error event, and kills the child when the request is aborted
+ * - refuses unusable Windows batch shims: the Muse installer ships `muse.cmd`
+ *   next to `muse-bin-<version>.exe`, and cmd.exe re-parses anything handed to
+ *   the shim, so the versioned executable named by `.muse-version` is used
  *
  * Usage:
  * 1. Copy this file to ~/.omp/agent/extensions/, or load it with
  *    `omp --extension packages/coding-agent/examples/extensions/command-provider.ts`
  * 2. Select `muse-exec/muse-exec` with /model
  * 3. Override the preset without editing it: MUSE_EXEC_COMMAND,
- *    MUSE_EXEC_ARGS, MUSE_OMP_PROVIDER, MUSE_OMP_MODEL
- *
- * On Windows the Muse installer only puts `muse.cmd` on PATH, and Bun refuses
- * to hand prompt text to a batch shim (cmd.exe would re-parse quotes, `&`, and
- * `<`). Point MUSE_EXEC_COMMAND at the versioned `muse-bin-<version>.exe` the
- * shim itself selects.
+ *    MUSE_EXEC_ARGS (a JSON string array, or whitespace-separated),
+ *    MUSE_OMP_PROVIDER, MUSE_OMP_MODEL
  */
-import { existsSync } from "node:fs";
-import { extname, join } from "node:path";
-import type {
-	Api,
-	AssistantMessage,
-	AssistantMessageEvent,
-	AssistantMessageEventStream,
-	Context,
-	Effort,
-	Model,
-	SimpleStreamOptions,
-	Usage,
-} from "@oh-my-pi/pi-ai";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai";
+import type { Api, AssistantMessage, Context, Effort, Model, SimpleStreamOptions, Usage } from "@oh-my-pi/pi-ai";
 import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
 
-export const COMMAND_PROVIDER_API = "command-subprocess-api" as Api;
+/** Prefix for the API id a command provider registers under. */
+export const COMMAND_PROVIDER_API = "command-subprocess-api";
+
+/**
+ * Custom API ids are global: `registerCustomApi()` keeps one stream handler per
+ * id, so two command providers sharing an id would run the second provider's
+ * command for the first provider's models.
+ */
+export function commandProviderApiId(providerName: string): Api {
+	return `${COMMAND_PROVIDER_API}:${providerName}` as Api;
+}
 
 /** Efforts offered for command-backed models, least to most intensive. */
 export const COMMAND_PROVIDER_EFFORTS = ["minimal", "low", "medium", "high", "xhigh", "max"] as const;
@@ -78,27 +91,62 @@ export function resolveReasoningEffort(options?: SimpleStreamOptions): string {
 	return "max";
 }
 
+/** Child sessions this process has already seeded, oldest first. */
+const seededSessions = new Set<string>();
+const SEEDED_SESSION_LIMIT = 64;
+
+/**
+ * Mark a child session as seeded. Returns true when the id had not been seen
+ * yet, which is exactly when the child has no conversation to continue.
+ */
+export function markSessionSeeded(sessionId: string): boolean {
+	if (seededSessions.has(sessionId)) return false;
+	seededSessions.add(sessionId);
+	if (seededSessions.size > SEEDED_SESSION_LIMIT) {
+		const oldest = seededSessions.values().next().value;
+		if (oldest !== undefined) seededSessions.delete(oldest);
+	}
+	return true;
+}
+
 export interface CommandProviderConfig {
 	providerName: string;
+	/** API id override. Defaults to {@link commandProviderApiId}; keep it unique per provider. */
 	api?: Api;
 	modelId: string;
 	modelName?: string;
+	/** Command to run. Resolved against PATH; Windows batch shims are replaced by the executable they launch. */
 	command?: string;
 	commandArgs?: readonly string[];
-	/** Build the command arguments after the configured prefix. */
+	/** Build the arguments after `command`, excluding the prompt. */
 	buildArgs?: (input: {
 		sessionId: string;
 		cwd: string;
 		prompt: string;
+		promptPath: string;
 		model: Model<Api>;
 		effort: string;
 	}) => readonly string[];
+	/**
+	 * How the prompt reaches the child. `prompt-file` (default) writes it to a
+	 * temp file and appends {@link CommandProviderConfig.promptFileArgs}; `argv`
+	 * appends the prompt itself as the last argument.
+	 */
+	promptTransport?: "prompt-file" | "argv";
+	/** Arguments that hand the temp prompt file to the command. Default `--prompt-file <path>`. */
+	promptFileArgs?: (promptPath: string) => readonly string[];
+	/** Resolve the real executable a Windows batch shim launches; returning undefined reports the shim as unusable. */
+	shimExecutable?: (shimPath: string) => Promise<string | undefined>;
 	/** Extract a text delta from one decoded JSONL record. */
 	extractText?: (record: unknown, state: { emittedText: string }) => string | undefined;
 	/** Extract a readable terminal failure from one decoded JSONL record. */
 	extractError?: (record: unknown) => string | undefined;
-	/** Convert OMP context into the prompt accepted by the command. */
+	/** Convert OMP context into the prompt for one incremental turn. */
 	formatPrompt?: (context: Context) => string;
+	/** Serialize the retained context sent to a child session that has no history yet. */
+	formatSeed?: (context: Context) => string;
+	/** Seed a new child session with the retained context instead of only the new turn. Default true. */
+	seedContextOnNewSession?: boolean;
 	/** Resolve the child working directory. Defaults to OMP's request cwd or process.cwd(). */
 	cwd?: string | ((options: SimpleStreamOptions | undefined) => string | undefined);
 	/** Extra child environment values; `undefined` removes an allowlisted key. */
@@ -111,83 +159,6 @@ export interface CommandProviderConfig {
 
 interface JsonRecord {
 	payload?: { kind?: string; text?: string; reason?: string; terminal?: string };
-}
-
-/**
- * Small host-independent implementation of OMP's structural stream contract.
- * Keeping this runtime-free lets the same file load from a user extension
- * directory in a compiled `omp` binary, where host packages are injected for
- * types but are not necessarily resolvable as npm dependencies.
- */
-class LocalAssistantMessageEventStream {
-	private queue: AssistantMessageEvent[] = [];
-	private waiters: Array<{
-		resolve: (result: IteratorResult<AssistantMessageEvent>) => void;
-		reject: (error: unknown) => void;
-	}> = [];
-	private finished = false;
-	private failure: unknown;
-	private readonly final: Promise<AssistantMessage>;
-	private resolveFinal!: (message: AssistantMessage) => void;
-	private rejectFinal!: (error: unknown) => void;
-
-	constructor() {
-		this.final = new Promise<AssistantMessage>((resolve, reject) => {
-			this.resolveFinal = resolve;
-			this.rejectFinal = reject;
-		});
-		this.final.catch(() => {});
-	}
-
-	push(event: AssistantMessageEvent): void {
-		if (this.finished) return;
-		if (event.type === "done") {
-			this.finished = true;
-			this.resolveFinal(event.message);
-		} else if (event.type === "error") {
-			this.finished = true;
-			this.rejectFinal(event.error);
-		}
-		const waiter = this.waiters.shift();
-		if (waiter) waiter.resolve({ value: event, done: false });
-		else this.queue.push(event);
-		if (this.finished) {
-			while (this.waiters.length) this.waiters.shift()!.resolve({ value: undefined as never, done: true });
-		}
-	}
-
-	fail(error: unknown): void {
-		if (this.finished) return;
-		this.finished = true;
-		this.failure = error;
-		this.rejectFinal(error);
-		while (this.waiters.length) this.waiters.shift()!.reject(error);
-	}
-
-	end(): void {
-		if (this.finished) return;
-		this.fail(new Error("Command provider ended without a final assistant message."));
-	}
-
-	result(): Promise<AssistantMessage> {
-		return this.final;
-	}
-
-	async *[Symbol.asyncIterator](): AsyncIterator<AssistantMessageEvent> {
-		while (true) {
-			if (this.queue.length) {
-				yield this.queue.shift()!;
-				continue;
-			}
-			if (this.failure) throw this.failure;
-			if (this.finished) return;
-			const next = await new Promise<IteratorResult<AssistantMessageEvent>>((resolve, reject) =>
-				this.waiters.push({ resolve, reject }),
-			);
-			if (next.done) return;
-			yield next.value;
-		}
-	}
 }
 
 function textFromMessageContent(content: unknown): string {
@@ -215,6 +186,16 @@ export function latestUserPrompt(context: Context): string {
 		}
 	}
 	throw new Error("The command provider received a context without a user prompt.");
+}
+
+/** Default seed for a child session with no history: system prompt plus every retained turn. */
+export function formatContextSeed(context: Context): string {
+	const sections = (context.systemPrompt ?? []).map(prompt => `[system]\n${prompt}`);
+	for (const message of context.messages) {
+		const text = textFromMessageContent(message.content).trim();
+		if (text) sections.push(`[${message.role}]\n${text}`);
+	}
+	return sections.join("\n\n");
 }
 
 function emptyUsage(): Usage {
@@ -258,6 +239,7 @@ function defaultMuseError(record: unknown): string | undefined {
 	return payload.reason || `Muse run terminated with status ${payload.terminal || "unknown"}.`;
 }
 
+/** Read a stdout stream line by line; the child's JSONL framing is part of its protocol. */
 function readLines(stream: ReadableStream<Uint8Array>, onLine: (line: string) => void): Promise<void> {
 	return (async () => {
 		const decoder = new TextDecoder();
@@ -355,28 +337,45 @@ export function childEnvironment(overrides: Record<string, string | undefined> |
 	return env;
 }
 
-/** Launcher suffixes Windows accepts but Bun's PATH lookup for a bare name does not try. */
-const WINDOWS_LAUNCHER_SUFFIXES = [".exe", ".cmd", ".bat", ".com"];
+/** Windows batch shims re-parse arguments through cmd.exe and cannot take the prompt. */
+const BATCH_SHIM_SUFFIXES = [".cmd", ".bat"];
 
 /**
- * Resolve a bare command name against PATH on Windows. `Bun.spawn(["muse", …])`
- * only matches the exact name on PATH and never tries PATHEXT, so a launcher
- * shipped as `muse.cmd` (the Muse installer) stays invisible to the spawn.
- * Anything already carrying a path separator or an extension is left alone.
+ * Muse installs `muse.cmd` next to `muse-bin-<version>.exe` and records the
+ * active version in `.muse-version`, so the shim's own target is resolvable
+ * without running cmd.exe.
  */
-export function resolveCommandPath(command: string, environment: Record<string, string>): string {
-	if (process.platform !== "win32") return command;
-	if (/[\\/]/.test(command) || extname(command)) return command;
-	const searchPath = environment.PATH ?? environment.Path ?? "";
-	for (const entry of searchPath.split(";")) {
-		if (!entry) continue;
-		const base = entry.replace(/[\\/]+$/, "");
-		for (const suffix of WINDOWS_LAUNCHER_SUFFIXES) {
-			const candidate = join(base, `${command}${suffix}`);
-			if (existsSync(candidate)) return candidate;
-		}
+export async function museShimExecutable(shimPath: string): Promise<string | undefined> {
+	const directory = path.dirname(shimPath);
+	const version = await Bun.file(path.join(directory, ".muse-version"))
+		.text()
+		.catch(() => "");
+	const trimmed = version.trim();
+	if (!trimmed) return undefined;
+	const executable = path.join(directory, `muse-bin-${trimmed}.exe`);
+	return (await Bun.file(executable).exists()) ? executable : undefined;
+}
+
+/**
+ * Resolve a command against PATH. A Windows batch shim is never returned: it
+ * cannot receive the prompt safely, so the executable it launches is used
+ * instead, and an unresolvable shim is reported rather than spawned.
+ */
+export async function resolveCommandPath(
+	command: string,
+	environment: Record<string, string | undefined>,
+	shimExecutable: (shimPath: string) => Promise<string | undefined> = museShimExecutable,
+): Promise<string> {
+	const resolved = Bun.which(command, { PATH: environment.PATH ?? process.env.PATH });
+	if (!resolved) {
+		throw new Error(`Command provider cannot find "${command}" on PATH; set the command explicitly.`);
 	}
-	return command;
+	if (!BATCH_SHIM_SUFFIXES.some(suffix => resolved.toLowerCase().endsWith(suffix))) return resolved;
+	const executable = await shimExecutable(resolved);
+	if (executable) return executable;
+	throw new Error(
+		`"${command}" resolves to the Windows batch shim ${resolved}, which cannot receive the prompt; point the command at the executable it launches.`,
+	);
 }
 
 function abortProcess(processHandle: Bun.Subprocess<"pipe", "pipe", "pipe">): void {
@@ -387,16 +386,45 @@ function abortProcess(processHandle: Bun.Subprocess<"pipe", "pipe", "pipe">): vo
 	}
 }
 
+/** Parse `MUSE_EXEC_ARGS`: a JSON string array, otherwise whitespace-separated. */
+export function parseCommandArgs(value: string): string[] {
+	const trimmed = value.trim();
+	if (!trimmed) return [];
+	if (trimmed.startsWith("[")) {
+		const parsed: unknown = JSON.parse(trimmed);
+		if (!Array.isArray(parsed) || parsed.some(entry => typeof entry !== "string")) {
+			throw new Error("Command arguments must be a JSON array of strings.");
+		}
+		return parsed;
+	}
+	return trimmed.split(/\s+/);
+}
+
+/** Write the prompt to a temp file the child reads by path. */
+async function writePromptFile(prompt: string): Promise<string> {
+	const file = path.join(os.tmpdir(), `omp-command-prompt-${crypto.randomUUID()}.txt`);
+	await Bun.write(file, prompt);
+	return file;
+}
+
 export interface DefaultCommandArgsInput {
 	sessionId: string;
 	cwd: string;
 	prompt: string;
 	effort: string;
+	transport?: "prompt-file" | "argv";
+	promptPath?: string;
+	promptFileArgs?: (promptPath: string) => readonly string[];
 	commandArgs?: readonly string[];
 }
 
 /** Default `muse exec` argument layout, with the resolved reasoning effort pinned. */
 export function buildDefaultArgs(input: DefaultCommandArgsInput): string[] {
+	const transport = input.transport ?? "prompt-file";
+	const promptArgs =
+		transport === "argv"
+			? [input.prompt]
+			: (input.promptFileArgs ?? ((promptPath: string) => ["--prompt-file", promptPath]))(input.promptPath ?? "");
 	return [
 		"exec",
 		"--json",
@@ -406,21 +434,23 @@ export function buildDefaultArgs(input: DefaultCommandArgsInput): string[] {
 		input.cwd,
 		"--reasoning-effort",
 		input.effort,
+		...promptArgs,
 		...(input.commandArgs ?? []),
-		input.prompt,
 	];
 }
 
 export function createCommandStreamSimple(config: CommandProviderConfig) {
 	const command = config.command ?? "muse";
+	const transport = config.promptTransport ?? "prompt-file";
 	return (model: Model<Api>, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream => {
-		const stream = new LocalAssistantMessageEventStream() as unknown as AssistantMessageEventStream;
+		const stream = new AssistantMessageEventStream();
 		const startedAt = Date.now();
 		const partial = buildMessage(model, "", startedAt);
 		stream.push({ type: "start", partial });
 
 		void (async () => {
 			let child: Bun.Subprocess<"pipe", "pipe", "pipe"> | undefined;
+			let promptPath: string | undefined;
 			let emittedText = "";
 			let textStarted = false;
 			let terminalError: string | undefined;
@@ -439,23 +469,45 @@ export function createCommandStreamSimple(config: CommandProviderConfig) {
 
 			try {
 				if (options?.signal?.aborted) throw new Error("Command provider request was aborted.");
-				const cwd = typeof config.cwd === "function" ? config.cwd(options) : config.cwd;
-				const workingDirectory = options?.cwd ?? cwd ?? process.cwd();
-				const prompt = (config.formatPrompt ?? latestUserPrompt)(context);
+				const configuredCwd = typeof config.cwd === "function" ? config.cwd(options) : config.cwd;
+				const workingDirectory = options?.cwd ?? configuredCwd ?? process.cwd();
 				const sessionId = options?.sessionId ?? crypto.randomUUID();
+				const seed =
+					(config.seedContextOnNewSession ?? true) && markSessionSeeded(sessionId)
+						? (config.formatSeed ?? formatContextSeed)(context)
+						: undefined;
+				const prompt = seed ?? (config.formatPrompt ?? latestUserPrompt)(context);
 				const effort = resolveReasoningEffort(options);
+				const environment = childEnvironment(config.env);
+				const executable = await resolveCommandPath(
+					command,
+					environment,
+					config.shimExecutable ?? museShimExecutable,
+				);
+				if (transport === "prompt-file") promptPath = await writePromptFile(prompt);
 				const args = config.buildArgs
-					? [...config.buildArgs({ sessionId, cwd: workingDirectory, prompt, model, effort })]
+					? [
+							...config.buildArgs({
+								sessionId,
+								cwd: workingDirectory,
+								prompt,
+								promptPath: promptPath ?? "",
+								model,
+								effort,
+							}),
+						]
 					: buildDefaultArgs({
 							sessionId,
 							cwd: workingDirectory,
 							prompt,
 							effort,
+							transport,
+							promptPath,
+							promptFileArgs: config.promptFileArgs,
 							commandArgs: config.commandArgs,
 						});
 
-				const environment = childEnvironment(config.env);
-				child = Bun.spawn([resolveCommandPath(command, environment), ...args], {
+				child = Bun.spawn([executable, ...args], {
 					cwd: workingDirectory,
 					env: environment,
 					stdout: "pipe",
@@ -485,15 +537,13 @@ export function createCommandStreamSimple(config: CommandProviderConfig) {
 					stream.push({ type: "text_delta", contentIndex: 0, delta, partial });
 				});
 
-				let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+				const timeout = Promise.withResolvers<number>();
+				const timeoutHandle: Bun.Timer = setTimeout(
+					() => timeout.reject(new Error(`Command timed out after ${timeoutMs} ms.`)),
+					timeoutMs,
+				);
 				try {
-					const timeout = new Promise<number>((_, reject) => {
-						timeoutHandle = setTimeout(
-							() => reject(new Error(`Command timed out after ${timeoutMs} ms.`)),
-							timeoutMs,
-						);
-					});
-					const exitCode = await Promise.race([child.exited, timeout]);
+					const exitCode = await Promise.race([child.exited, timeout.promise]);
 					await stdoutPromise;
 					const stderr = (await stderrPromise).trim();
 					if (options?.signal?.aborted) throw new Error("Command provider request was aborted.");
@@ -509,7 +559,7 @@ export function createCommandStreamSimple(config: CommandProviderConfig) {
 					}
 					stream.push({ type: "done", reason: "stop", message: partial });
 				} finally {
-					if (timeoutHandle) clearTimeout(timeoutHandle);
+					clearTimeout(timeoutHandle);
 				}
 			} catch (error) {
 				if (child) abortProcess(child);
@@ -518,6 +568,7 @@ export function createCommandStreamSimple(config: CommandProviderConfig) {
 				stream.push({ type: "error", reason: "error", error: errorMessage });
 			} finally {
 				options?.signal?.removeEventListener("abort", abortHandler);
+				if (promptPath) await fs.promises.rm(promptPath, { force: true }).catch(() => {});
 			}
 		})();
 		return stream;
@@ -525,7 +576,7 @@ export function createCommandStreamSimple(config: CommandProviderConfig) {
 }
 
 export function registerCommandProvider(pi: ExtensionAPI, config: CommandProviderConfig): void {
-	const api = config.api ?? COMMAND_PROVIDER_API;
+	const api = config.api ?? commandProviderApiId(config.providerName);
 	const reasoning = config.reasoning ?? true;
 	pi.registerProvider(config.providerName, {
 		baseUrl: "https://command-provider.invalid/",
@@ -560,10 +611,8 @@ export default function museExecProvider(pi: ExtensionAPI): void {
 		providerName: process.env.MUSE_OMP_PROVIDER ?? "muse-exec",
 		modelId: process.env.MUSE_OMP_MODEL ?? "muse-exec",
 		modelName: "Muse Code via muse exec",
-		// Resolve the launcher through PATH; on Windows this also finds
-		// `muse.cmd`, which `Bun.spawn(["muse", …])` alone would miss.
-		command: process.env.MUSE_EXEC_COMMAND ?? resolveCommandPath("muse", childEnvironment(undefined)),
-		commandArgs: process.env.MUSE_EXEC_ARGS ? process.env.MUSE_EXEC_ARGS.split(" ") : [],
+		command: process.env.MUSE_EXEC_COMMAND ?? "muse",
+		commandArgs: process.env.MUSE_EXEC_ARGS ? parseCommandArgs(process.env.MUSE_EXEC_ARGS) : [],
 		// Keep this a Muse session: Muse owns the inner read/write/bash/web loop.
 		// OMP receives only the final text stream. The child environment is
 		// allowlisted, so OMP's PAYG keys cannot leak in; META_API_KEY is pinned

--- a/packages/coding-agent/examples/extensions/command-provider.ts
+++ b/packages/coding-agent/examples/extensions/command-provider.ts
@@ -1,0 +1,573 @@
+/**
+ * Command-Backed Provider Extension
+ *
+ * Registers a provider whose transport is a local command instead of an HTTP
+ * endpoint: one child process per request, JSONL on stdout, assistant text
+ * streamed back into OMP. The preset below runs `muse exec --json`, which is
+ * how a Muse Code plan can be used from OMP — the CLI authenticates with its
+ * own subscription, while the same model reached through a Meta API key bills
+ * per token even for an account that already pays for a plan. Any local CLI or
+ * stdio service that emits incremental JSONL works the same way.
+ *
+ * Features:
+ * - maps OMP thinking levels onto the command's own effort flag
+ * - spawns one child per request and streams its output as canonical assistant
+ *   events, with `options.signal`, `options.cwd`, and `options.sessionId`
+ *   forwarded so cancellation, the working directory, and one child
+ *   conversation per stable session id all behave
+ * - builds the child environment from an allowlist: platform basics, proxy/TLS
+ *   settings, XDG locations, and the child's own MUSE_* switches. OMP's
+ *   provider keys are never inherited, so the child authenticates the way it
+ *   normally does on this machine (for Muse: its own login/session)
+ * - converts a hung command into a timeout and a non-zero exit into a stream
+ *   error instead of an empty success
+ *
+ * Usage:
+ * 1. Copy this file to ~/.omp/agent/extensions/, or load it with
+ *    `omp --extension packages/coding-agent/examples/extensions/command-provider.ts`
+ * 2. Select `muse-exec/muse-exec` with /model
+ * 3. Override the preset without editing it: MUSE_EXEC_COMMAND,
+ *    MUSE_EXEC_ARGS, MUSE_OMP_PROVIDER, MUSE_OMP_MODEL
+ *
+ * On Windows the Muse installer only puts `muse.cmd` on PATH, and Bun refuses
+ * to hand prompt text to a batch shim (cmd.exe would re-parse quotes, `&`, and
+ * `<`). Point MUSE_EXEC_COMMAND at the versioned `muse-bin-<version>.exe` the
+ * shim itself selects.
+ */
+import { existsSync } from "node:fs";
+import { extname, join } from "node:path";
+import type {
+	Api,
+	AssistantMessage,
+	AssistantMessageEvent,
+	AssistantMessageEventStream,
+	Context,
+	Effort,
+	Model,
+	SimpleStreamOptions,
+	Usage,
+} from "@oh-my-pi/pi-ai";
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+
+export const COMMAND_PROVIDER_API = "command-subprocess-api" as Api;
+
+/** Efforts offered for command-backed models, least to most intensive. */
+export const COMMAND_PROVIDER_EFFORTS = ["minimal", "low", "medium", "high", "xhigh", "max"] as const;
+
+/** Muse `--reasoning-effort` accepts the OMP effort vocabulary 1:1 (plus none/ultra). */
+const MUSE_REASONING_EFFORTS: ReadonlySet<string> = new Set([
+	"none",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+	"ultra",
+]);
+
+/**
+ * Resolve the Muse reasoning effort for one request. The OMP thinking level
+ * maps 1:1 onto `muse exec --reasoning-effort`; requests without a level run
+ * at max, and thinking-off utility calls run at none.
+ */
+export function resolveReasoningEffort(options?: SimpleStreamOptions): string {
+	if (options?.disableReasoning) return "none";
+	const effort = options?.reasoning as string | undefined;
+	if (effort && MUSE_REASONING_EFFORTS.has(effort)) return effort;
+	return "max";
+}
+
+export interface CommandProviderConfig {
+	providerName: string;
+	api?: Api;
+	modelId: string;
+	modelName?: string;
+	command?: string;
+	commandArgs?: readonly string[];
+	/** Build the command arguments after the configured prefix. */
+	buildArgs?: (input: {
+		sessionId: string;
+		cwd: string;
+		prompt: string;
+		model: Model<Api>;
+		effort: string;
+	}) => readonly string[];
+	/** Extract a text delta from one decoded JSONL record. */
+	extractText?: (record: unknown, state: { emittedText: string }) => string | undefined;
+	/** Extract a readable terminal failure from one decoded JSONL record. */
+	extractError?: (record: unknown) => string | undefined;
+	/** Convert OMP context into the prompt accepted by the command. */
+	formatPrompt?: (context: Context) => string;
+	/** Resolve the child working directory. Defaults to OMP's request cwd or process.cwd(). */
+	cwd?: string | ((options: SimpleStreamOptions | undefined) => string | undefined);
+	/** Extra child environment values; `undefined` removes an allowlisted key. */
+	env?: Record<string, string | undefined>;
+	timeoutMs?: number;
+	contextWindow?: number;
+	maxTokens?: number;
+	reasoning?: boolean;
+}
+
+interface JsonRecord {
+	payload?: { kind?: string; text?: string; reason?: string; terminal?: string };
+}
+
+/**
+ * Small host-independent implementation of OMP's structural stream contract.
+ * Keeping this runtime-free lets the same file load from a user extension
+ * directory in a compiled `omp` binary, where host packages are injected for
+ * types but are not necessarily resolvable as npm dependencies.
+ */
+class LocalAssistantMessageEventStream {
+	private queue: AssistantMessageEvent[] = [];
+	private waiters: Array<{
+		resolve: (result: IteratorResult<AssistantMessageEvent>) => void;
+		reject: (error: unknown) => void;
+	}> = [];
+	private finished = false;
+	private failure: unknown;
+	private readonly final: Promise<AssistantMessage>;
+	private resolveFinal!: (message: AssistantMessage) => void;
+	private rejectFinal!: (error: unknown) => void;
+
+	constructor() {
+		this.final = new Promise<AssistantMessage>((resolve, reject) => {
+			this.resolveFinal = resolve;
+			this.rejectFinal = reject;
+		});
+		this.final.catch(() => {});
+	}
+
+	push(event: AssistantMessageEvent): void {
+		if (this.finished) return;
+		if (event.type === "done") {
+			this.finished = true;
+			this.resolveFinal(event.message);
+		} else if (event.type === "error") {
+			this.finished = true;
+			this.rejectFinal(event.error);
+		}
+		const waiter = this.waiters.shift();
+		if (waiter) waiter.resolve({ value: event, done: false });
+		else this.queue.push(event);
+		if (this.finished) {
+			while (this.waiters.length) this.waiters.shift()!.resolve({ value: undefined as never, done: true });
+		}
+	}
+
+	fail(error: unknown): void {
+		if (this.finished) return;
+		this.finished = true;
+		this.failure = error;
+		this.rejectFinal(error);
+		while (this.waiters.length) this.waiters.shift()!.reject(error);
+	}
+
+	end(): void {
+		if (this.finished) return;
+		this.fail(new Error("Command provider ended without a final assistant message."));
+	}
+
+	result(): Promise<AssistantMessage> {
+		return this.final;
+	}
+
+	async *[Symbol.asyncIterator](): AsyncIterator<AssistantMessageEvent> {
+		while (true) {
+			if (this.queue.length) {
+				yield this.queue.shift()!;
+				continue;
+			}
+			if (this.failure) throw this.failure;
+			if (this.finished) return;
+			const next = await new Promise<IteratorResult<AssistantMessageEvent>>((resolve, reject) =>
+				this.waiters.push({ resolve, reject }),
+			);
+			if (next.done) return;
+			yield next.value;
+		}
+	}
+}
+
+function textFromMessageContent(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.map(block => {
+			if (typeof block !== "object" || block === null) return "";
+			const value = block as { type?: string; text?: unknown; thinking?: unknown };
+			if (value.type === "text" && typeof value.text === "string") return value.text;
+			if (value.type === "thinking" && typeof value.thinking === "string") return value.thinking;
+			return "";
+		})
+		.filter(Boolean)
+		.join("");
+}
+
+/** Default context policy: Muse keeps the conversation; send only the new user turn. */
+export function latestUserPrompt(context: Context): string {
+	for (let index = context.messages.length - 1; index >= 0; index--) {
+		const message = context.messages[index];
+		if (message.role === "user") {
+			const prompt = textFromMessageContent(message.content).trim();
+			if (prompt) return prompt;
+		}
+	}
+	throw new Error("The command provider received a context without a user prompt.");
+}
+
+function emptyUsage(): Usage {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function buildMessage(model: Model<Api>, text: string, startedAt: number): AssistantMessage {
+	return {
+		role: "assistant",
+		content: text ? [{ type: "text", text }] : [],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: emptyUsage(),
+		stopReason: "stop",
+		timestamp: startedAt,
+	};
+}
+
+function defaultMuseText(record: unknown, state: { emittedText: string }): string | undefined {
+	if (typeof record !== "object" || record === null) return undefined;
+	const payload = (record as JsonRecord).payload;
+	if (payload?.kind === "run_output_delta" && typeof payload.text === "string") return payload.text;
+	if (payload?.kind === "run_terminal" && state.emittedText.length === 0 && typeof payload.text === "string") {
+		return payload.text;
+	}
+	return undefined;
+}
+
+function defaultMuseError(record: unknown): string | undefined {
+	if (typeof record !== "object" || record === null) return undefined;
+	const payload = (record as JsonRecord).payload;
+	if (payload?.kind !== "run_terminal" || payload.terminal === "completed") return undefined;
+	return payload.reason || `Muse run terminated with status ${payload.terminal || "unknown"}.`;
+}
+
+function readLines(stream: ReadableStream<Uint8Array>, onLine: (line: string) => void): Promise<void> {
+	return (async () => {
+		const decoder = new TextDecoder();
+		let buffer = "";
+		for await (const chunk of stream) {
+			buffer += decoder.decode(chunk, { stream: true });
+			const lines = buffer.split("\n");
+			buffer = lines.pop() ?? "";
+			for (const line of lines) if (line.trim()) onLine(line);
+		}
+		buffer += decoder.decode();
+		if (buffer.trim()) onLine(buffer);
+	})();
+}
+
+/**
+ * The only parent environment the child command may inherit. The child gets
+ * platform basics (so it can spawn helpers, resolve its own config, and write
+ * temp files) plus proxy/TLS settings; every other parent variable - model API
+ * keys, Cloudflare tokens, 1Password sessions, CI variables - stays inside the
+ * OMP process. Secrets must be opted in through `config.env`, never inherited.
+ */
+const INHERITED_ENVIRONMENT_KEYS = [
+	// POSIX runtime
+	"PATH",
+	"HOME",
+	"USER",
+	"LOGNAME",
+	"SHELL",
+	"TERM",
+	"TMPDIR",
+	"LANG",
+	"LC_ALL",
+	"LC_CTYPE",
+	"TZ",
+	// Windows runtime
+	"USERPROFILE",
+	"APPDATA",
+	"LOCALAPPDATA",
+	"TEMP",
+	"TMP",
+	"SystemDrive",
+	"SystemRoot",
+	"windir",
+	"ComSpec",
+	"PATHEXT",
+	"PSModulePath",
+	"PROGRAMDATA",
+	"PROGRAMFILES",
+	"PROGRAMFILES(X86)",
+	"COMMONPROGRAMFILES",
+	"USERNAME",
+	"USERDOMAIN",
+	"HOMEDRIVE",
+	"HOMEPATH",
+	"OS",
+	"PROCESSOR_ARCHITECTURE",
+	"NUMBER_OF_PROCESSORS",
+	"SESSIONNAME",
+	// Network and TLS, for headless runs behind a proxy or a private CA
+	"HTTP_PROXY",
+	"HTTPS_PROXY",
+	"ALL_PROXY",
+	"NO_PROXY",
+	"http_proxy",
+	"https_proxy",
+	"all_proxy",
+	"no_proxy",
+	"NODE_EXTRA_CA_CERTS",
+	"SSL_CERT_FILE",
+	"SSL_CERT_DIR",
+	// XDG locations, so the child finds its own config, state, and cache
+	"XDG_CONFIG_HOME",
+	"XDG_DATA_HOME",
+	"XDG_STATE_HOME",
+	"XDG_CACHE_HOME",
+] as const;
+
+/** The child's own MUSE_* switches are the one prefix that passes through. */
+const INHERITED_ENVIRONMENT_PREFIX = "MUSE_";
+
+export function childEnvironment(overrides: Record<string, string | undefined> | undefined): Record<string, string> {
+	const env: Record<string, string> = {};
+	for (const key of INHERITED_ENVIRONMENT_KEYS) {
+		const value = process.env[key];
+		if (value !== undefined) env[key] = value;
+	}
+	for (const [key, value] of Object.entries(process.env)) {
+		if (value !== undefined && key.startsWith(INHERITED_ENVIRONMENT_PREFIX)) env[key] = value;
+	}
+	for (const [key, value] of Object.entries(overrides ?? {})) {
+		if (value === undefined) delete env[key];
+		else env[key] = value;
+	}
+	return env;
+}
+
+/** Launcher suffixes Windows accepts but Bun's PATH lookup for a bare name does not try. */
+const WINDOWS_LAUNCHER_SUFFIXES = [".exe", ".cmd", ".bat", ".com"];
+
+/**
+ * Resolve a bare command name against PATH on Windows. `Bun.spawn(["muse", …])`
+ * only matches the exact name on PATH and never tries PATHEXT, so a launcher
+ * shipped as `muse.cmd` (the Muse installer) stays invisible to the spawn.
+ * Anything already carrying a path separator or an extension is left alone.
+ */
+export function resolveCommandPath(command: string, environment: Record<string, string>): string {
+	if (process.platform !== "win32") return command;
+	if (/[\\/]/.test(command) || extname(command)) return command;
+	const searchPath = environment.PATH ?? environment.Path ?? "";
+	for (const entry of searchPath.split(";")) {
+		if (!entry) continue;
+		const base = entry.replace(/[\\/]+$/, "");
+		for (const suffix of WINDOWS_LAUNCHER_SUFFIXES) {
+			const candidate = join(base, `${command}${suffix}`);
+			if (existsSync(candidate)) return candidate;
+		}
+	}
+	return command;
+}
+
+function abortProcess(processHandle: Bun.Subprocess<"pipe", "pipe", "pipe">): void {
+	try {
+		processHandle.kill();
+	} catch {
+		// The process may have exited between the abort and kill calls.
+	}
+}
+
+export interface DefaultCommandArgsInput {
+	sessionId: string;
+	cwd: string;
+	prompt: string;
+	effort: string;
+	commandArgs?: readonly string[];
+}
+
+/** Default `muse exec` argument layout, with the resolved reasoning effort pinned. */
+export function buildDefaultArgs(input: DefaultCommandArgsInput): string[] {
+	return [
+		"exec",
+		"--json",
+		"--session-id",
+		input.sessionId,
+		"--workspace",
+		input.cwd,
+		"--reasoning-effort",
+		input.effort,
+		...(input.commandArgs ?? []),
+		input.prompt,
+	];
+}
+
+export function createCommandStreamSimple(config: CommandProviderConfig) {
+	const command = config.command ?? "muse";
+	return (model: Model<Api>, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream => {
+		const stream = new LocalAssistantMessageEventStream() as unknown as AssistantMessageEventStream;
+		const startedAt = Date.now();
+		const partial = buildMessage(model, "", startedAt);
+		stream.push({ type: "start", partial });
+
+		void (async () => {
+			let child: Bun.Subprocess<"pipe", "pipe", "pipe"> | undefined;
+			let emittedText = "";
+			let textStarted = false;
+			let terminalError: string | undefined;
+			let malformedOutput: string | undefined;
+			const state = {
+				get emittedText() {
+					return emittedText;
+				},
+			};
+			const extractText = config.extractText ?? defaultMuseText;
+			const extractError = config.extractError ?? defaultMuseError;
+			const timeoutMs = config.timeoutMs ?? 15 * 60 * 1000;
+			const abortHandler = () => {
+				if (child) abortProcess(child);
+			};
+
+			try {
+				if (options?.signal?.aborted) throw new Error("Command provider request was aborted.");
+				const cwd = typeof config.cwd === "function" ? config.cwd(options) : config.cwd;
+				const workingDirectory = options?.cwd ?? cwd ?? process.cwd();
+				const prompt = (config.formatPrompt ?? latestUserPrompt)(context);
+				const sessionId = options?.sessionId ?? crypto.randomUUID();
+				const effort = resolveReasoningEffort(options);
+				const args = config.buildArgs
+					? [...config.buildArgs({ sessionId, cwd: workingDirectory, prompt, model, effort })]
+					: buildDefaultArgs({
+							sessionId,
+							cwd: workingDirectory,
+							prompt,
+							effort,
+							commandArgs: config.commandArgs,
+						});
+
+				const environment = childEnvironment(config.env);
+				child = Bun.spawn([resolveCommandPath(command, environment), ...args], {
+					cwd: workingDirectory,
+					env: environment,
+					stdout: "pipe",
+					stderr: "pipe",
+				});
+				options?.signal?.addEventListener("abort", abortHandler, { once: true });
+
+				const stderrPromise = new Response(child.stderr).text();
+				const stdoutPromise = readLines(child.stdout, line => {
+					let record: unknown;
+					try {
+						record = JSON.parse(line);
+					} catch {
+						malformedOutput ??= line.slice(0, 500);
+						return;
+					}
+					terminalError ??= extractError(record);
+					const delta = extractText(record, state);
+					if (!delta) return;
+					if (!textStarted) {
+						textStarted = true;
+						partial.content = [{ type: "text", text: "" }];
+						stream.push({ type: "text_start", contentIndex: 0, partial });
+					}
+					emittedText += delta;
+					partial.content = [{ type: "text", text: emittedText }];
+					stream.push({ type: "text_delta", contentIndex: 0, delta, partial });
+				});
+
+				let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+				try {
+					const timeout = new Promise<number>((_, reject) => {
+						timeoutHandle = setTimeout(
+							() => reject(new Error(`Command timed out after ${timeoutMs} ms.`)),
+							timeoutMs,
+						);
+					});
+					const exitCode = await Promise.race([child.exited, timeout]);
+					await stdoutPromise;
+					const stderr = (await stderrPromise).trim();
+					if (options?.signal?.aborted) throw new Error("Command provider request was aborted.");
+					if (exitCode !== 0) {
+						throw new Error(
+							terminalError || stderr || malformedOutput || `${command} exited with code ${exitCode}.`,
+						);
+					}
+					if (terminalError) throw new Error(terminalError);
+					if (textStarted) {
+						partial.content = [{ type: "text", text: emittedText }];
+						stream.push({ type: "text_end", contentIndex: 0, content: emittedText, partial });
+					}
+					stream.push({ type: "done", reason: "stop", message: partial });
+				} finally {
+					if (timeoutHandle) clearTimeout(timeoutHandle);
+				}
+			} catch (error) {
+				if (child) abortProcess(child);
+				const message = error instanceof Error ? error.message : String(error);
+				const errorMessage = { ...partial, stopReason: "error" as const, errorMessage: message };
+				stream.push({ type: "error", reason: "error", error: errorMessage });
+			} finally {
+				options?.signal?.removeEventListener("abort", abortHandler);
+			}
+		})();
+		return stream;
+	};
+}
+
+export function registerCommandProvider(pi: ExtensionAPI, config: CommandProviderConfig): void {
+	const api = config.api ?? COMMAND_PROVIDER_API;
+	const reasoning = config.reasoning ?? true;
+	pi.registerProvider(config.providerName, {
+		baseUrl: "https://command-provider.invalid/",
+		api,
+		apiKey: "command-provider-does-not-use-an-api-key",
+		streamSimple: createCommandStreamSimple({ ...config, api }),
+		models: [
+			{
+				id: config.modelId,
+				name: config.modelName ?? config.modelId,
+				reasoning,
+				...(reasoning
+					? {
+							thinking: {
+								mode: "effort",
+								efforts: [...COMMAND_PROVIDER_EFFORTS] as Effort[],
+								defaultLevel: "max" as Effort,
+							},
+						}
+					: {}),
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: config.contextWindow ?? 200_000,
+				maxTokens: config.maxTokens ?? 32_000,
+			},
+		],
+	});
+}
+
+export default function museExecProvider(pi: ExtensionAPI): void {
+	registerCommandProvider(pi, {
+		providerName: process.env.MUSE_OMP_PROVIDER ?? "muse-exec",
+		modelId: process.env.MUSE_OMP_MODEL ?? "muse-exec",
+		modelName: "Muse Code via muse exec",
+		// Resolve the launcher through PATH; on Windows this also finds
+		// `muse.cmd`, which `Bun.spawn(["muse", …])` alone would miss.
+		command: process.env.MUSE_EXEC_COMMAND ?? resolveCommandPath("muse", childEnvironment(undefined)),
+		commandArgs: process.env.MUSE_EXEC_ARGS ? process.env.MUSE_EXEC_ARGS.split(" ") : [],
+		// Keep this a Muse session: Muse owns the inner read/write/bash/web loop.
+		// OMP receives only the final text stream. The child environment is
+		// allowlisted, so OMP's PAYG keys cannot leak in; META_API_KEY is pinned
+		// absent as a second guard.
+		env: { META_API_KEY: undefined },
+	});
+}

--- a/packages/coding-agent/test/extensibility/command-provider.test.ts
+++ b/packages/coding-agent/test/extensibility/command-provider.test.ts
@@ -1,0 +1,281 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Api, AssistantMessageEventStream, Context, Model } from "@oh-my-pi/pi-ai";
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+import {
+	COMMAND_PROVIDER_API,
+	buildDefaultArgs,
+	childEnvironment,
+	commandProviderApiId,
+	createCommandStreamSimple,
+	type CommandProviderConfig,
+	museShimExecutable,
+	parseCommandArgs,
+	registerCommandProvider,
+	resolveCommandPath,
+	resolveReasoningEffort,
+} from "../../examples/extensions/command-provider";
+
+const MODEL = { id: "stub-model", api: "command-subprocess-api:stub", provider: "stub" } as unknown as Model<Api>;
+
+const tempDirectories: string[] = [];
+
+afterAll(async () => {
+	for (const directory of tempDirectories) await fs.promises.rm(directory, { recursive: true, force: true });
+});
+
+/**
+ * Write a stub child script and build the adapter around it. The prompt-file
+ * path arrives as `argv[2]` (`bun <script> <promptPath>`), so a stub can prove
+ * what the child actually received.
+ */
+async function stubAdapter(body: string, overrides: Partial<CommandProviderConfig> = {}) {
+	const directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-command-provider-"));
+	tempDirectories.push(directory);
+	const scriptPath = path.join(directory, "stub.ts");
+	await Bun.write(scriptPath, body);
+	const streamSimple = createCommandStreamSimple({
+		providerName: "stub",
+		modelId: "stub-model",
+		command: process.execPath,
+		buildArgs: ({ promptPath }) => [scriptPath, promptPath],
+		...overrides,
+	});
+	return { streamSimple, scriptPath };
+}
+
+async function drain(stream: AssistantMessageEventStream) {
+	const types: string[] = [];
+	let text = "";
+	for await (const event of stream) {
+		types.push(event.type);
+		if (event.type === "text_delta") text += event.delta;
+	}
+	return { types, text, result: await stream.result() };
+}
+
+const REPORT_TEXT = (expression: string) =>
+	`console.log(JSON.stringify({payload:{kind:"run_output_delta",text:${expression}}}));`;
+
+describe("command-backed provider transport", () => {
+	it("streams the child's JSONL text and settles the assistant message", async () => {
+		const { streamSimple } = await stubAdapter(
+			`${REPORT_TEXT('"hello from child"')}\nconsole.log(JSON.stringify({payload:{kind:"run_terminal",terminal:"completed"}}));`,
+		);
+		const stream = streamSimple(MODEL, { messages: [{ role: "user", content: "hi" }] } as Context, {
+			sessionId: crypto.randomUUID(),
+		});
+
+		const { types, result } = await drain(stream);
+
+		expect(types).toEqual(["start", "text_start", "text_delta", "text_end", "done"]);
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toEqual([{ type: "text", text: "hello from child" }]);
+	});
+
+	it("resolves a terminal failure record as the error result instead of rejecting", async () => {
+		const { streamSimple } = await stubAdapter(
+			'console.log(JSON.stringify({payload:{kind:"run_terminal",terminal:"failed",reason:"child exploded"}}));',
+		);
+		const stream = streamSimple(MODEL, { messages: [{ role: "user", content: "hi" }] } as Context, {
+			sessionId: crypto.randomUUID(),
+		});
+
+		const { types, result } = await drain(stream);
+
+		// The canonical stream settles result() with the error message; the agent
+		// loop reads that message back after observing the error event.
+		expect(types).toEqual(["start", "error"]);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("child exploded");
+	});
+
+	it("turns a non-zero exit into an error result", async () => {
+		const { streamSimple } = await stubAdapter("process.exit(3);");
+		const stream = streamSimple(MODEL, { messages: [{ role: "user", content: "hi" }] } as Context, {
+			sessionId: crypto.randomUUID(),
+		});
+
+		const { result } = await drain(stream);
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("exited with code 3");
+	});
+
+	it("kills the child and reports an aborted request", async () => {
+		const { streamSimple } = await stubAdapter("await new Promise(resolve => setTimeout(resolve, 30_000));");
+		const controller = new AbortController();
+		const stream = streamSimple(MODEL, { messages: [{ role: "user", content: "hi" }] } as Context, {
+			sessionId: crypto.randomUUID(),
+			signal: controller.signal,
+		});
+		setTimeout(() => controller.abort(), 100);
+
+		const { result } = await drain(stream);
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("aborted");
+	});
+
+	it("times out a hung command", async () => {
+		const { streamSimple } = await stubAdapter("await new Promise(resolve => setTimeout(resolve, 30_000));", {
+			timeoutMs: 150,
+		});
+		const stream = streamSimple(MODEL, { messages: [{ role: "user", content: "hi" }] } as Context, {
+			sessionId: crypto.randomUUID(),
+		});
+
+		const { result } = await drain(stream);
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("timed out after 150 ms");
+	});
+
+	it("hands a prompt larger than the Windows command line to the child through its prompt file", async () => {
+		const pending: Array<{ prompt: string; promptPath: string }> = [];
+		const { streamSimple, scriptPath } = await stubAdapter(
+			"const body = await Bun.file(process.argv[2]).text();\n" + REPORT_TEXT('String(body.endsWith("END-MARKER"))'),
+			{
+				buildArgs: input => {
+					pending.push({ prompt: input.prompt, promptPath: input.promptPath });
+					return [scriptPath, input.promptPath];
+				},
+			},
+		);
+		const prompt = `${"x".repeat(100_000)}END-MARKER`;
+		const stream = streamSimple(MODEL, { messages: [{ role: "user", content: prompt }] } as Context, {
+			sessionId: crypto.randomUUID(),
+		});
+
+		const { text, result } = await drain(stream);
+
+		expect(result.stopReason).toBe("stop");
+		// The child saw the whole prompt: 100k characters never fit an argv element.
+		expect(text).toBe("true");
+		expect(pending[0]?.prompt.endsWith(prompt)).toBe(true);
+		await Bun.sleep(100);
+		// The prompt travels by path only, and the temp file does not outlive the request.
+		expect(pending[0]?.promptPath.endsWith(".txt")).toBe(true);
+		expect(await Bun.file(pending[0]!.promptPath).exists()).toBe(false);
+	});
+
+	it("seeds a new child session with the retained context, then sends only the new turn", async () => {
+		const { streamSimple } = await stubAdapter(
+			"const body = await Bun.file(process.argv[2]).text();\n" + REPORT_TEXT("JSON.stringify(body)"),
+		);
+		const sessionId = crypto.randomUUID();
+		const retained = {
+			systemPrompt: ["be terse"],
+			messages: [
+				{ role: "user", content: "first question" },
+				{ role: "assistant", content: "first answer" },
+				{ role: "user", content: "second question" },
+			],
+		} as Context;
+
+		const first = await drain(streamSimple(MODEL, retained, { sessionId }));
+		const second = await drain(
+			streamSimple(MODEL, { messages: [{ role: "user", content: "third question" }] } as Context, { sessionId }),
+		);
+
+		const seeded = JSON.parse(first.text) as string;
+		expect(seeded).toContain("[system]\nbe terse");
+		expect(seeded).toContain("first answer");
+		expect(JSON.parse(second.text)).toBe("third question");
+	});
+});
+
+describe("command-backed provider configuration", () => {
+	it("keeps OMP credentials out of the child environment while passing MUSE_* through", () => {
+		const previous = {
+			OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+			META_API_KEY: process.env.META_API_KEY,
+			MUSE_TEST_SWITCH: process.env.MUSE_TEST_SWITCH,
+		};
+		process.env.OPENAI_API_KEY = "sk-should-not-leak";
+		process.env.META_API_KEY = "LLM|payg";
+		process.env.MUSE_TEST_SWITCH = "1";
+		try {
+			const env = childEnvironment({ META_API_KEY: undefined });
+
+			expect(env.OPENAI_API_KEY).toBeUndefined();
+			expect(env.MUSE_TEST_SWITCH).toBe("1");
+			expect(env.META_API_KEY).toBeUndefined();
+			expect(typeof env.PATH).toBe("string");
+		} finally {
+			for (const [key, value] of Object.entries(previous)) {
+				if (value === undefined) delete process.env[key];
+				else process.env[key] = value;
+			}
+		}
+	});
+
+	it("parses command arguments as JSON when a value contains spaces", () => {
+		expect(parseCommandArgs('["--config","C:\\\\Muse Config\\\\muse.json"]')).toEqual([
+			"--config",
+			"C:\\Muse Config\\muse.json",
+		]);
+		expect(parseCommandArgs("--verbose  --retries 2")).toEqual(["--verbose", "--retries", "2"]);
+		expect(() => parseCommandArgs("[1,2]")).toThrow();
+	});
+
+	it("maps thinking levels onto the command's effort flag", () => {
+		expect(resolveReasoningEffort({ reasoning: "low" })).toBe("low");
+		expect(resolveReasoningEffort({ disableReasoning: true, reasoning: "high" })).toBe("none");
+		expect(resolveReasoningEffort({ reasoning: "ultra" as never })).toBe("ultra");
+		expect(resolveReasoningEffort({ reasoning: "bogus" as never })).toBe("max");
+	});
+
+	it("builds the prompt-file layout and switches to argv on request", () => {
+		const base = { sessionId: "sid", cwd: "C:/work", prompt: "hello", effort: "high", promptPath: "/tmp/p.txt" };
+
+		expect(buildDefaultArgs({ ...base, commandArgs: ["--extra"] })).toEqual([
+			"exec",
+			"--json",
+			"--session-id",
+			"sid",
+			"--workspace",
+			"C:/work",
+			"--reasoning-effort",
+			"high",
+			"--prompt-file",
+			"/tmp/p.txt",
+			"--extra",
+		]);
+		expect(buildDefaultArgs({ ...base, transport: "argv" }).at(-1)).toBe("hello");
+	});
+
+	it("gives every registered command provider its own API id", () => {
+		const registered: Array<{ name: string; api: string }> = [];
+		const pi = {
+			registerProvider: (name: string, config: { api: string }) => registered.push({ name, api: config.api }),
+		} as unknown as ExtensionAPI;
+
+		registerCommandProvider(pi, { providerName: "alpha", modelId: "shared-model" });
+		registerCommandProvider(pi, { providerName: "beta", modelId: "shared-model" });
+
+		// Custom APIs are keyed by id in one global registry: a shared id would
+		// let the second provider run the first provider's command.
+		expect(registered.map(entry => entry.api)).toEqual([commandProviderApiId("alpha"), commandProviderApiId("beta")]);
+		expect(registered[0]?.api).toStartWith(`${COMMAND_PROVIDER_API}:`);
+	});
+
+	it("resolves the executable a Windows batch shim launches and reports a shim it cannot", async () => {
+		const directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-muse-shim-"));
+		tempDirectories.push(directory);
+		const shim = path.join(directory, "muse.cmd");
+		const executable = path.join(directory, "muse-bin-1.1.1-R2514.1.exe");
+		await Bun.write(shim, "@echo off\n");
+		await Bun.write(executable, "");
+		expect(await museShimExecutable(shim)).toBeUndefined();
+
+		await Bun.write(path.join(directory, ".muse-version"), "1.1.1-R2514.1\n");
+		expect(await museShimExecutable(shim)).toBe(executable);
+	});
+
+	it("reports a command it cannot find on PATH", async () => {
+		await expect(resolveCommandPath("omp-command-provider-absent", { PATH: "" })).rejects.toThrow(/cannot find/);
+	});
+});


### PR DESCRIPTION
## What

Adds `packages/coding-agent/examples/extensions/command-provider.ts`, a worked command-backed provider whose transport is a local command instead of an HTTP endpoint, plus contract tests for it.

In my own words: "muse exec needs to run thru omp bc using api will bill ppl unnecessarily like if they have a plan."

The adapter maps OMP thinking levels onto the command's effort flag, hands the prompt to the child through its prompt-file flag, seeds a child session that has no history yet with the retained context, streams the child's JSONL as canonical assistant events through `AssistantMessageEventStream`, and builds the child environment from an allowlist so OMP's provider keys never reach it. Every provider registers its own API id, and the Windows launcher resolves to the versioned executable the Muse shim selects instead of `muse.cmd`.

## Why

OMP registers providers over HTTP, so a CLI that holds its own subscription is the only way to use a plan-only transport. `muse exec` is the concrete case: the CLI authenticates with a Muse Code plan, while the same model reached through a Meta API key bills per token even for an account that already pays for a plan. Any local CLI or stdio service that emits incremental JSONL fits the same adapter. `docs/extensions.md` documents the pattern (#11798); this PR ships the runnable example and its tests.

## Testing

- `bun test packages/coding-agent/test/extensibility/command-provider.test.ts` → 14 pass / 0 fail. Coverage: success stream shape, terminal failure record, non-zero exit, abort, timeout, a 100k-character prompt through the prompt file, new-session seeding, environment allowlist, `MUSE_EXEC_ARGS` parsing, effort mapping, default argv layout, per-provider API ids, and shim resolution.
- Windows launcher resolution against a stock Muse install on this machine: returns `...\\muse-bin-1.1.1-R2514.1.exe`, not `muse.cmd`.
- `bun x oxfmt --check` and `bun x oxlint` are clean for the new and changed files.
- Not run: `bun check` (this checkout has no dependencies installed, and `examples/` sits outside the package tsconfig) and a live `muse exec` request inside an OMP session; the adapter is exercised against stub children instead.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution