### PR TITLE
fix(snapcompact): add devin to PROVIDER_IMAGE_BUDGETS

### DIFF
--- a/packages/snapcompact/src/snapcompact.ts
+++ b/packages/snapcompact/src/snapcompact.ts
@@ -514,6 +514,8 @@ export const PROVIDER_IMAGE_BUDGETS: Record<string, number> = {
 	"google-gemini-cli": 200,
 	openrouter: 90,
 	umans: 10,
+	devin: 200,
+	"devin-agent": 200,
 };
 
 /** Safe floor for unknown providers (strictest mainstream measured: Groq ~5). */

--- a/packages/snapcompact/test/snapcompact.test.ts
+++ b/packages/snapcompact/test/snapcompact.test.ts
@@ -1213,6 +1213,8 @@ describe("archive helpers", () => {
 		expect(snapcompact.providerImageBudget(undefined)).toBe(snapcompact.DEFAULT_PROVIDER_IMAGE_BUDGET);
 		expect(snapcompact.providerImageBudget("some-new-router")).toBe(snapcompact.DEFAULT_PROVIDER_IMAGE_BUDGET);
 		expect(snapcompact.providerImageBudget("openai-codex")).toBe(200);
+		expect(snapcompact.providerImageBudget("devin")).toBe(200);
+		expect(snapcompact.providerFrameBudget("devin")).toBe(snapcompact.MAX_FRAMES_DEFAULT);
 		expect(snapcompact.providerFrameBudget("some-new-router")).toBe(snapcompact.DEFAULT_PROVIDER_IMAGE_BUDGET);
 		expect(snapcompact.providerFrameBudget("umans")).toBe(10);
 		expect(snapcompact.providerFrameBudget("anthropic")).toBe(snapcompact.MAX_FRAMES_DEFAULT);


### PR DESCRIPTION
## Problem

`PROVIDER_IMAGE_BUDGETS` in `packages/snapcompact/src/snapcompact.ts` does not list `devin`.

While the static SWE models (`swe-1-6`, `swe-1-6-fast`) are text-only, the dynamic Devin catalog exposes 260+ models that support vision (such as Claude and GPT lanes routed through Devin). When using a vision model through the Devin provider, `providerImageBudget("devin")` misses the lookup and falls back to `DEFAULT_PROVIDER_IMAGE_BUDGET = 5`.

In longer sessions where snapcompact archive frames and historical `toolResult` images exceed 5 in total, `clampProviderContextImages()` drops the oldest image. This rewrites the first history entry and invalidates the prompt-cache prefix, causing 100% cache misses on later turns.

## Changes

- Add `devin: 200` and `"devin-agent": 200` to `PROVIDER_IMAGE_BUDGETS`.
- `providerImageBudget("devin")` now returns `200`.
- `providerFrameBudget("devin")` now returns `Math.min(200, 80) = 80`.

## Verification

- Added budget assertions in `packages/snapcompact/test/snapcompact.test.ts`.
- Ran `bun test packages/snapcompact/test/snapcompact.test.ts` (94 passed, 0 failed).
- Verified behaviorally: with 6 historical images in context, 0 messages are rewritten (previously 1 message was dropped, rewriting the oldest entry).