### PR TITLE
feat(coding-agent): per-model reasoning efforts in retry fallback chains

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `/usage` now shows prepaid credit balances (e.g. Charm Hyper's `100 credits left`) on the provider cards and account summaries instead of `no data` ([#11656](https://github.com/can1357/oh-my-pi/pull/11656) by [@oldschoola](https://github.com/oldschoola)).
+- Retry fallback chains now support per-model reasoning efforts: a fallback entry may carry an explicit thinking suffix (`"default": ["openai/gpt-5-mini:low"]`), and pressing `t` on a fallback row in `/models` sets or clears it. Bare entries keep inheriting the failing turn's effort. ([#11842](https://github.com/can1357/oh-my-pi/pull/11842) by [@H4vC](https://github.com/H4vC)).
 
 ### Fixed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1974,7 +1974,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Retry & Fallback",
 			label: "Retry Fallback Chains",
 			description:
-				'JSON object mapping model roles, model selectors ("provider/model-id"), or provider wildcards ("provider/*") to ordered fallback selectors, e.g. {"default":["openai/gpt-4o-mini"],"google-antigravity/*":["google/*","google-vertex/*"]}. Model-oriented keys apply whenever that model/provider is active, regardless of role; a "provider/*" entry keeps the failing model\'s id and swaps the provider. An id-prefixed wildcard ("openrouter/google/*") re-prefixes the failing model\'s bare id (google-antigravity/gemini-x -> openrouter/google/gemini-x) and, used as a key, matches only that provider\'s ids under the prefix.',
+				'JSON object mapping model roles, model selectors ("provider/model-id"), or provider wildcards ("provider/*") to ordered fallback selectors, e.g. {"default":["openai/gpt-4o-mini"],"google-antigravity/*":["google/*","google-vertex/*"]}. Model-oriented keys apply whenever that model/provider is active, regardless of role; a "provider/*" entry keeps the failing model\'s id and swaps the provider. An id-prefixed wildcard ("openrouter/google/*") re-prefixes the failing model\'s bare id (google-antigravity/gemini-x -> openrouter/google/gemini-x) and, used as a key, matches only that provider\'s ids under the prefix. A fallback entry may carry an explicit thinking suffix ("provider/model:low", ":high", ":max", ":off"); a bare entry inherits the failing turn\'s effort, and "provider/*" entries always inherit.',
 		},
 	},
 	"retry.fallbackRevertPolicy": {

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -28,7 +28,14 @@ import {
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
 import type { ModelRegistry } from "../../config/model-registry";
-import { type ModelRoleLookup, type ResolvedModelRoleValue, resolveModelRoleValue } from "../../config/model-resolver";
+import {
+	formatModelSelectorValue,
+	type ModelRoleLookup,
+	parseModelString,
+	splitUpstreamRouting,
+	type ResolvedModelRoleValue,
+	resolveModelRoleValue,
+} from "../../config/model-resolver";
 import { getKnownRoleIds, getRoleInfo } from "../../config/model-roles";
 import type { Settings } from "../../config/settings";
 import { AUTO_THINKING, type ConfiguredThinkingLevel, getConfiguredThinkingLevelMetadata } from "../../thinking";
@@ -142,6 +149,8 @@ type StripState =
 			kind: "role" | "scope" | "thinking";
 			item: ModelBrowserItem;
 			role?: string;
+			/** Set when a thinking strip edits a fallback-chain entry instead of a role assignment. */
+			fallbackIndex?: number;
 			scope?: ModelRoleSelectionScope;
 			chips: StripChip[];
 			index: number;
@@ -954,16 +963,7 @@ export class ModelHubComponent implements Component {
 			this.#settings.get("modelRoleStorage") === "project" && scope !== undefined
 				? this.#thinkingLevelForScope(role, scope)
 				: (this.#roles[role]?.thinkingLevel ?? ThinkingLevel.Inherit);
-		const chips: StripChip[] = options.map(level => {
-			const label = getConfiguredThinkingLevelMetadata(level).label;
-			const glyph = thinkingLevelGlyph(level, theme);
-			return {
-				label,
-				styled: glyph ? `${theme.fg("accent", glyph)} ${label}` : label,
-				action: "thinking",
-				thinkingLevel: level,
-			};
-		});
+		const chips = this.#thinkingChips(options);
 		const preselect = options.indexOf(current);
 		this.#strip = {
 			kind: "thinking",
@@ -974,6 +974,144 @@ export class ModelHubComponent implements Component {
 			index: preselect >= 0 ? preselect : 0,
 			returnToRoles,
 		};
+	}
+
+	/** Build the footer chips for a thinking strip from its level options. */
+	#thinkingChips(options: ConfiguredThinkingLevel[]): StripChip[] {
+		return options.map(level => {
+			const label = getConfiguredThinkingLevelMetadata(level).label;
+			const glyph = thinkingLevelGlyph(level, theme);
+			return {
+				label,
+				styled: glyph ? `${theme.fg("accent", glyph)} ${label}` : label,
+				action: "thinking",
+				thinkingLevel: level,
+			};
+		});
+	}
+
+	/**
+	 * Fallback-entry model lookup through the registry — the same
+	 * case-insensitive, alias-aware resolution the runtime uses, so
+	 * `OpenAI/GPT-5.5` edits the model it runs. Covers locked providers too:
+	 * effort support is a catalog fact, not an auth fact, and the row already
+	 * exists, so the strip changes no scope.
+	 */
+	#findFallbackModel(provider: string, id: string): ModelBrowserItem | undefined {
+		const model = this.#registry.find(provider, id);
+		if (!model) return undefined;
+		return { provider: model.provider, id: model.id, model, selector: `${model.provider}/${model.id}` };
+	}
+
+	/**
+	 * Split a fallback-chain entry into its model base, explicit effort, and
+	 * `@upstream` routing. An exact literal id wins over routing
+	 * (`google-vertex/claude-opus-4-8@default` is a real model, not a route —
+	 * mirroring the runtime's exact-first precedence); otherwise the routing
+	 * slug is kept verbatim so saves can re-attach it (`openrouter/id@fireworks`
+	 * looks up `openrouter/id` but persists with the route intact).
+	 */
+	#parseFallbackEntry(raw: string):
+		| {
+				provider: string;
+				id: string;
+				thinkingLevel?: ConfiguredThinkingLevel;
+				upstream: string | undefined;
+		  }
+		| undefined {
+		const trimmed = raw.trim();
+		const parse = (pattern: string) =>
+			parseModelString(pattern, {
+				allowMaxSuffix: true,
+				allowAutoAlias: true,
+				isLiteralModelId: (provider, id) => this.#findFallbackModel(provider, id) !== undefined,
+			});
+		const literal = parse(trimmed);
+		if (literal && this.#findFallbackModel(literal.provider, literal.id)) return { ...literal, upstream: undefined };
+		const routing = splitUpstreamRouting(trimmed);
+		if (!routing) {
+			if (!literal) return undefined;
+			return { ...literal, upstream: undefined };
+		}
+		const parsed = parse(routing.base.trim());
+		if (!parsed) return undefined;
+		return { ...parsed, upstream: routing.upstream };
+	}
+
+	/**
+	 * Resolve a fallback-chain entry to its browser item, explicit effort, and
+	 * routing. Undefined when the row is inert: `provider/*` wildcards (always
+	 * inherit) or models known neither live nor from the catalog.
+	 */
+	#resolveFallbackEntry(
+		role: string,
+		index: number,
+	):
+		| { item: ModelBrowserItem; thinkingLevel: ConfiguredThinkingLevel | undefined; upstream: string | undefined }
+		| undefined {
+		const raw = this.#fallbackChains()[role]?.[index];
+		if (!raw || raw.endsWith("/*")) return undefined;
+		const parsed = this.#parseFallbackEntry(raw);
+		if (!parsed) return undefined;
+		const item = this.#findFallbackModel(parsed.provider, parsed.id);
+		if (!item) return undefined;
+		return { item, thinkingLevel: parsed.thinkingLevel, upstream: parsed.upstream };
+	}
+
+	/**
+	 * Open the thinking strip for a fallback-chain entry (`t` on a `↳` row).
+	 * Wildcard entries (`provider/*`) always inherit by design, so `t` is inert on them.
+	 */
+	#openFallbackThinkingStrip(row: { role: string; chainIndex: number }): void {
+		const resolved = this.#resolveFallbackEntry(row.role, row.chainIndex);
+		if (!resolved) return;
+		const { item } = resolved;
+		// No `auto` chip: a hand-written `:auto` suffix collapses to inherit at
+		// apply time, so offering it would promise per-prompt classification the
+		// fallback never performs. A primary running `auto` is inherited anyway
+		// through the bare form.
+		const options: ConfiguredThinkingLevel[] = [
+			ThinkingLevel.Inherit,
+			ThinkingLevel.Off,
+			...getSupportedEfforts(item.model),
+		];
+		const current =
+			resolved.thinkingLevel === undefined || resolved.thinkingLevel === AUTO_THINKING
+				? ThinkingLevel.Inherit
+				: resolved.thinkingLevel;
+		const chips = this.#thinkingChips(options);
+		this.#strip = {
+			kind: "thinking",
+			item,
+			role: row.role,
+			fallbackIndex: row.chainIndex,
+			chips,
+			index: Math.max(0, options.indexOf(current)),
+			returnToRoles: true,
+		};
+	}
+
+	/** Persist a fallback entry's thinking choice: an explicit effort is suffixed, inherit is stored bare. */
+	#setFallbackThinking(role: string, index: number, level: ConfiguredThinkingLevel): void {
+		const chain = [...(this.#fallbackChains()[role] ?? [])];
+		if (index >= chain.length) return;
+		const resolved = this.#resolveFallbackEntry(role, index);
+		if (!resolved) return;
+		// Save the registry-canonical spelling (`OpenAI/GPT-5.5` persists as
+		// `openai/gpt-5.5:off`), re-attaching `@upstream` routing ahead of the
+		// effort suffix (`id@up:low` is the canonical order).
+		const base = `${resolved.item.provider}/${resolved.item.id}`;
+		const routed = resolved.upstream ? `${base}@${resolved.upstream}` : base;
+		const next = formatModelSelectorValue(routed, level);
+		chain[index] = next;
+		for (let i = chain.length - 1; i >= 0; i--) {
+			if (i !== index && chain[i] === next) chain.splice(i, 1);
+		}
+		this.#setFallbackChain(role, chain);
+		const rowIndex = this.#rolesRows.findIndex(
+			row => row.kind === "fallback" && row.role === role && row.selector === next,
+		);
+		if (rowIndex >= 0) this.#roleIndex = rowIndex;
 	}
 
 	#closeStrip(): void {
@@ -1029,6 +1167,12 @@ export class ModelHubComponent implements Component {
 				return;
 			case "thinking":
 				if (strip.role && chip.thinkingLevel !== undefined) {
+					if (strip.kind === "thinking" && strip.fallbackIndex !== undefined) {
+						this.#setFallbackThinking(strip.role, strip.fallbackIndex, chip.thinkingLevel);
+						this.#strip = null;
+						this.#chipRanges = [];
+						return;
+					}
 					this.#callbacks.onAssign(
 						strip.item.model,
 						strip.role,
@@ -1065,7 +1209,12 @@ export class ModelHubComponent implements Component {
 		this.#browser.setQuery("");
 		if (index !== null) {
 			const selector = this.#fallbackChains()[role]?.[index];
-			if (selector) this.#browser.selectSelector(selector);
+			// Suffixed entries (`provider/id:low`) carry effort the browser rows
+			// don't show; match on the base so the current model preselects.
+			if (selector) {
+				const parsed = this.#parseFallbackEntry(selector);
+				this.#browser.selectSelector(parsed ? `${parsed.provider}/${parsed.id}` : selector);
+			}
 		}
 	}
 
@@ -1098,6 +1247,7 @@ export class ModelHubComponent implements Component {
 	/** Write the picked model into the target chain slot, dedupe, and land back on its Roles row. */
 	#commitFallback(item: ModelBrowserItem, target: { role: string; index: number | null }): void {
 		const chain = [...(this.#fallbackChains()[target.role] ?? [])];
+		// New picks are stored bare, i.e. inherit-the-primary; `t` on the row specializes the effort.
 		const selector = item.selector;
 		if (target.index !== null && target.index < chain.length) {
 			chain[target.index] = selector;
@@ -1511,6 +1661,8 @@ export class ModelHubComponent implements Component {
 					selector: `${scopedModel.provider}/${scopedModel.id}`,
 				};
 				this.#openThinkingStrip(item, role, true, scope);
+			} else if (row?.kind === "fallback") {
+				this.#openFallbackThinkingStrip(row);
 			}
 			return;
 		}
@@ -2010,7 +2162,12 @@ export class ModelHubComponent implements Component {
 			}
 			const row = this.#rolesRows[this.#roleIndex];
 			if (row?.kind === "fallback") {
-				return "↑/↓ rows · Enter replace · f add another · x remove · [/] reorder · ← providers";
+				// Advertise `t` only when the entry resolves: wildcards always
+				// inherit and unknown models have no ladder to offer, so the
+				// action would be inert there.
+				const editable = this.#resolveFallbackEntry(row.role, row.chainIndex) !== undefined;
+				const thinking = editable ? " · t thinking" : "";
+				return `↑/↓ rows · Enter replace · f add another · x remove${thinking} · [/] reorder · ← providers`;
 			}
 			if (row?.kind === "chainKey") {
 				return "↑/↓ rows · Enter/f add fallback · x clear chain · ← providers";

--- a/packages/coding-agent/test/model-hub.test.ts
+++ b/packages/coding-agent/test/model-hub.test.ts
@@ -59,15 +59,27 @@ interface RegistryOverrides {
 	getAll?: () => Model[];
 	getDiscoverableProviders?: () => string[];
 	getProviderDiscoveryState?: (providerId: string) => unknown;
+	find?: (provider: string, id: string) => Model | undefined;
 }
 
 function makeRegistry(models: () => Model[], overrides: RegistryOverrides = {}): ModelRegistry {
+	const getAll = overrides.getAll ?? models;
 	return {
 		refresh: overrides.refresh ?? (async () => {}),
 		refreshProvider: overrides.refreshProvider ?? (async () => {}),
 		getError: () => undefined,
 		getAvailable: overrides.getAvailable ?? models,
-		getAll: overrides.getAll ?? models,
+		getAll,
+		// Mirrors the production lookup's case-insensitivity (alias/variant
+		// tables live in the real resolver and need no mock here).
+		find:
+			overrides.find ??
+			((provider: string, id: string) =>
+				getAll().find(
+					model =>
+						model.provider.toLowerCase() === provider.toLowerCase() &&
+						model.id.toLowerCase() === id.toLowerCase(),
+				)),
 		getDiscoverableProviders: overrides.getDiscoverableProviders ?? (() => []),
 		getProviderDiscoveryState: overrides.getProviderDiscoveryState ?? (() => undefined),
 		authStorage: { hasAuth: () => false },
@@ -984,6 +996,150 @@ describe("ModelHub", () => {
 			hub.handleInput("x");
 			expect(onFallbackChainChange).toHaveBeenLastCalledWith("test/*", []);
 			expect(normalize(hub.render(220))).not.toContain("↳ test/model-a");
+		});
+
+		test("t on a fallback entry sets an explicit effort suffix", () => {
+			const model = getBundledModel("openai", "gpt-5.5");
+			if (!model) throw new Error("Expected bundled model openai/gpt-5.5");
+			const selector = `${model.provider}/${model.id}`;
+			const settings = Settings.isolated({ "retry.fallbackChains": { default: [selector] } });
+			const { hub, onFallbackChainChange } = createHub({ models: [model], scoped: true, settings });
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // default → its fallback entry
+			expect(footerLine(hub.render(220))).toContain("t thinking");
+
+			hub.handleInput("t");
+			const strip = footerLine(hub.render(220));
+			expect(strip).toContain("inherit");
+			expect(strip).toContain("off");
+			expect(strip).not.toContain("auto");
+
+			hub.handleInput("\x1b[C"); // inherit → off
+			hub.handleInput("\n");
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", [`${selector}:off`]);
+			expect(normalize(hub.render(220))).toContain(`↳ ${selector}:off`);
+		});
+
+		test("t on a suffixed fallback entry clears back to inherit", () => {
+			const model = getBundledModel("openai", "gpt-5.5");
+			if (!model) throw new Error("Expected bundled model openai/gpt-5.5");
+			const selector = `${model.provider}/${model.id}`;
+			const settings = Settings.isolated({ "retry.fallbackChains": { default: [`${selector}:off`] } });
+			const { hub, onFallbackChainChange } = createHub({ models: [model], scoped: true, settings });
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // default → its fallback entry
+			expect(normalize(hub.render(220))).toContain(`↳ ${selector}:off`);
+
+			hub.handleInput("t");
+			hub.handleInput(LEFT); // off → inherit
+			hub.handleInput("\n");
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", [selector]);
+			expect(normalize(hub.render(220))).not.toContain(`${selector}:off`);
+		});
+
+		test("t on a routed fallback entry preserves @upstream when setting effort", () => {
+			const model = makeModel("openrouter", "z-ai/glm-4.7");
+			const routed = `${model.provider}/${model.id}@fireworks`;
+			const settings = Settings.isolated({ "retry.fallbackChains": { default: [routed] } });
+			const { hub, onFallbackChainChange } = createHub({ models: [model], scoped: true, settings });
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // default → its fallback entry
+			expect(normalize(hub.render(220))).toContain(`↳ ${routed}`);
+
+			hub.handleInput("t");
+			hub.handleInput("\x1b[C"); // inherit → off
+			hub.handleInput("\n");
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", [`${routed}:off`]);
+			expect(normalize(hub.render(220))).toContain(`↳ ${routed}:off`);
+		});
+
+		test("t on a routed+suffixed entry clears back to the bare route", () => {
+			const model = makeModel("openrouter", "z-ai/glm-4.7");
+			const routed = `${model.provider}/${model.id}@fireworks`;
+			const settings = Settings.isolated({ "retry.fallbackChains": { default: [`${routed}:off`] } });
+			const { hub, onFallbackChainChange } = createHub({ models: [model], scoped: true, settings });
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // default → its fallback entry
+			hub.handleInput("t");
+			hub.handleInput(LEFT); // off → inherit
+			hub.handleInput("\n");
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", [routed]);
+			expect(normalize(hub.render(220))).not.toContain(`${routed}:off`);
+		});
+
+		test("wildcard fallback rows hide the thinking hint and ignore t", () => {
+			const a = makeModel("test", "model-a");
+			const settings = Settings.isolated({ "retry.fallbackChains": { default: ["test/*"] } });
+			const { hub, onFallbackChainChange } = createHub({ models: [a], scoped: true, settings });
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // default → its wildcard entry
+			expect(normalize(hub.render(220))).toContain("↳ test/*");
+			expect(footerLine(hub.render(220))).not.toContain("t thinking");
+
+			hub.handleInput("t"); // inert: no strip, no chain write
+			expect(onFallbackChainChange).not.toHaveBeenCalled();
+			expect(footerLine(hub.render(220))).not.toContain("inherit");
+		});
+
+		test("t on a literal @-suffixed id does not strip it as routing", () => {
+			const model = makeModel("test", "model@default");
+			const selector = `${model.provider}/${model.id}`;
+			const settings = Settings.isolated({ "retry.fallbackChains": { default: [selector] } });
+			const { hub, onFallbackChainChange } = createHub({ models: [model], scoped: true, settings });
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // default → its fallback entry
+			expect(normalize(hub.render(220))).toContain(`↳ ${selector}`);
+
+			hub.handleInput("t");
+			hub.handleInput("\x1b[C"); // inherit → off
+			hub.handleInput("\n");
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", [`${selector}:off`]);
+		});
+
+		test("t on a locked fallback entry resolves the ladder from the catalog", () => {
+			const available = makeModel("test", "model-a");
+			const locked = makeModel("locked", "model-x");
+			const selector = `${locked.provider}/${locked.id}`;
+			const settings = Settings.isolated({ "retry.fallbackChains": { default: [selector] } });
+			const { hub, onFallbackChainChange } = createHub({
+				models: [available],
+				scoped: true,
+				settings,
+				registry: { getAvailable: () => [available], getAll: () => [available, locked] },
+			});
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // default → its fallback entry
+			expect(footerLine(hub.render(220))).toContain("t thinking");
+
+			hub.handleInput("t");
+			hub.handleInput("\x1b[C"); // inherit → off
+			hub.handleInput("\n");
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", [`${selector}:off`]);
+		});
+
+		test("t on a case-variant entry resolves through the registry and saves canonically", () => {
+			const model = getBundledModel("openai", "gpt-5.5");
+			if (!model) throw new Error("Expected bundled model openai/gpt-5.5");
+			const selector = `${model.provider}/${model.id}`;
+			const settings = Settings.isolated({ "retry.fallbackChains": { default: ["OpenAI/GPT-5.5"] } });
+			const { hub, onFallbackChainChange } = createHub({ models: [model], scoped: true, settings });
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // default → its fallback entry
+			expect(normalize(hub.render(220))).toContain("↳ OpenAI/GPT-5.5");
+			expect(footerLine(hub.render(220))).toContain("t thinking");
+
+			hub.handleInput("t");
+			hub.handleInput("\x1b[C"); // inherit → off
+			hub.handleInput("\n");
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", [`${selector}:off`]);
 		});
 	});
 

--- a/packages/coding-agent/test/retry-fallback.test.ts
+++ b/packages/coding-agent/test/retry-fallback.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import {
 	expandDefaultRetryFallbackChains,
@@ -115,6 +116,15 @@ describe("retry fallback selector resolution", () => {
 				thinkingLevel: undefined,
 			},
 		]);
+	});
+
+	it("carries per-entry thinking levels while bare entries inherit", () => {
+		const context = createContext({ default: ["openai/gpt-4o-mini:low", "google/gemini-2.5-flash"] });
+		const candidates = findRetryFallbackCandidates(context, "default", "openai/gpt-4o-mini");
+		expect(candidates.map(candidate => candidate.raw)).toEqual(["openai/gpt-4o-mini:low", "google/gemini-2.5-flash"]);
+		expect(candidates[0]?.thinkingLevel).toBe(ThinkingLevel.Low);
+		// Bare entries carry no level so the failing turn's effort applies at switch time.
+		expect(candidates[1]?.thinkingLevel).toBeUndefined();
 	});
 
 	it("inherits the default chain only for roles without an explicit chain", () => {


### PR DESCRIPTION
## What

per-model reasoning efforts in retry fallback chains as requested on discord

Fallback-chain entries accept an explicit thinking suffix (`"default": ["openai/gpt-5-mini:low"]`); bare entries keep
inheriting the failing turn's effort and `provider/*` entries always inherit. Pressing `t` on a fallback row in
`/models` opens a thinking strip that sets (`provider/id:effort`) or clears (back to bare) the entry's effort. New picks
stay bare; the strip offers no `auto` chip because a hand-written `:auto` collapses to inherit at apply time.

## Why

Discord request:

> "can we have specific reasoning efforts for each model in the fallback chain instead of defaulting to the effort level
of the primary model"

## Testing

- `bun test` on `retry-fallback`, `model-hub`, `turn-recovery-replay-unsafe`, `issue-2761-hidden-local-providers`,
`issue-970-custom-provider-discovery`: 159 pass, 0 fail.
- New: suffixed candidate carries its level while bare entries stay `undefined` (inherit at switch time); hub tests for
`t`-sets-`:off` and `t`-clears-to-bare on a fallback row, driving the real component through `handleInput` plus rendered
frames.
- `bun check` not run: this worktree has no `node_modules` (`oxlint: command not found`), so lint/typecheck could not
execute here. No live-TUI session was exercised either.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external
contributions add the PR link and contributor credit after creation)