### PR TITLE
fix(ai): allow Codex OAuth login without account ID

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 - Charm Hyper accounts now report their remaining prepaid credit balance in `/usage` ([#11656](https://github.com/can1357/oh-my-pi/pull/11656) by [@oldschoola](https://github.com/oldschoola)).
 
+### Fixed
+
+- Codex OAuth login now accepts valid account tokens that expose an email but omit `chatgpt_account_id`, without fabricating a workspace header ([#11847](https://github.com/can1357/oh-my-pi/pull/11847) by [@nguyennguyenit](https://github.com/nguyennguyenit)).
+
 ## [18.1.18] - 2026-09-11
 
 ### Added

--- a/packages/ai/src/registry/oauth/openai-codex.ts
+++ b/packages/ai/src/registry/oauth/openai-codex.ts
@@ -90,8 +90,8 @@ function describeTokenEndpointValue(value: unknown): string | undefined {
 export const openAICodexProfileHook: AfterExchangeHook = async (credentials, context) => {
 	const idToken = isRecord(context.raw) && typeof context.raw.id_token === "string" ? context.raw.id_token : undefined;
 	const { accountId, email, planType } = getTokenProfile(credentials.access, idToken);
-	if (context.phase === "login" && !accountId) {
-		throw new AIError.OAuthError("Failed to extract accountId from token", {
+	if (context.phase === "login" && !accountId && !email) {
+		throw new AIError.OAuthError("Failed to extract account identity from token", {
 			kind: "validation",
 			provider: context.provider,
 		});
@@ -190,18 +190,17 @@ async function exchangeCodeForToken(
 	}
 
 	const { accountId, email, planType } = getTokenProfile(tokenData.access_token, tokenData.id_token);
-	if (!accountId) {
-		throw new AIError.OAuthError("Failed to extract accountId from token", { kind: "validation" });
+	if (!accountId && !email) {
+		throw new AIError.OAuthError("Failed to extract account identity from token", { kind: "validation" });
 	}
 
 	return {
 		access: tokenData.access_token,
 		refresh: tokenData.refresh_token,
 		expires: Date.now() + tokenData.expires_in * 1000,
-		accountId,
-		email,
-		orgId: accountId,
-		orgName: planType,
+		...(accountId ? { accountId, orgId: accountId } : {}),
+		...(email ? { email } : {}),
+		...(planType ? { orgName: planType } : {}),
 	};
 }
 

--- a/packages/ai/test/registry/oauth/openai-codex.test.ts
+++ b/packages/ai/test/registry/oauth/openai-codex.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, expect, test, vi } from "bun:test";
+import { loginOpenAICodexDevice, openAICodexProfileHook } from "@oh-my-pi/pi-ai/oauth/openai-codex";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function jwtWithPayload(payload: Record<string, unknown>): string {
+	const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+	const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+	return `${header}.${body}.sig`;
+}
+
+test("accepts Codex login tokens with an email when workspace claims are absent", async () => {
+	const access = jwtWithPayload({
+		sub: "user-fixture",
+		"https://api.openai.com/auth": { user_id: "user-fixture", poid: "org-fixture" },
+		"https://api.openai.com/profile": { email: "Fixture@Example.com" },
+	});
+
+	const credentials = await openAICodexProfileHook(
+		{ access, refresh: "refresh-token", expires: Date.now() + 60_000 },
+		{ provider: "openai-codex", phase: "login", raw: {}, fetch },
+	);
+
+	expect(credentials.email).toBe("fixture@example.com");
+	expect(credentials.accountId).toBeUndefined();
+	expect(credentials.orgId).toBeUndefined();
+});
+
+test("completes device login when the token has email but no workspace claim", async () => {
+	const access = jwtWithPayload({
+		sub: "user-fixture",
+		"https://api.openai.com/auth": { user_id: "user-fixture", poid: "org-fixture" },
+		"https://api.openai.com/profile": { email: "fixture@example.com" },
+	});
+	vi.spyOn(globalThis, "fetch").mockImplementation(
+		Object.assign(
+			async (input: string | URL | Request) => {
+				const url = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
+				if (url.endsWith("/api/accounts/deviceauth/usercode")) {
+					return Response.json({ device_auth_id: "device-auth", user_code: "USER-CODE", interval: -3 });
+				}
+				if (url.endsWith("/api/accounts/deviceauth/token")) {
+					return Response.json({ authorization_code: "authorization-code", code_verifier: "verifier" });
+				}
+				if (url.endsWith("/oauth/token")) {
+					return Response.json({
+						access_token: access,
+						refresh_token: "refresh-token",
+						expires_in: 3600,
+					});
+				}
+				throw new Error(`Unexpected request: ${url}`);
+			},
+			{ preconnect: fetch.preconnect },
+		),
+	);
+
+	const credentials = await loginOpenAICodexDevice({});
+
+	expect(credentials.email).toBe("fixture@example.com");
+	expect(credentials.accountId).toBeUndefined();
+	expect(credentials.orgId).toBeUndefined();
+});
+
+test("rejects Codex login tokens without a workspace or email identity", async () => {
+	const access = jwtWithPayload({ sub: "user-fixture" });
+
+	await expect(
+		openAICodexProfileHook(
+			{ access, refresh: "refresh-token", expires: Date.now() + 60_000 },
+			{ provider: "openai-codex", phase: "login", raw: {}, fetch },
+		),
+	).rejects.toMatchObject({ kind: "validation", provider: "openai-codex" });
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Added `f follow up` in BTW history to continue a selected side conversation with an English input prompt, persistent multi-turn history, and no changes to the main conversation.
 - Completed inline BTW answers now support `f follow up` directly; history uses `Tab` for pane navigation and `Enter` or `f` to start a follow-up.
 - Marketplace plugins that share a repository root now load only their declared skills instead of every skill in the repository ([#11513](https://github.com/can1357/oh-my-pi/issues/11513)).
+- Codex web search now accepts valid email-only OAuth credentials without requiring or fabricating a `ChatGPT-Account-Id` header ([#11847](https://github.com/can1357/oh-my-pi/pull/11847) by [@nguyennguyenit](https://github.com/nguyennguyenit)).
 - Sessions now stay alive when their working directory is removed instead of crashing while preparing shell tools ([#11828](https://github.com/can1357/oh-my-pi/issues/11828)).
 - MCP HTTP reconnects now release obsolete tool generations instead of growing session memory on every reconnect ([#11784](https://github.com/can1357/oh-my-pi/issues/11784)).
 - `/debug` memory reports now keep large heap snapshots out of JavaScript strings and reject empty snapshots instead of saving zero-byte files ([#11785](https://github.com/can1357/oh-my-pi/issues/11785)).

--- a/packages/coding-agent/src/web/search/providers/codex.ts
+++ b/packages/coding-agent/src/web/search/providers/codex.ts
@@ -4,14 +4,7 @@
  * Uses the configured Codex Responses transport for proxy/API-key setups and
  * the official ChatGPT backend for OAuth logins.
  */
-import {
-	type AuthStorage,
-	type FetchImpl,
-	type Model,
-	type OAuthAccess,
-	withAuth,
-	withOAuthAccess,
-} from "@oh-my-pi/pi-ai";
+import { type AuthStorage, type FetchImpl, type Model, withAuth, withOAuthAccess } from "@oh-my-pi/pi-ai";
 import { resolveCodexResponsesUrl } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
 import {
@@ -380,24 +373,6 @@ function extractTextSources(text: string): SearchSource[] {
 	}
 
 	return sources;
-}
-
-/**
- * Resolve a Codex bearer + accountId through {@link AuthStorage} — the single
- * refresh authority. Returns `null` when no OAuth credential is configured,
- * when the credential cannot be refreshed (broker error, revoked token, etc.),
- * or when the access token carries no `chatgpt_account_id` claim.
- */
-async function findCodexAuth(
-	authStorage: AuthStorage,
-	sessionId: string | undefined,
-	signal: AbortSignal | undefined,
-): Promise<{ access: OAuthAccess; accountId: string } | null> {
-	const access = await authStorage.getOAuthAccess("openai-codex", sessionId, { signal });
-	if (!access) return null;
-	const accountId = access.accountId ?? getCodexAccountId(access.accessToken);
-	if (!accountId) return null;
-	return { access, accountId };
 }
 
 function resolveCodexSearchTransport(modelRegistry: ModelRegistry | undefined, modelId: string): CodexSearchTransport {
@@ -791,7 +766,9 @@ export async function searchCodex(params: SearchParams): Promise<SearchResponse>
 			},
 		);
 	} else {
-		const seed = await findCodexAuth(params.authStorage, params.sessionId, params.signal);
+		const seed = await params.authStorage.getOAuthAccess("openai-codex", params.sessionId, {
+			signal: params.signal,
+		});
 		if (!seed) {
 			throw new Error(
 				"No Codex OAuth credentials found. Login with 'omp /login openai-codex' to enable Codex web search.",
@@ -805,9 +782,6 @@ export async function searchCodex(params: SearchParams): Promise<SearchResponse>
 				// A refreshed/rotated credential can carry a different bearer and
 				// ChatGPT account id than the seed used to select the first attempt.
 				const accountId = access.accountId ?? getCodexAccountId(access.accessToken);
-				if (!accountId) {
-					throw new Error("Codex OAuth credential is missing a ChatGPT account id");
-				}
 				return runCodexSearchCandidates({
 					auth: { accessToken: access.accessToken, accountId },
 					params,
@@ -817,7 +791,7 @@ export async function searchCodex(params: SearchParams): Promise<SearchResponse>
 					transport,
 				});
 			},
-			{ sessionId: params.sessionId, signal: params.signal, seed: seed.access },
+			{ sessionId: params.sessionId, signal: params.signal, seed },
 		);
 	}
 

--- a/packages/coding-agent/test/tools/web-search-codex.test.ts
+++ b/packages/coding-agent/test/tools/web-search-codex.test.ts
@@ -216,6 +216,17 @@ describe("searchCodex model selection", () => {
 			return true;
 		},
 	} as unknown as AuthStorage;
+	const emailOnlyAuthStorage = {
+		async getOAuthAccess() {
+			return {
+				accessToken: "email-only-access-token",
+				email: "user@example.com",
+			};
+		},
+		hasOAuth() {
+			return true;
+		},
+	} as unknown as AuthStorage;
 	const proxyAuthStorage = {
 		hasAuth(provider: string) {
 			return provider === "openai-codex";
@@ -305,6 +316,18 @@ describe("searchCodex model selection", () => {
 		expect(capturedRequest?.body?.model).toBe("gpt-5.6-luna");
 		expect(result.model).toBe("gpt-5.6-luna");
 		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
+	});
+
+	it("uses email-only OAuth credentials without an account header", async () => {
+		const result = await searchCodex({
+			...makeSearchParams("email-only Codex search", mockCodexFetch("gpt-5.6-luna")),
+			authStorage: emailOnlyAuthStorage,
+		});
+
+		const headers = new Headers(capturedRequest?.headers);
+		expect(headers.get("authorization")).toBe("Bearer email-only-access-token");
+		expect(headers.has("chatgpt-account-id")).toBe(false);
+		expect(result.answer).toBe("Codex answer");
 	});
 
 	it("applies the configured request timeout to Codex search", async () => {


### PR DESCRIPTION
## What

Sửa login nhiều account từ Codex vì thiếu `chatgpt_account_id`.

Allow Codex OAuth login to accept tokens that contain a normalized email identity but omit `chatgpt_account_id`. The credential does not fabricate `accountId` or `orgId`.

Extend the same contract to Codex web search: email-only OAuth credentials can search without a `ChatGPT-Account-Id` header, while account-bearing credentials keep sending it.

## Why

OpenAI can issue valid Codex OAuth tokens containing email, `user_id`, `poid`, and `sub`, but no `chatgpt_account_id`. The official Codex CLI accepts these tokens, while OMP rejected them before storing the credential with:

`Failed to extract accountId from token`

After login was relaxed, Codex web search still rejected the same credential during initial selection and refresh. Both paths now treat the account ID as optional, matching the main Codex transport.

Identity-less login tokens and missing OAuth credentials remain rejected.

## Testing

- Reproduced the login failure with a synthetic token matching the observed claim shape.
- Confirmed browser-profile enrichment and device-code login accept email-only identity.
- Confirmed tokens without workspace or email identity remain rejected.
- Reproduced the Codex web-search failure with an email-only OAuth credential.
- Confirmed Codex web search sends the bearer token, omits `ChatGPT-Account-Id`, and returns results.
- `bun test packages/ai/test/registry/oauth/openai-codex.test.ts packages/ai/test/openai-codex.test.ts packages/coding-agent/test/tools/web-search-codex.test.ts`
  - 49 pass, 0 fail
- `bun --cwd=packages/ai check`
  - passed
- `bun --cwd=packages/coding-agent check`
  - passed

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution