### PR TITLE
fix(ai): allow null subs_tier_id/subs_tier_name in Muse Code login response

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fixed Muse Code login failing when Meta returns no assigned subscription tier (`subs_tier_id`/`subs_tier_name` as null); sign-in now succeeds and usage is reported without a tier.
+- Fixed Muse Code login failing when Meta returns no assigned subscription tier (`subs_tier_id`/`subs_tier_name` as null); sign-in now succeeds and usage is reported without a tier ([#11843](https://github.com/can1357/oh-my-pi/pull/11843) by [@John-Cusack](https://github.com/John-Cusack)).
 
 ## [18.1.18] - 2026-09-11
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Charm Hyper accounts now report their remaining prepaid credit balance in `/usage` ([#11656](https://github.com/can1357/oh-my-pi/pull/11656) by [@oldschoola](https://github.com/oldschoola)).
 
+### Fixed
+
+- Fixed Muse Code login failing when Meta returns no assigned subscription tier (`subs_tier_id`/`subs_tier_name` as null); sign-in now succeeds and usage is reported without a tier.
+
 ## [18.1.18] - 2026-09-11
 
 ### Added

--- a/packages/ai/src/registry/oauth/muse-code.ts
+++ b/packages/ai/src/registry/oauth/muse-code.ts
@@ -28,8 +28,8 @@ const museCodeKeyResponseSchema = type({
 	"user_email?": "string",
 	"user_id?": "string",
 	"is_subs_active?": "boolean",
-	"subs_tier_id?": "string",
-	"subs_tier_name?": "string",
+	"subs_tier_id?": "string | null",
+	"subs_tier_name?": "string | null",
 	"subs_usage?": subscriptionUsageSchema.or("null"),
 });
 export type MuseCodeKeyResponse = typeof museCodeKeyResponseSchema.infer;

--- a/packages/ai/test/muse-code-usage.test.ts
+++ b/packages/ai/test/muse-code-usage.test.ts
@@ -61,6 +61,31 @@ describe("Muse Code subscription usage", () => {
 		});
 	});
 
+	test("reports quota without a tier when Meta returns null subscription tier fields", async () => {
+		const fetchImpl: FetchImpl = () =>
+			Promise.resolve(
+				Response.json({
+					api_key: "LLM|subscription-key",
+					user_email: "Muse@Example.com",
+					is_subs_active: true,
+					subs_tier_id: null,
+					subs_tier_name: null,
+					subs_usage: {
+						window: { used_percent: 42, resets_at: 1_800_000_000, window_duration_mins: 300 },
+					},
+				}),
+			);
+
+		const report = await museCodeUsageProvider.fetchUsage(
+			{ provider: "muse-code", credential },
+			{ fetch: fetchImpl },
+		);
+
+		expect(report?.limits).toHaveLength(1);
+		expect(report?.limits[0]?.scope.tier).toBeUndefined();
+		expect(report?.metadata).not.toHaveProperty("tier");
+	});
+
 	test("does not report Meta PAYG credentials as Muse subscription quota", () => {
 		expect(
 			museCodeUsageProvider.supports?.({

--- a/packages/ai/test/registry/oauth/muse-code.test.ts
+++ b/packages/ai/test/registry/oauth/muse-code.test.ts
@@ -218,6 +218,38 @@ describe("Muse Code OAuth", () => {
 		});
 	});
 
+	test("completes login when Meta returns null subscription tier fields", async () => {
+		// Accounts without an assigned subscription tier at login time get
+		// explicit nulls; the schema must accept them instead of failing login.
+		const result = await attachMuseCodeApiKey(
+			{ access: "meta-account-access", refresh: "meta-refresh", expires: Date.now() + 3_600_000 },
+			{
+				provider: "muse-code",
+				phase: "login",
+				raw: {},
+				fetch: Object.assign(
+					() =>
+						Promise.resolve(
+							Response.json({
+								api_key: "LLM|subscription-key",
+								user_email: "Muse@Example.com",
+								user_id: "meta-account-1",
+								is_subs_active: true,
+								subs_tier_id: null,
+								subs_tier_name: null,
+							}),
+						),
+					{ preconnect: fetch.preconnect },
+				),
+			},
+		);
+		expect(result).toMatchObject({ accountId: "meta-account-1", email: "muse@example.com" });
+		expect(parseMuseCodeCredential(result.access)).toEqual({
+			oauthAccessToken: "meta-account-access",
+			apiKey: "LLM|subscription-key",
+		});
+	});
+
 	test("rejects an inactive subscription instead of exposing a Model API credential", async () => {
 		await expect(
 			attachMuseCodeApiKey(


### PR DESCRIPTION
## What

I changed this so the muse login would since it wasn't working before.

Relaxed `subs_tier_id`/`subs_tier_name` in the Muse Code key-response schema (`packages/ai/src/registry/oauth/muse-code.ts`) from required strings to nullable, so accounts with no assigned subscription tier can sign in; usage is reported without a tier.

## Why

Meta's key endpoint (`api.meta.ai/muse-code/key`) can return explicit `null` for both tier fields for accounts without an assigned subscription tier at login time, which failed login with:

`Invalid Muse Code key response: subs_tier_id must be a string (was null) / subs_tier_name must be a string (was null)`

No existing open issue reports this, so none referenced (per CONTRIBUTING.md, no issue filed since the fix is submitted directly). Downstream code needed no changes: `buildLimits` already folds null into an undefined tier and the /usage renderers guard on truthy tier values.

## Testing

- Reproduced the exact error against `requestMuseCodeKey` with a null-tier payload before the fix; the same payload succeeds after.
- New regression tests (both fail pre-fix, pass post-fix): `completes login when Meta returns null subscription tier fields` (login mints the credential via `attachMuseCodeApiKey`) and `reports quota without a tier when Meta returns null subscription tier fields` (limits reported, `scope.tier` undefined, no `tier` in metadata). Full files: 17/17 green.
- `bun --cwd=packages/ai run check:types`, oxlint, and oxfmt all clean on the changed files.
- I fixed it and tested it: ran the fix branch against my real Meta account — the reported `Invalid Muse Code key response` validation failure no longer occurs; login now proceeds past validation to Meta's subscription-state check.

---

- [x] `bun check` passes (package `check:types` + oxlint/oxfmt; full-workspace Rust gate N/A to this TS-only change)
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)
