### PR TITLE
test(coding-agent): assert the shortened artifact notice path independently

### DIFF
--- a/packages/coding-agent/test/tools/read-artifact-large.test.ts
+++ b/packages/coding-agent/test/tools/read-artifact-large.test.ts
@@ -9,7 +9,6 @@ import {
 } from "@oh-my-pi/pi-coding-agent/internal-urls/registry-helpers";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { formatTruncationMetaNotice } from "@oh-my-pi/pi-coding-agent/tools/output-meta";
-import { shortenPath } from "@oh-my-pi/pi-coding-agent/tools/render-utils";
 import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
 
 function getTextOutput(result: { content: Array<{ type: string; text?: string }> }): string {
@@ -77,9 +76,10 @@ describe("read tool large artifact handling", () => {
 
 		expect(output).toContain("Unbounded raw read blocked for artifact://0");
 		expect(output).toContain("artifact://0:raw:1-3000");
-		// The notice displays the artifact path through the shared shortener, which
-		// collapses a home prefix to `~` (Windows temp dirs live under `%USERPROFILE%`).
-		expect(output).toContain(shortenPath(artifactDir));
+		// The notice must name the artifact file so it can be searched or copied.
+		// Only the directory prefix varies by host (a Windows temp dir sits under
+		// `%USERPROFILE%` and is displayed shortened), so match the path tail.
+		expect(output).toMatch(/session[/\\]0\.mcp\.log/);
 		expect(output).not.toContain("line-001");
 	});
 
@@ -202,11 +202,11 @@ describe("read tool large artifact handling", () => {
 		try {
 			const result = await tool.execute("call-raw-home", { path: "artifact://0:raw" });
 			const output = getTextOutput(result);
-			// artifactDir sits under the (mocked) home, so shortenPath rewrites the
-			// prefix to `~` — the notice must NOT leak the absolute artifact path.
-			// The shortener normalizes separators to `/`, so derive the expectation
-			// from it instead of assuming the host's path style.
-			expect(output).toContain(shortenPath(artifactDir));
+			// artifactDir sits under the (mocked) home, so the notice must display it
+			// as `~`-relative (with `/` separators) and must NOT leak the absolute
+			// artifact path. Assert the exact displayed path rather than recomputing
+			// it with the production shortener.
+			expect(output).toContain("~/session/0.mcp.log");
 			expect(output).not.toContain(artifactDir);
 		} finally {
 			homeSpy.mockRestore();


### PR DESCRIPTION
## Problem

#11851 made the two artifact-notice assertions pass on Windows by computing the expected value with the production helper:

```ts
expect(output).toContain(shortenPath(artifactDir));
```

That closes the platform gap, but the regression test then echoes the same implementation the `ReadTool` uses — if `shortenPath` ever returns an empty or malformed value, the assertion still passes as long as the notice no longer leaks the absolute path. (Flagged as a P2 suggestion on #11851 after it merged.)

## Change

`test/tools/read-artifact-large.test.ts` — assert the observable result instead of recomputing it:

- *blocks unbounded raw reads…*: match the displayed path tail (`session/0.mcp.log`, either separator). Only the directory prefix varies by host, so the tail is the part this test is actually about.
- *shortens artifact paths under the user's home dir…*: with the home directory mocked, the displayed path is exactly `~/session/0.mcp.log`, so assert that literal string (the shortener normalizes separators to `/`); the existing `not.toContain(artifactDir)` still guards the absolute-path leak.

The `shortenPath` import is dropped. No production code changes.

## Verification

Windows 11, `packages/coding-agent`:

- `bun test test/tools/read-artifact-large.test.ts` → 11 pass / 0 fail (same as before the change).
- `bunx oxfmt --check test/tools/read-artifact-large.test.ts` → clean.
- Linux/macOS reasoning: with the artifact root outside the home directory, the notice prints the absolute path, which still matches the tail regex; the mocked-home case already produced `~/session/0.mcp.log` there.
