### PR TITLE
fix(session): preserve text in mixed Claude records

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Claude Code session imports now preserve typed user text stored alongside tool results ([#11854](https://github.com/can1357/oh-my-pi/issues/11854)).
 - Extension commands now settle BTW writes before creating, switching, or branching sessions, preventing side requests from outliving their source session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).
 - Session selection and active-session deletion now settle BTW writes before switching or removing history, preventing stale saves from blocking the next session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).
 - Escape now cancels BTW follow-ups that are still waiting for startup writes, without launching a model request ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).

--- a/packages/coding-agent/src/session/claude-session-store.ts
+++ b/packages/coding-agent/src/session/claude-session-store.ts
@@ -149,17 +149,19 @@ function imageContent(value: unknown): ImageContent | undefined {
 	return data && mimeType ? { type: "image", data, mimeType } : undefined;
 }
 
+function userPart(value: unknown): TextContent | ImageContent | undefined {
+	if (!isRecord(value)) return undefined;
+	if (value.type === "text" && typeof value.text === "string") return { type: "text", text: value.text };
+	return imageContent(value);
+}
+
 function userContent(value: unknown): string | (TextContent | ImageContent)[] | undefined {
 	if (typeof value === "string") return value;
 	if (!Array.isArray(value)) return undefined;
 	const content: (TextContent | ImageContent)[] = [];
 	for (const block of value) {
-		if (!isRecord(block)) continue;
-		if (block.type === "text" && typeof block.text === "string") content.push({ type: "text", text: block.text });
-		else {
-			const image = imageContent(block);
-			if (image) content.push(image);
-		}
+		const part = userPart(block);
+		if (part) content.push(part);
 	}
 	return content.length > 0 ? content : undefined;
 }
@@ -268,11 +270,28 @@ function convertRecord(
 	const rawContent = record.message.content;
 	if (Array.isArray(rawContent)) {
 		const results: ConvertedMessage[] = [];
+		let content: (TextContent | ImageContent)[] = [];
+		let contentStart = 0;
+		const flushContent = () => {
+			if (content.length === 0) return;
+			results.push({
+				message: { role: "user", content, timestamp },
+				suffix: `user-${contentStart}`,
+			});
+			content = [];
+		};
 		for (let index = 0; index < rawContent.length; index += 1) {
 			const block = rawContent[index];
+			const part = userPart(block);
+			if (part) {
+				if (content.length === 0) contentStart = index;
+				content.push(part);
+				continue;
+			}
 			if (!isRecord(block) || block.type !== "tool_result") continue;
 			const toolCallId = stringField(block, "tool_use_id");
 			if (!toolCallId) continue;
+			flushContent();
 			const message: ToolResultMessage = {
 				role: "toolResult",
 				toolCallId,
@@ -283,13 +302,8 @@ function convertRecord(
 			};
 			results.push({ message, suffix: `tool-${index}` });
 		}
-		if (results.length > 0) {
-			const content = userContent(rawContent);
-			if (content !== undefined) {
-				results.push({ message: { role: "user", content, timestamp }, suffix: "message" });
-			}
-			return results;
-		}
+		flushContent();
+		if (results.length > 0) return results;
 	}
 	const content = userContent(rawContent);
 	if (content === undefined || (typeof content === "string" && content.length === 0)) return [];

--- a/packages/coding-agent/src/session/claude-session-store.ts
+++ b/packages/coding-agent/src/session/claude-session-store.ts
@@ -283,7 +283,13 @@ function convertRecord(
 			};
 			results.push({ message, suffix: `tool-${index}` });
 		}
-		if (results.length > 0) return results;
+		if (results.length > 0) {
+			const content = userContent(rawContent);
+			if (content !== undefined) {
+				results.push({ message: { role: "user", content, timestamp }, suffix: "message" });
+			}
+			return results;
+		}
 	}
 	const content = userContent(rawContent);
 	if (content === undefined || (typeof content === "string" && content.length === 0)) return [];

--- a/packages/coding-agent/test/foreign-session-stores.test.ts
+++ b/packages/coding-agent/test/foreign-session-stores.test.ts
@@ -78,8 +78,9 @@ async function createClaudeFixture(): Promise<{ info: ForeignSessionInfo; store:
 			timestamp: "2026-01-01T00:00:02.000Z",
 			message: {
 				content: [
+					{ type: "text", text: "Preserve this before the result." },
 					{ type: "tool_result", tool_use_id: "tool-claude", content: "file contents" },
-					{ type: "text", text: "Please preserve this typed follow-up." },
+					{ type: "text", text: "Preserve this after the result." },
 				],
 			},
 		},
@@ -103,17 +104,20 @@ describe("ClaudeSessionStore", () => {
 		expect(manager.getSessionName()).toBe("Imported Claude");
 		const entries = manager.getEntries();
 		const messages = entries.filter(entry => entry.type === "message");
-		expect(messages.map(entry => entry.message.role)).toEqual(["user", "assistant", "toolResult", "user"]);
+		expect(messages.map(entry => entry.message.role)).toEqual(["user", "assistant", "user", "toolResult", "user"]);
 		const assistant = messages.find(entry => entry.message.role === "assistant");
 		if (assistant?.message.role !== "assistant") throw new Error("Missing imported Claude assistant");
 		const call = assistant.message.content.find(block => block.type === "toolCall");
 		expect(call).toMatchObject({ id: "tool-claude", name: "read", arguments: { path: "file.ts" } });
-		const result = messages.find(entry => entry.message.role === "toolResult");
+		const beforeResult = messages[2];
+		if (beforeResult?.message.role !== "user") throw new Error("Missing pre-result Claude follow-up");
+		expect(beforeResult.message.content).toEqual([{ type: "text", text: "Preserve this before the result." }]);
+		const result = messages[3];
 		if (result?.message.role !== "toolResult") throw new Error("Missing imported Claude tool result");
 		expect(result.message.toolCallId).toBe("tool-claude");
-		const followUp = messages[3];
-		if (followUp?.message.role !== "user") throw new Error("Missing imported Claude follow-up");
-		expect(followUp.message.content).toEqual([{ type: "text", text: "Please preserve this typed follow-up." }]);
+		const afterResult = messages[4];
+		if (afterResult?.message.role !== "user") throw new Error("Missing post-result Claude follow-up");
+		expect(afterResult.message.content).toEqual([{ type: "text", text: "Preserve this after the result." }]);
 		expect(
 			entries.some(entry => entry.type === "model_change" && entry.model === "anthropic/claude-sonnet-4-5"),
 		).toBe(true);

--- a/packages/coding-agent/test/foreign-session-stores.test.ts
+++ b/packages/coding-agent/test/foreign-session-stores.test.ts
@@ -77,7 +77,10 @@ async function createClaudeFixture(): Promise<{ info: ForeignSessionInfo; store:
 			parentUuid: "claude-assistant",
 			timestamp: "2026-01-01T00:00:02.000Z",
 			message: {
-				content: [{ type: "tool_result", tool_use_id: "tool-claude", content: "file contents" }],
+				content: [
+					{ type: "tool_result", tool_use_id: "tool-claude", content: "file contents" },
+					{ type: "text", text: "Please preserve this typed follow-up." },
+				],
 			},
 		},
 		{ type: "custom-title", customTitle: "Imported Claude", timestamp: "2026-01-01T00:00:03.000Z" },
@@ -100,7 +103,7 @@ describe("ClaudeSessionStore", () => {
 		expect(manager.getSessionName()).toBe("Imported Claude");
 		const entries = manager.getEntries();
 		const messages = entries.filter(entry => entry.type === "message");
-		expect(messages.map(entry => entry.message.role)).toEqual(["user", "assistant", "toolResult"]);
+		expect(messages.map(entry => entry.message.role)).toEqual(["user", "assistant", "toolResult", "user"]);
 		const assistant = messages.find(entry => entry.message.role === "assistant");
 		if (assistant?.message.role !== "assistant") throw new Error("Missing imported Claude assistant");
 		const call = assistant.message.content.find(block => block.type === "toolCall");
@@ -108,6 +111,9 @@ describe("ClaudeSessionStore", () => {
 		const result = messages.find(entry => entry.message.role === "toolResult");
 		if (result?.message.role !== "toolResult") throw new Error("Missing imported Claude tool result");
 		expect(result.message.toolCallId).toBe("tool-claude");
+		const followUp = messages[3];
+		if (followUp?.message.role !== "user") throw new Error("Missing imported Claude follow-up");
+		expect(followUp.message.content).toEqual([{ type: "text", text: "Please preserve this typed follow-up." }]);
 		expect(
 			entries.some(entry => entry.type === "model_change" && entry.model === "anthropic/claude-sonnet-4-5"),
 		).toBe(true);


### PR DESCRIPTION
## Repro

A synthetic Claude Code transcript with a `user` record containing both `tool_result` and `text` blocks reproduced the loss with `bun /tmp/omp-11854/repro-issue.ts`: the imported roles were `user`, `assistant`, `toolResult`, `assistant`, and the typed follow-up was absent.

## Cause

`convertRecord()` in `packages/coding-agent/src/session/claude-session-store.ts` returned immediately after converting any tool results, so the same record's remaining user content never reached `userContent()`.

## Fix

- Convert user text and image content from a mixed record after its tool results.
- Extend the foreign-session regression fixture to assert the imported follow-up's role and content.
- Document the restored Claude Code import behavior in the coding-agent changelog.

## Verification

`bun test packages/coding-agent/test/foreign-session-stores.test.ts` passed all 6 tests. Re-running `bun /tmp/omp-11854/repro-issue.ts` produced the missing `user: "While that runs: keep the rollout in two phases, canary first."` entry after the tool result. The pre-publish `bun check` gate passed.

Fixes #11854