### PR TITLE
fix(coding-agent): exclude metadata from executable tool discovery

### DIFF
--- a/docs/custom-tools.md
+++ b/docs/custom-tools.md
@@ -56,7 +56,8 @@ CustomTool.execute(toolCallId, params, onUpdate, ctx, signal)
 
 - Duplicate resolved paths are deduplicated.
 - Tool name conflicts are rejected against built-ins and already-loaded custom tools.
-- Automatic executable discovery selects `.ts`, `.js`, `.mjs`, and `.cjs` modules (excluding `.d.ts`) before tool-name deduplication. Declarative metadata such as `.md` and `.json` remains available to capability consumers but is not loaded as executable tools. Explicitly configured `.md` or `.json` paths still produce a load error.
+- Automatic tool-directory scans discover `.ts` and `.js` modules; native OMP discovery also checks immediate subdirectories for `index.ts`. Executable discovery excludes `.d.ts` and filters out metadata and scripts before tool-name deduplication. Declarative metadata such as `.md` and `.json` remains available to capability consumers but is not loaded as executable tools.
+- `.mjs` and `.cjs` modules can be loaded through explicitly configured paths or declared plugin tool entries, but the tool-directory scans above do not discover them automatically. Explicitly configured `.md` or `.json` paths still produce a load error.
 - Relative configured paths are resolved from `cwd`; `~` is expanded.
 
 ## Module contract

--- a/docs/custom-tools.md
+++ b/docs/custom-tools.md
@@ -56,7 +56,7 @@ CustomTool.execute(toolCallId, params, onUpdate, ctx, signal)
 
 - Duplicate resolved paths are deduplicated.
 - Tool name conflicts are rejected against built-ins and already-loaded custom tools.
-- `.md` and `.json` files are discovered as tool metadata by some providers, but the executable module loader rejects them as runnable tools.
+- Automatic executable discovery selects `.ts`, `.js`, `.mjs`, and `.cjs` modules (excluding `.d.ts`) before tool-name deduplication. Declarative metadata such as `.md` and `.json` remains available to capability consumers but is not loaded as executable tools. Explicitly configured `.md` or `.json` paths still produce a load error.
 - Relative configured paths are resolved from `cwd`; `~` is expanded.
 
 ## Module contract

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Fixed automatic custom-tool loading trying to execute package metadata and declarative files, including metadata shadowing an executable tool with the same name.
 - Claude Code session imports now preserve typed user text stored alongside tool results ([#11854](https://github.com/can1357/oh-my-pi/issues/11854)).
 - Extension commands now settle BTW writes before creating, switching, or branching sessions, preventing side requests from outliving their source session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).
 - Session selection and active-session deletion now settle BTW writes before switching or removing history, preventing stale saves from blocking the next session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixed
 
-- Fixed automatic custom-tool loading trying to execute package metadata and declarative files, including metadata shadowing an executable tool with the same name.
+- Fixed automatic custom-tool loading trying to execute package metadata and declarative files, including metadata shadowing an executable tool with the same name ([#11864](https://github.com/can1357/oh-my-pi/pull/11864) by [@moodiness](https://github.com/moodiness)).
 - Claude Code session imports now preserve typed user text stored alongside tool results ([#11854](https://github.com/can1357/oh-my-pi/issues/11854)).
 - Extension commands now settle BTW writes before creating, switching, or branching sessions, preventing side requests from outliving their source session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).
 - Session selection and active-session deletion now settle BTW writes before switching or removing history, preventing stale saves from blocking the next session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).

--- a/packages/coding-agent/src/extensibility/custom-tools/loader.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/loader.ts
@@ -248,8 +248,12 @@ export async function discoverCustomToolPaths(configuredPaths: string[], cwd: st
 		}
 	};
 
-	// 1. Discover tools via capability system (user + project from all providers)
-	const discoveredTools = await loadCapability<CustomTool>(toolCapability.id, { cwd });
+	// Capability providers also expose metadata and scripts. Filter before deduplication
+	// so those entries cannot shadow executable modules with the same name.
+	const discoveredTools = await loadCapability<CustomTool>(toolCapability.id, {
+		cwd,
+		filter: tool => /\.(ts|js|mjs|cjs)$/.test(tool.path) && !tool.path.endsWith(".d.ts"),
+	});
 	for (const tool of discoveredTools.items) {
 		addPath(tool.path, {
 			provider: tool._source.provider,

--- a/packages/coding-agent/test/discovery/builtin-tools.test.ts
+++ b/packages/coding-agent/test/discovery/builtin-tools.test.ts
@@ -8,7 +8,8 @@ import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config
 import { initializeWithSettings, loadCapability } from "@oh-my-pi/pi-coding-agent/discovery";
 import { clearClaudePluginRootsCache } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import { discoverCustomToolPaths, loadCustomTools } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools/loader";
-import { getAgentDir, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
+import { __resetDirsFromEnvForTests, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
+import { restoreEnvValue } from "../helpers/settings-test-state";
 
 function toolSource(name: string): string {
 	return `export default api => ({
@@ -26,7 +27,8 @@ describe("native executable custom tool discovery", () => {
 	let userTools: string;
 	let originalHome: string | undefined;
 	let originalAgentDirEnv: string | undefined;
-	let originalAgentDir: string;
+	let originalOmpProfileEnv: string | undefined;
+	let originalPiProfileEnv: string | undefined;
 
 	beforeEach(async () => {
 		resetSettingsForTest();
@@ -34,7 +36,8 @@ describe("native executable custom tool discovery", () => {
 		clearFsCache();
 		originalHome = process.env.HOME;
 		originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
-		originalAgentDir = getAgentDir();
+		originalOmpProfileEnv = process.env.OMP_PROFILE;
+		originalPiProfileEnv = process.env.PI_PROFILE;
 		root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-builtin-tools-"));
 		const home = path.join(root, "home");
 		project = path.join(root, "project");
@@ -56,11 +59,11 @@ describe("native executable custom tool discovery", () => {
 		clearClaudePluginRootsCache();
 		clearFsCache();
 		vi.restoreAllMocks();
-		setAgentDir(originalAgentDir);
-		if (originalAgentDirEnv === undefined) delete process.env.PI_CODING_AGENT_DIR;
-		else process.env.PI_CODING_AGENT_DIR = originalAgentDirEnv;
-		if (originalHome === undefined) delete process.env.HOME;
-		else process.env.HOME = originalHome;
+		restoreEnvValue("HOME", originalHome);
+		restoreEnvValue("OMP_PROFILE", originalOmpProfileEnv);
+		restoreEnvValue("PI_PROFILE", originalPiProfileEnv);
+		restoreEnvValue("PI_CODING_AGENT_DIR", originalAgentDirEnv);
+		__resetDirsFromEnvForTests();
 		await removeWithRetries(root);
 	});
 

--- a/packages/coding-agent/test/discovery/builtin-tools.test.ts
+++ b/packages/coding-agent/test/discovery/builtin-tools.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { clearCache as clearFsCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import { type CustomTool, toolCapability } from "@oh-my-pi/pi-coding-agent/capability/tool";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { initializeWithSettings, loadCapability } from "@oh-my-pi/pi-coding-agent/discovery";
+import { clearClaudePluginRootsCache } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
+import { discoverCustomToolPaths, loadCustomTools } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools/loader";
+import { getAgentDir, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
+
+function toolSource(name: string): string {
+	return `export default api => ({
+		name: ${JSON.stringify(name)},
+		description: "Discovery fixture",
+		parameters: api.arktype({}),
+		async execute() { return { content: [{ type: "text", text: "ok" }] }; },
+	});`;
+}
+
+describe("native executable custom tool discovery", () => {
+	let root: string;
+	let project: string;
+	let projectTools: string;
+	let userTools: string;
+	let originalHome: string | undefined;
+	let originalAgentDirEnv: string | undefined;
+	let originalAgentDir: string;
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		clearClaudePluginRootsCache();
+		clearFsCache();
+		originalHome = process.env.HOME;
+		originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+		originalAgentDir = getAgentDir();
+		root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-builtin-tools-"));
+		const home = path.join(root, "home");
+		project = path.join(root, "project");
+		projectTools = path.join(project, ".omp", "tools");
+		userTools = path.join(home, ".omp", "agent", "tools");
+		process.env.HOME = home;
+		vi.spyOn(os, "homedir").mockReturnValue(home);
+		setAgentDir(path.dirname(userTools));
+		await Promise.all([
+			fs.mkdir(projectTools, { recursive: true }),
+			fs.mkdir(userTools, { recursive: true }),
+			fs.mkdir(path.join(project, ".git"), { recursive: true }),
+		]);
+		initializeWithSettings(await Settings.init({ inMemory: true, cwd: project }));
+	});
+
+	afterEach(async () => {
+		resetSettingsForTest();
+		clearClaudePluginRootsCache();
+		clearFsCache();
+		vi.restoreAllMocks();
+		setAgentDir(originalAgentDir);
+		if (originalAgentDirEnv === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalAgentDirEnv;
+		if (originalHome === undefined) delete process.env.HOME;
+		else process.env.HOME = originalHome;
+		await removeWithRetries(root);
+	});
+
+	test("loads modules beside metadata without errors or metadata shadowing", async () => {
+		const packagePath = path.join(projectTools, "package.json");
+		const notesPath = path.join(projectTools, "notes.md");
+		await fs.mkdir(path.join(projectTools, "nested"));
+		await Promise.all([
+			fs.writeFile(packagePath, JSON.stringify({ name: "user-module", type: "module" })),
+			fs.writeFile(notesPath, "---\nname: notes\ndescription: Declarative tool metadata\n---\n# Notes\n"),
+			fs.writeFile(path.join(projectTools, "project-module.ts"), toolSource("project_module")),
+			fs.writeFile(path.join(userTools, "user-module.js"), toolSource("user_module")),
+			fs.writeFile(path.join(projectTools, "nested", "index.ts"), toolSource("nested_module")),
+			fs.writeFile(path.join(projectTools, "types.d.ts"), "export declare const tool: unknown;\n"),
+			fs.writeFile(path.join(projectTools, "helper.sh"), "#!/bin/sh\necho helper\n"),
+			fs.writeFile(path.join(projectTools, "helper.bash"), "#!/bin/bash\necho helper\n"),
+			fs.writeFile(path.join(projectTools, "helper.py"), "print('helper')\n"),
+		]);
+
+		const discoveredPaths = await discoverCustomToolPaths([], project);
+		const loaded = await loadCustomTools(discoveredPaths, project, []);
+		expect(loaded.errors).toEqual([]);
+		expect(loaded.tools.map(tool => tool.tool.name).sort()).toEqual([
+			"nested_module",
+			"project_module",
+			"user_module",
+		]);
+
+		// Capability consumers still receive declarative definitions; only executable discovery filters them.
+		const definitions = await loadCapability<CustomTool>(toolCapability.id, { cwd: project, providers: ["native"] });
+		expect(definitions.items.find(tool => tool.path === packagePath)?.name).toBe("user-module");
+		expect(definitions.items.find(tool => tool.path === notesPath)?.description).toBe("Declarative tool metadata");
+	});
+
+	test("reports explicitly configured metadata instead of silently skipping it", async () => {
+		const packagePath = path.join(projectTools, "package.json");
+		await fs.writeFile(packagePath, JSON.stringify({ type: "module" }));
+
+		const discoveredPaths = await discoverCustomToolPaths([packagePath], project);
+		const loaded = await loadCustomTools(discoveredPaths, project, []);
+		expect(loaded.tools).toEqual([]);
+		expect(loaded.errors).toHaveLength(1);
+		expect(loaded.errors[0]).toMatchObject({ path: packagePath, source: { provider: "config" } });
+		expect(loaded.errors[0]?.error).toMatch(/cannot be loaded as executable modules/);
+	});
+});


### PR DESCRIPTION
## What

- Filter automatic custom-tool discovery to executable JavaScript/TypeScript modules before name deduplication.
- Keep declarative metadata available to capability consumers and retain errors for explicitly configured metadata paths.
- Document automatic versus explicit loading behavior.

> When using an API configured through `models.yml`, I frequently encountered the reported errors. Since these changes, I have not encountered them again during manual testing.

## Why

Metadata files such as package.json must not be executed as tools or shadow an executable tool with the same name.

This is one of three focused PRs split from the local fixes. Related: #11863, #11865. The manual observation above concerns the combined local changes, not an isolated proof of this particular fix. I reviewed the changes and confirmed that I understand their behavior before publication. AI assistance was used to prepare the fixes and submission.

## Testing

- Review follow-up: a same-process teardown sentinel reproduced loss of OMP_PROFILE and PI_PROFILE before the fix. The discovery suite now passes with both selectors set, with only the legacy selector, and with an explicitly empty OMP_PROFILE; each run verifies environment values, active profile, agent directory, and subsequent default-profile restoration (2 tests passed per run). The temporary sentinel was not added to the repository.
- `bun run check:ts` passed after the review corrections.

- `bun test packages/coding-agent/test/eval/kernel-process-group.test.ts packages/coding-agent/test/discovery/builtin-tools.test.ts` — 10 tests passed across the two files.
- The TypeScript portion of `bun check` completed successfully, including lint, formatting, and workspace type checks.
- Full `bun check` did not complete: the command reached its 120-second timeout while compiling Rust dependencies. No Rust source is changed here; the full-check box remains unchecked.
- Manual integration check: launched local OMP from the existing project with `bun /Users/admin/orca/oh-my-pi/packages/coding-agent/src/cli.ts --continue`, used the API configured through `models.yml`, and did not observe the previously reported error again. This is the contributor's reported result, not an exhaustive provider test.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)
