### PR TITLE
fix(catalog): scope the Fable cache-read patch to the 5.1 revision

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added Charm Hyper as a built-in provider with API-key login, live model discovery, and per-model pricing, effort ladders, and limits read straight from its catalog ([#11656](https://github.com/can1357/oh-my-pi/pull/11656) by [@oldschoola](https://github.com/oldschoola)).
 
+### Fixed
+
+- `anthropic/claude-fable-5-1` cache reads now cost Anthropic's published $0.25/MTok instead of $1.00, so session cost and usage reports no longer overstate cache-read spend by 4x ([#11862](https://github.com/can1357/oh-my-pi/pull/11862) by [@camjac251](https://github.com/camjac251)).
+
 ## [18.1.18] - 2026-09-11
 
 ### Added

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -3927,6 +3927,28 @@
 				}
 			},
 			{
+				"source": "classes/anthropic.kdl:181",
+				"class": "anthropic",
+				"providers": [
+					"anthropic"
+				],
+				"family": "fable",
+				"revision": [
+					{
+						"op": "=",
+						"revision": "5.1.0"
+					}
+				],
+				"catalog": {
+					"costPatch": {
+						"input": 10,
+						"output": 50,
+						"cacheRead": 0.25,
+						"cacheWrite": 12.5
+					}
+				}
+			},
+			{
 				"source": "classes/anthropic.kdl:165",
 				"class": "anthropic",
 				"providers": [
@@ -3947,7 +3969,7 @@
 				}
 			},
 			{
-				"source": "classes/anthropic.kdl:177",
+				"source": "classes/anthropic.kdl:194",
 				"class": "anthropic",
 				"providers": [
 					"anthropic"
@@ -3967,7 +3989,7 @@
 				}
 			},
 			{
-				"source": "classes/anthropic.kdl:195",
+				"source": "classes/anthropic.kdl:212",
 				"class": "anthropic",
 				"providers": [
 					"amazon-bedrock"
@@ -3990,7 +4012,7 @@
 				}
 			},
 			{
-				"source": "classes/anthropic.kdl:200",
+				"source": "classes/anthropic.kdl:217",
 				"class": "anthropic",
 				"providers": [
 					"amazon-bedrock"
@@ -4010,7 +4032,7 @@
 				}
 			},
 			{
-				"source": "classes/anthropic.kdl:206",
+				"source": "classes/anthropic.kdl:223",
 				"class": "anthropic",
 				"providers": [
 					"amazon-bedrock"
@@ -4039,7 +4061,7 @@
 				}
 			},
 			{
-				"source": "classes/anthropic.kdl:220",
+				"source": "classes/anthropic.kdl:237",
 				"class": "anthropic",
 				"providers": [
 					"amazon-bedrock"
@@ -4063,7 +4085,7 @@
 				}
 			},
 			{
-				"source": "classes/anthropic.kdl:226",
+				"source": "classes/anthropic.kdl:243",
 				"class": "anthropic",
 				"providers": [
 					"amazon-bedrock"
@@ -4083,7 +4105,7 @@
 				}
 			},
 			{
-				"source": "classes/anthropic.kdl:235",
+				"source": "classes/anthropic.kdl:252",
 				"class": "anthropic",
 				"providers": [
 					"amazon-bedrock"
@@ -4108,7 +4130,7 @@
 				}
 			},
 			{
-				"source": "classes/anthropic.kdl:241",
+				"source": "classes/anthropic.kdl:258",
 				"class": "anthropic",
 				"providers": [
 					"amazon-bedrock"
@@ -4127,7 +4149,7 @@
 				}
 			},
 			{
-				"source": "classes/anthropic.kdl:246",
+				"source": "classes/anthropic.kdl:263",
 				"class": "anthropic",
 				"providers": [
 					"amazon-bedrock"
@@ -4150,7 +4172,7 @@
 				}
 			},
 			{
-				"source": "classes/anthropic.kdl:251",
+				"source": "classes/anthropic.kdl:268",
 				"class": "anthropic",
 				"providers": [
 					"amazon-bedrock"
@@ -4170,7 +4192,7 @@
 				}
 			},
 			{
-				"source": "classes/anthropic.kdl:257",
+				"source": "classes/anthropic.kdl:274",
 				"class": "anthropic",
 				"providers": [
 					"amazon-bedrock"
@@ -4189,7 +4211,7 @@
 				}
 			},
 			{
-				"source": "classes/anthropic.kdl:262",
+				"source": "classes/anthropic.kdl:279",
 				"class": "anthropic",
 				"providers": [
 					"amazon-bedrock"
@@ -4209,7 +4231,7 @@
 				}
 			},
 			{
-				"source": "classes/anthropic.kdl:270",
+				"source": "classes/anthropic.kdl:287",
 				"class": "anthropic",
 				"providers": [
 					"amazon-bedrock"
@@ -4228,7 +4250,7 @@
 				}
 			},
 			{
-				"source": "classes/anthropic.kdl:275",
+				"source": "classes/anthropic.kdl:292",
 				"class": "anthropic",
 				"providers": [
 					"amazon-bedrock"
@@ -4248,7 +4270,7 @@
 				}
 			},
 			{
-				"source": "classes/anthropic.kdl:283",
+				"source": "classes/anthropic.kdl:300",
 				"class": "anthropic",
 				"providers": [
 					"amazon-bedrock"
@@ -4268,7 +4290,7 @@
 				}
 			},
 			{
-				"source": "classes/anthropic.kdl:293",
+				"source": "classes/anthropic.kdl:310",
 				"class": "anthropic",
 				"family": "haiku",
 				"revision": [
@@ -4282,7 +4304,7 @@
 				}
 			},
 			{
-				"source": "classes/anthropic.kdl:299",
+				"source": "classes/anthropic.kdl:316",
 				"class": "anthropic",
 				"providers": [
 					"google-antigravity",
@@ -4294,7 +4316,7 @@
 				}
 			},
 			{
-				"source": "classes/anthropic.kdl:303",
+				"source": "classes/anthropic.kdl:320",
 				"class": "anthropic",
 				"providers": [
 					"google-antigravity"

--- a/packages/catalog/src/compat/rules/classes/anthropic.kdl
+++ b/packages/catalog/src/compat/rules/classes/anthropic.kdl
@@ -169,6 +169,23 @@ class "anthropic" {
 				cache-read 1.0
 				cache-write 12.5
 			}
+			// Fable 5.1 cut cache reads to $0.25/MTok, 0.025x input, a 75% rate
+			// unique to the 5.1 generation; Fable 5 stays at the 0.1x family
+			// default. https://www.anthropic.com/claude/fable
+			//
+			// `cost-patch` is an object axis, so the winning rule supplies the
+			// whole payload rather than merging field-wise over the family
+			// patch above. Restate input/output/cache-write, or a
+			// discovery-sourced 5.1 row (Anthropic's /v1/models omits pricing)
+			// would keep only the cache-read correction.
+			revision "=5.1" {
+				cost-patch {
+					input 10.0
+					output 50.0
+					cache-read 0.25
+					cache-write 12.5
+				}
+			}
 			limits-patch {
 				context-window 1000000
 				max-tokens 128000

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -37648,7 +37648,7 @@
 			"cost": {
 				"input": 10,
 				"output": 50,
-				"cacheRead": 1,
+				"cacheRead": 0.25,
 				"cacheWrite": 12.5
 			},
 			"contextWindow": 1000000,

--- a/packages/catalog/test/anthropic-fable-5-1-cache-read.test.ts
+++ b/packages/catalog/test/anthropic-fable-5-1-cache-read.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
+
+// Anthropic priced Fable 5.1 cache reads at $0.25/MTok, 0.025x its $10 input,
+// a 75% cut from Fable 5's $1.00. Every other current Claude model keeps the
+// Anthropic-wide 0.1x.
+//   https://www.anthropic.com/claude/fable
+//   https://www.anthropic.com/claude-fable-and-mythos-5-1
+//
+// `classes/anthropic.kdl` pins Fable pricing family-wide because Anthropic's
+// /v1/models omits it. That patch predates Fable 5.1, so the 5.1 revision
+// inherited Fable 5's pre-cut cache-read rate; a revision-scoped patch
+// corrects 5.1 without disturbing the family default.
+
+// Synthetic specs, so the rule assertions hold regardless of what upstream
+// metadata the bundled snapshot happens to carry (AGENTS.md: test the rule,
+// not the generated JSON).
+function spec(id: string): ModelSpec<"anthropic-messages"> {
+	return {
+		id,
+		name: id,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com",
+		reasoning: true,
+		input: ["text", "image"],
+		// Deliberately wrong on every axis the family patch owns, so a passing
+		// assertion can only come from the rule.
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1,
+		maxTokens: 1,
+	} as ModelSpec<"anthropic-messages">;
+}
+
+describe("anthropic Fable cache-read rules", () => {
+	test("the 5.1 revision resolves to Anthropic's published $0.25/MTok", () => {
+		expect(buildModel(spec("claude-fable-5-1")).cost?.cacheRead).toBe(0.25);
+	});
+
+	test("the 5.1 revision keeps the rest of the family cost and limits patch", () => {
+		const built = buildModel(spec("claude-fable-5-1"));
+		expect(built.cost).toMatchObject({ input: 10, output: 50, cacheWrite: 12.5 });
+		expect(built.contextWindow).toBe(1_000_000);
+		expect(built.maxTokens).toBe(128_000);
+	});
+
+	test("Fable 5 keeps the family default, which Anthropic did not cut", () => {
+		expect(buildModel(spec("claude-fable-5")).cost?.cacheRead).toBe(1);
+	});
+
+	test("the Mythos family is untouched", () => {
+		expect(buildModel(spec("claude-mythos-5")).cost?.cacheRead).toBe(1);
+	});
+
+	test("other Claude families stay on their own patches", () => {
+		expect(buildModel(spec("claude-opus-4-5")).cost?.cacheRead).toBe(0.5);
+	});
+});
+
+describe("anthropic Fable 5.1 bundled row", () => {
+	// `getProviderModels` consumes models.json verbatim and never reruns
+	// `buildModel`, so an offline/static startup reports whatever the committed
+	// row says. The rule fix only reaches users once the row is regenerated.
+	test("ships the corrected cache-read rate", () => {
+		const bundled = getBundledModels("anthropic").find(model => model.id === "claude-fable-5-1");
+		expect(bundled?.cost?.cacheRead).toBe(0.25);
+	});
+
+	test("still ships Fable 5 at the uncut rate", () => {
+		const bundled = getBundledModels("anthropic").find(model => model.id === "claude-fable-5");
+		expect(bundled?.cost?.cacheRead).toBe(1);
+	});
+});


### PR DESCRIPTION
## What

`anthropic/claude-fable-5-1` was reporting prompt-cache reads at $1.00 per million tokens when Anthropic charges $0.25. I narrowed the Fable cache-read rule in `classes/anthropic.kdl` so the 5.1 revision gets its own rate instead of inheriting Fable 5's, and corrected the bundled catalog row so offline and static startups ship the same number.

The family-wide patch exists because Anthropic's `/v1/models` omits pricing and limits for that generation, and it was written when Fable 5 was the family's only member. Fable 5.1 resolves to the same `family "fable"` and picked up the pre-cut rate, which then overrode the correct value the upstream catalog already served.

## Why

Anthropic's [Fable page](https://www.anthropic.com/claude/fable):

> Claude Fable 5.1 is priced at $10 per million input tokens and $50 per million output tokens. Cache reads now cost $0.25 per million tokens, 75% less than Fable 5.

The [5.1 launch post](https://www.anthropic.com/claude-fable-and-mythos-5-1) gives the same figure and calls the cache-read cut the only price change. $0.25 on a $10 input is 0.025x, against the 0.1x every other current Claude model uses.

Every non-Anthropic row for this model already carried 0.025x scaled to its own input price: bedrock 0.25, bedrock-us 0.275, vertex 0.25, commandcode 0.25, opencode-zen 0.25, venice 0.3. The first-party row was the only one reporting the pre-cut rate, so first-party sessions overstated cache-read spend by 4x. That matters most in long agent sessions, where cache reads dominate prompt-side cost and the figure feeds cost display, usage reporting, and any caching decision made from it.

Two details worth flagging for review:

`cost-patch` is an object axis, so the winning rule supplies the whole payload rather than merging over the family patch above it. The revision block restates `input`, `output`, and `cache-write` for that reason; listing only `cache-read` silently drops the rest for any discovery-sourced 5.1 row. `limits-patch` is a separate axis and still inherits.

`getProviderModels` consumes `models.json` verbatim and never reruns `buildModel`, so the rule change alone would not reach a bundled-catalog startup. A full `gen:models` run reproduces the same value but rewrites 21,539 insertions and 3,197 deletions of unrelated upstream drift, so I corrected the row in place, as cb5db8df72 did.

## Testing

`test/anthropic-fable-5-1-cache-read.test.ts`, split to match the two layers. Rule assertions run against synthetic specs with every cost field zeroed, so a pass can only come from the rule and the coverage survives upstream metadata shifts, per AGENTS.md. A separate case pins what the bundled row ships.

Each half fails on its own when the other is reverted to `upstream/main`:

```
rule reverted, snapshot fixed  -> (fail) the 5.1 revision resolves to Anthropic's published $0.25/MTok
snapshot reverted, rule fixed  -> (fail) ships the corrected cache-read rate
both fixed                     -> 7 pass, 0 fail
```

Resolved pricing after the change, confirming nothing else moved:

```
claude-fable-5-1   in=10 out=50 cacheRead=0.25 cacheWrite=12.5 ctx=1000000
claude-fable-5     in=10 out=50 cacheRead=1    cacheWrite=12.5 ctx=1000000
claude-mythos-5    in=10 out=50 cacheRead=1    cacheWrite=12.5 ctx=1000000
claude-opus-5      in=5  out=25 cacheRead=0.5  cacheWrite=6.25 ctx=1000000
claude-sonnet-5    in=2  out=10 cacheRead=0.2  cacheWrite=2.5  ctx=1000000
claude-haiku-4-5   in=1  out=5  cacheRead=0.1  cacheWrite=1.25 ctx=200000
```

`bun test` in `packages/catalog`: 949 pass, 0 fail. `bun check` passes at the repo root.

The `rules.json` diff is one added rule plus source-line renumbering of the 37 rules that follow it in the same file.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)
