### PR TITLE
fix(collab): restore guests after transient room loss

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Collab guests now automatically rejoin when a transient host network drop recreates the relay room ([#11858](https://github.com/can1357/oh-my-pi/issues/11858)).
+
 - Claude Code session imports now preserve typed user text stored alongside tool results ([#11854](https://github.com/can1357/oh-my-pi/issues/11854)).
 - Extension commands now settle BTW writes before creating, switching, or branching sessions, preventing side requests from outliving their source session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).
 - Session selection and active-session deletion now settle BTW writes before switching or removing history, preventing stale saves from blocking the next session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -290,7 +290,14 @@ export class CollabHost {
 	/** Broadcast a goodbye, detach all taps, and close the socket. */
 	async stop(reason: string): Promise<void> {
 		if (this.#stopped) return;
-		this.#socket?.send({ t: "bye", reason });
+		const socket = this.#socket;
+		if (socket) {
+			socket.send({ t: "bye", reason });
+			// Flush the goodbye onto the wire before #teardown closes the socket;
+			// otherwise close() drops the queued frame and guests only see the
+			// relay's transient 4001, retrying a room that is gone for good.
+			await socket.flush();
+		}
 		await this.#teardown();
 	}
 

--- a/packages/coding-agent/src/collab/relay-client.ts
+++ b/packages/coding-agent/src/collab/relay-client.ts
@@ -2,15 +2,15 @@
  * Client-side WebSocket wrapper for collab live-session sharing.
  *
  * Connects to a relay room, seals/opens AES-GCM frames, and reconnects with
- * exponential backoff on transient drops. Fatal relay close codes (room gone,
- * host conflict, room full) and decryption failures never reconnect.
+ * exponential backoff on transient drops. Guests also survive the relay's
+ * host-drop room teardown while the host recreates the room.
  */
 import { logger } from "@oh-my-pi/pi-utils";
 import { open, seal } from "./crypto";
 import type { CollabFrame, RelayControlMessage } from "./protocol";
 import { packEnvelope, unpackEnvelope } from "./protocol";
 
-const FATAL_CLOSE_REASONS: Record<number, string> = {
+const RELAY_CLOSE_REASONS: Record<number, string> = {
 	4001: "room closed",
 	4004: "no such room",
 	4009: "a host is already connected for this room",
@@ -37,7 +37,7 @@ export class CollabSocket {
 	onOpen?: () => void;
 	onFrame?: (frame: CollabFrame, fromPeer: number) => void;
 	onControl?: (msg: RelayControlMessage) => void;
-	/** Fires once per terminal close (intentional, fatal code, or bad key). willReconnect=true for transient drops that will retry. */
+	/** Fires on each close; `willReconnect` distinguishes retries from terminal shutdown. */
 	onClose?: (reason: string, willReconnect: boolean) => void;
 
 	readonly #opts: CollabSocketOptions;
@@ -47,6 +47,8 @@ export class CollabSocket {
 	#attempt = 0;
 	/** Terminal state: intentional close or fatal failure. Cleared by connect(). */
 	#closed = false;
+	/** Allows a previously joined guest to outlive room recreation races. */
+	#retryMissingRoom = false;
 	/** Serializes seal() so frames hit the wire in send() order. */
 	#sendChain: Promise<void> = Promise.resolve();
 	/** Serializes open() so frames are delivered in arrival order. */
@@ -65,6 +67,7 @@ export class CollabSocket {
 	connect(): void {
 		if (this.#ws || this.#retryTimer) return;
 		this.#closed = false;
+		this.#retryMissingRoom = false;
 		this.#attempt = 0;
 		this.#openSocket();
 	}
@@ -156,6 +159,7 @@ export class CollabSocket {
 		this.#clearBackpressureDrain();
 		const wasClosed = this.#closed;
 		this.#closed = true;
+		this.#retryMissingRoom = false;
 		this.#pendingSends.length = 0;
 		const ws = this.#ws;
 		this.#ws = null;
@@ -232,14 +236,22 @@ export class CollabSocket {
 	#handleClose(code: number, reason: string): void {
 		if (this.#closed) return;
 		this.#clearBackpressureDrain();
-		const fatalReason = FATAL_CLOSE_REASONS[code];
+		const fatalReason = RELAY_CLOSE_REASONS[code];
+		const closeReason = fatalReason ?? (reason || `connection lost (code ${code})`);
+		const retryRoom = this.#opts.role === "guest" && (code === 4001 || (code === 4004 && this.#retryMissingRoom));
+		if (retryRoom) {
+			this.#retryMissingRoom = true;
+			this.onClose?.(closeReason, true);
+			this.#scheduleRetry();
+			return;
+		}
 		if (fatalReason !== undefined) {
 			this.#closed = true;
 			this.#pendingSends.length = 0;
 			this.onClose?.(fatalReason, false);
 			return;
 		}
-		this.onClose?.(reason || `connection lost (code ${code})`, true);
+		this.onClose?.(closeReason, true);
 		this.#scheduleRetry();
 	}
 

--- a/packages/coding-agent/src/collab/relay-client.ts
+++ b/packages/coding-agent/src/collab/relay-client.ts
@@ -109,6 +109,24 @@ export class CollabSocket {
 			});
 	}
 
+	/**
+	 * Awaits queued seal/send work, then yields one macrotask so the runtime
+	 * dispatches the buffered socket write before a following {@link close}.
+	 * Callers MUST flush before closing on a graceful shutdown: `send()` only
+	 * queues on `#sendChain`, and `close()` flips `#closed` and tears down the
+	 * socket, so an unflushed goodbye is dropped and the relay's transient
+	 * room-closed code becomes the only signal guests receive — leaving them
+	 * retrying a room that is gone for good.
+	 */
+	async flush(): Promise<void> {
+		await this.#sendChain;
+		// A queued ws.send() is handed to the OS socket on the next event-loop
+		// turn, not synchronously; without this yield close() races ahead and
+		// the frame never leaves. A microtask is not enough — this needs a
+		// timer-backed macrotask.
+		if (this.#ws?.readyState === WebSocket.OPEN) await Bun.sleep(1);
+	}
+
 	#enqueuePendingSend(envelope: Uint8Array, frameType: CollabFrame["t"]): void {
 		if (this.#pendingSends.length >= MAX_PENDING_SENDS) {
 			logger.debug("collab: dropping frame, reconnect buffer full", { t: frameType });

--- a/packages/coding-agent/test/collab/relay-client-flush.test.ts
+++ b/packages/coding-agent/test/collab/relay-client-flush.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { CollabSocket } from "../../src/collab/relay-client";
+
+const NativeWebSocket = globalThis.WebSocket;
+
+/** Records outbound frames and never drops a queued write on close(), so the
+ * assertions isolate `CollabSocket`'s own send/close ordering rather than any
+ * transport quirk. */
+class RecordingWebSocket {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSING = 2;
+	static readonly CLOSED = 3;
+	static instances: RecordingWebSocket[] = [];
+
+	readonly url: string;
+	binaryType = "arraybuffer";
+	bufferedAmount = 0;
+	onclose: ((event: CloseEvent) => void) | null = null;
+	onerror: ((event: Event) => void) | null = null;
+	onmessage: ((event: MessageEvent) => void) | null = null;
+	onopen: ((event: Event) => void) | null = null;
+	readyState = RecordingWebSocket.CONNECTING;
+	sent: Uint8Array[] = [];
+
+	constructor(url: string | URL) {
+		this.url = String(url);
+		RecordingWebSocket.instances.push(this);
+	}
+
+	send(data: Uint8Array): void {
+		this.sent.push(data);
+	}
+
+	open(): void {
+		this.readyState = RecordingWebSocket.OPEN;
+		this.onopen?.(new Event("open"));
+	}
+
+	close(): void {
+		if (this.readyState === RecordingWebSocket.CLOSED) return;
+		this.readyState = RecordingWebSocket.CLOSED;
+		this.onclose?.(new CloseEvent("close", { code: 1000, reason: "closed" }));
+	}
+}
+
+function install(): void {
+	RecordingWebSocket.instances = [];
+	Object.defineProperty(globalThis, "WebSocket", { configurable: true, value: RecordingWebSocket });
+}
+
+function instance(index: number): RecordingWebSocket {
+	const ws = RecordingWebSocket.instances[index];
+	if (!ws) throw new Error(`WebSocket instance ${index} was not created`);
+	return ws;
+}
+
+async function hostSocket(): Promise<CollabSocket> {
+	const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, false, ["encrypt", "decrypt"]);
+	return new CollabSocket({ wsUrl: "ws://localhost:8788/r/graceful-shutdown-room", role: "host", key });
+}
+
+afterEach(() => {
+	Object.defineProperty(globalThis, "WebSocket", { configurable: true, value: NativeWebSocket });
+});
+
+describe("CollabSocket.flush", () => {
+	it("closing without flushing drops a frame still queued behind the async seal", async () => {
+		install();
+		const socket = await hostSocket();
+		socket.connect();
+		instance(0).open();
+
+		socket.send({ t: "bye", reason: "stopped sharing" });
+		socket.close();
+		// Await the real send chain (the socket is already closed, so flush()
+		// adds no timer): the seal callback must observe the closed socket and
+		// drop the frame instead of writing it.
+		await socket.flush();
+
+		expect(instance(0).sent).toHaveLength(0);
+	});
+
+	it("flush writes the queued goodbye before the socket is closed", async () => {
+		install();
+		const socket = await hostSocket();
+		socket.connect();
+		instance(0).open();
+
+		socket.send({ t: "bye", reason: "stopped sharing" });
+		await socket.flush();
+		expect(instance(0).sent).toHaveLength(1);
+
+		socket.close();
+		expect(instance(0).sent).toHaveLength(1);
+	});
+});

--- a/packages/coding-agent/test/collab/relay-client-reconnect.test.ts
+++ b/packages/coding-agent/test/collab/relay-client-reconnect.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { CollabSocket } from "../../src/collab/relay-client";
+
+const NativeWebSocket = globalThis.WebSocket;
+
+class ScriptedWebSocket {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSING = 2;
+	static readonly CLOSED = 3;
+	static instances: ScriptedWebSocket[] = [];
+
+	readonly url: string;
+	binaryType = "arraybuffer";
+	bufferedAmount = 0;
+	onclose: ((event: CloseEvent) => void) | null = null;
+	onerror: ((event: Event) => void) | null = null;
+	onmessage: ((event: MessageEvent) => void) | null = null;
+	onopen: ((event: Event) => void) | null = null;
+	readyState = ScriptedWebSocket.CONNECTING;
+
+	constructor(url: string | URL) {
+		this.url = String(url);
+		ScriptedWebSocket.instances.push(this);
+	}
+
+	send(_data: unknown): void {}
+
+	open(): void {
+		this.readyState = ScriptedWebSocket.OPEN;
+		this.onopen?.(new Event("open"));
+	}
+
+	relayClose(code: number, reason: string): void {
+		this.readyState = ScriptedWebSocket.CLOSED;
+		this.onclose?.(new CloseEvent("close", { code, reason }));
+	}
+
+	close(code = 1000, reason = "closed"): void {
+		if (this.readyState === ScriptedWebSocket.CLOSED) return;
+		this.relayClose(code, reason);
+	}
+}
+
+function installScriptedWebSocket(): void {
+	ScriptedWebSocket.instances = [];
+	Object.defineProperty(globalThis, "WebSocket", { configurable: true, value: ScriptedWebSocket });
+}
+
+function restoreNativeWebSocket(): void {
+	Object.defineProperty(globalThis, "WebSocket", { configurable: true, value: NativeWebSocket });
+}
+
+function guestSocket(key: CryptoKey): CollabSocket {
+	return new CollabSocket({
+		wsUrl: "ws://localhost:8788/r/transient-network-room",
+		role: "guest",
+		key,
+	});
+}
+
+function instance(index: number): ScriptedWebSocket {
+	const ws = ScriptedWebSocket.instances[index];
+	if (!ws) throw new Error(`WebSocket instance ${index} was not created`);
+	return ws;
+}
+
+afterEach(() => {
+	restoreNativeWebSocket();
+	vi.restoreAllMocks();
+	vi.useRealTimers();
+});
+
+describe("CollabSocket guest room recovery", () => {
+	it("retries a host-closed room and missing-room races until the host returns", async () => {
+		vi.useFakeTimers();
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
+		installScriptedWebSocket();
+		const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, false, ["encrypt", "decrypt"]);
+		const closes: Array<{ reason: string; willReconnect: boolean }> = [];
+		const socket = guestSocket(key);
+		socket.onClose = (reason, willReconnect) => closes.push({ reason, willReconnect });
+
+		try {
+			socket.connect();
+			instance(0).open();
+			instance(0).relayClose(4001, "room closed");
+			expect(closes).toEqual([{ reason: "room closed", willReconnect: true }]);
+
+			vi.advanceTimersByTime(1_000);
+			instance(1).open();
+			instance(1).relayClose(4004, "no such room");
+			expect(closes.at(-1)).toEqual({ reason: "no such room", willReconnect: true });
+
+			vi.advanceTimersByTime(2_000);
+			instance(2).open();
+			expect(socket.isOpen).toBe(true);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("keeps a missing room terminal on the initial join", async () => {
+		vi.useFakeTimers();
+		installScriptedWebSocket();
+		const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, false, ["encrypt", "decrypt"]);
+		const closes: Array<{ reason: string; willReconnect: boolean }> = [];
+		const socket = guestSocket(key);
+		socket.onClose = (reason, willReconnect) => closes.push({ reason, willReconnect });
+
+		socket.connect();
+		instance(0).open();
+		instance(0).relayClose(4004, "no such room");
+
+		expect(closes).toEqual([{ reason: "no such room", willReconnect: false }]);
+		vi.advanceTimersByTime(30_000);
+		expect(ScriptedWebSocket.instances).toHaveLength(1);
+	});
+});

--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Browser collab guests now automatically rejoin when a transient host network drop recreates the relay room ([#11858](https://github.com/can1357/oh-my-pi/issues/11858)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Fixed

--- a/packages/collab-web/src/lib/client.ts
+++ b/packages/collab-web/src/lib/client.ts
@@ -129,9 +129,6 @@ export class GuestClient {
 		this.#socket = new CollabSocket({ wsUrl: parsed.wsUrl, role: "guest", key: importRoomKey(parsed.key) });
 		this.#socket.onOpen = () => this.#handleOpen();
 		this.#socket.onFrame = frame => this.#applyFrameSafe(frame);
-		this.#socket.onControl = msg => {
-			if (msg.t === "room-closed") this.#end("room closed");
-		};
 		this.#socket.onClose = (reason, willReconnect) => this.#handleClose(reason, willReconnect);
 		this.#snapshot = this.#buildSnapshot();
 	}

--- a/packages/collab-web/src/lib/socket.ts
+++ b/packages/collab-web/src/lib/socket.ts
@@ -2,17 +2,15 @@
  * Browser WebSocket wrapper for collab live-session sharing (vendored mirror
  * of `@oh-my-pi/pi-coding-agent/src/collab/relay-client.ts` semantics).
  *
- * Connects to a relay room, seals/opens AES-GCM frames in strict order, and
- * reconnects with exponential backoff on transient drops. Fatal relay close
- * codes (room gone, host conflict, room full) and decryption failures never
- * reconnect.
+ * Connects to a relay room, seals/opens AES-GCM frames, and reconnects with
+ * exponential backoff. Guests survive host-drop teardown while the host recreates the room.
  */
 
 import type { GuestFrame, HostFrame, RelayControlMessage } from "@oh-my-pi/pi-wire";
 import { open, seal } from "./codec";
 import { packEnvelope, unpackEnvelope } from "./link";
 
-const FATAL_CLOSE_REASONS: Record<number, string> = {
+const RELAY_CLOSE_REASONS: Record<number, string> = {
 	4001: "room closed",
 	4004: "no such room",
 	4009: "a host is already connected for this room",
@@ -37,7 +35,7 @@ export class CollabSocket {
 	onOpen?: () => void;
 	onFrame?: (frame: HostFrame, fromPeer: number) => void;
 	onControl?: (msg: RelayControlMessage) => void;
-	/** Fires once per terminal close (intentional, fatal code, or bad key). willReconnect=true for transient drops that will retry. */
+	/** Fires on each close; `willReconnect` distinguishes retries from terminal shutdown. */
 	onClose?: (reason: string, willReconnect: boolean) => void;
 
 	readonly #opts: CollabSocketOptions;
@@ -46,6 +44,8 @@ export class CollabSocket {
 	#attempt = 0;
 	/** Terminal state: intentional close or fatal failure. Cleared by connect(). */
 	#closed = false;
+	/** Allows a previously joined guest to outlive room recreation races. */
+	#retryMissingRoom = false;
 	/** Serializes seal() so frames hit the wire in send() order. */
 	#sendChain: Promise<void> = Promise.resolve();
 	/** Serializes open() so frames are delivered in arrival order. */
@@ -64,6 +64,7 @@ export class CollabSocket {
 	connect(): void {
 		if (this.#ws || this.#retryTimer) return;
 		this.#closed = false;
+		this.#retryMissingRoom = false;
 		this.#attempt = 0;
 		this.#openSocket();
 	}
@@ -93,6 +94,7 @@ export class CollabSocket {
 		this.#clearRetry();
 		const wasClosed = this.#closed;
 		this.#closed = true;
+		this.#retryMissingRoom = false;
 		this.#pendingSends.length = 0;
 		const ws = this.#ws;
 		this.#ws = null;
@@ -170,14 +172,22 @@ export class CollabSocket {
 
 	#handleClose(code: number, reason: string): void {
 		if (this.#closed) return;
-		const fatalReason = FATAL_CLOSE_REASONS[code];
+		const fatalReason = RELAY_CLOSE_REASONS[code];
+		const closeReason = fatalReason ?? (reason || `connection lost (code ${code})`);
+		const retryRoom = this.#opts.role === "guest" && (code === 4001 || (code === 4004 && this.#retryMissingRoom));
+		if (retryRoom) {
+			this.#retryMissingRoom = true;
+			this.onClose?.(closeReason, true);
+			this.#scheduleRetry();
+			return;
+		}
 		if (fatalReason !== undefined) {
 			this.#closed = true;
 			this.#pendingSends.length = 0;
 			this.onClose?.(fatalReason, false);
 			return;
 		}
-		this.onClose?.(reason || `connection lost (code ${code})`, true);
+		this.onClose?.(closeReason, true);
 		this.#scheduleRetry();
 	}
 

--- a/packages/collab-web/test/socket-reconnect.test.ts
+++ b/packages/collab-web/test/socket-reconnect.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { GuestClient } from "../src/lib/client";
+import { encodeBase64Url } from "../src/lib/link";
+
+const NativeWebSocket = globalThis.WebSocket;
+const LINK = `transient-network-room#${encodeBase64Url(new Uint8Array(32))}`;
+
+class ScriptedWebSocket {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSING = 2;
+	static readonly CLOSED = 3;
+	static instances: ScriptedWebSocket[] = [];
+
+	readonly url: string;
+	binaryType = "arraybuffer";
+	onclose: ((event: CloseEvent) => void) | null = null;
+	onerror: ((event: Event) => void) | null = null;
+	onmessage: ((event: MessageEvent) => void) | null = null;
+	onopen: ((event: Event) => void) | null = null;
+	readyState = ScriptedWebSocket.CONNECTING;
+
+	constructor(url: string | URL) {
+		this.url = String(url);
+		ScriptedWebSocket.instances.push(this);
+	}
+
+	send(_data: unknown): void {}
+
+	open(): void {
+		this.readyState = ScriptedWebSocket.OPEN;
+		this.onopen?.(new Event("open"));
+	}
+
+	message(data: string): void {
+		this.onmessage?.(new MessageEvent("message", { data }));
+	}
+
+	relayClose(code: number, reason: string): void {
+		this.readyState = ScriptedWebSocket.CLOSED;
+		this.onclose?.(new CloseEvent("close", { code, reason }));
+	}
+
+	close(code = 1000, reason = "closed"): void {
+		if (this.readyState === ScriptedWebSocket.CLOSED) return;
+		this.relayClose(code, reason);
+	}
+}
+
+function installScriptedWebSocket(): void {
+	ScriptedWebSocket.instances = [];
+	Object.defineProperty(globalThis, "WebSocket", { configurable: true, value: ScriptedWebSocket });
+}
+
+function restoreNativeWebSocket(): void {
+	Object.defineProperty(globalThis, "WebSocket", { configurable: true, value: NativeWebSocket });
+}
+
+function instance(index: number): ScriptedWebSocket {
+	const ws = ScriptedWebSocket.instances[index];
+	if (!ws) throw new Error(`WebSocket instance ${index} was not created`);
+	return ws;
+}
+
+afterEach(() => {
+	restoreNativeWebSocket();
+	vi.restoreAllMocks();
+	vi.useRealTimers();
+});
+
+describe("browser guest room recovery", () => {
+	it("stays reconnecting while a dropped host recreates the room", () => {
+		vi.useFakeTimers();
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
+		installScriptedWebSocket();
+		const client = new GuestClient(LINK, "tester");
+
+		try {
+			client.connect();
+			instance(0).open();
+			expect(client.getSnapshot().phase).toBe("waiting");
+
+			instance(0).message('{"t":"room-closed"}');
+			expect(client.getSnapshot().phase).not.toBe("ended");
+			instance(0).relayClose(4001, "room closed");
+			expect(client.getSnapshot().phase).toBe("reconnecting");
+
+			vi.advanceTimersByTime(1_000);
+			instance(1).open();
+			instance(1).relayClose(4004, "no such room");
+			expect(client.getSnapshot().phase).toBe("reconnecting");
+
+			vi.advanceTimersByTime(2_000);
+			instance(2).open();
+			expect(client.getSnapshot().phase).toBe("reconnecting");
+		} finally {
+			client.close();
+		}
+	});
+
+	it("ends an initial join when the room does not exist", () => {
+		vi.useFakeTimers();
+		installScriptedWebSocket();
+		const client = new GuestClient(LINK, "tester");
+
+		client.connect();
+		instance(0).open();
+		instance(0).relayClose(4004, "no such room");
+
+		expect(client.getSnapshot()).toMatchObject({ phase: "ended", endedReason: "no such room" });
+		vi.advanceTimersByTime(30_000);
+		expect(ScriptedWebSocket.instances).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## Repro
A local-relay host socket was dropped after a guest connected, then a replacement host recreated the same room. `bun /tmp/repro-11858.ts` exited 1 before the fix with `{"closureControl":true,"guestCloseReason":"room closed","guestWillReconnect":false,"hostRecreatedRoom":true,"guestRejoined":false}`.

## Cause
`CollabSocket.#handleClose` in `packages/coding-agent/src/collab/relay-client.ts` and `packages/collab-web/src/lib/socket.ts` treated relay close 4001 and every following 4004 as terminal. The browser `GuestClient` additionally ended immediately on the relay's `room-closed` control frame, so neither guest survived the race while the host recreated its room.

## Fix
- Retry close 4001 for guests and remember that the established room may temporarily return 4004 during host recreation.
- Keep 4004 terminal for an initial join so stale links still fail immediately.
- Let the browser lifecycle follow the reconnecting socket instead of ending on the advisory `room-closed` control frame.
- Cover the recovery and initial-missing-room contracts in both client implementations.

## Verification
`bun test packages/coding-agent/test/collab/relay-client-backpressure.test.ts packages/coding-agent/test/collab/relay-client-reconnect.test.ts packages/collab-web/test/client.test.ts packages/collab-web/test/local-relay.test.ts packages/collab-web/test/socket-reconnect.test.ts` passed: 28 tests, 94 assertions. `bun run check` passed in both `packages/coding-agent` and `packages/collab-web`. Re-running the local-relay reproduction reported `guestWillReconnect:true` and `guestRejoined:true`.

Fixes #11858