### PR TITLE
fix(ai,envd,sandbox,desktop,shell-builtins,py): unblocked Linux builds and reasoning turns

### DIFF
--- a/crates/ai/src/auth/aws.rs
+++ b/crates/ai/src/auth/aws.rs
@@ -2284,7 +2284,7 @@ mod tests {
 		assert_eq!(resolver.effective_region().await.expect("explicit region"), sf!("eu-west-2"),);
 	}
 
-	#[tokio::tes]
+	#[tokio::test]
 	async fn registry_availability_classifies_every_ambient_source_without_network() {
 		let environment = FakeEnvironment::default()
 			.with("AWS_ACCESS_KEY_ID", "AKIAENV")

--- a/crates/ai/src/codec/openai_chat.rs
+++ b/crates/ai/src/codec/openai_chat.rs
@@ -1306,7 +1306,14 @@ fn validate_thinking_selection(
 		Setting::Require(reasoning) | Setting::Prefer(reasoning) => reasoning,
 	};
 	let selection = selection.ok_or_else(capability_error)?;
-	if reasoning.max_tokens != selection.budget {
+	// Only a bound the caller pinned is checked against the catalog: effort-only
+	// wires reject a request that carries one at all, so an unpinned request
+	// takes the resolved effort and leaves the budget to the routes that spell
+	// it.
+	if reasoning
+		.max_tokens
+		.is_some_and(|budget| selection.budget != Some(budget))
+	{
 		return Err(capability_error());
 	}
 	if let Some(effort) = reasoning.effort
@@ -4940,5 +4947,43 @@ mod tests {
 		let policy = policy::WirePolicy::baseline();
 		let wire = encode_with_model_limit(&policy, Some(131_072), limited_request(200_000));
 		assert_eq!(wire["max_completion_tokens"], 200_000_u64);
+	}
+
+	fn selection_with_budget(
+		effort: omp_catalog::ThinkingEffort,
+		budget: u64,
+	) -> omp_catalog::ThinkingSelection {
+		omp_catalog::ThinkingSelection {
+			effort,
+			wire_effort: effort,
+			native_effort: None,
+			budget: Some(budget),
+			wire_model: omp_catalog::WireModelId::from_ref("test-wire-model").into(),
+			reasoning_mode: None,
+			suppress_when_off: false,
+			adaptive_tag_only: false,
+		}
+	}
+
+	#[test]
+	fn unpinned_reasoning_takes_the_resolved_catalog_budget() {
+		// Effort-only wires reject a request that carries a budget at all, so an
+		// unpinned request has to pass validation while the policy resolved one.
+		let pin = |max_tokens| ReasoningRequest {
+			visibility: ReasoningVisibility::Visible,
+			effort: Some(ReasoningEffort::High),
+			max_tokens,
+			preserve_signatures: true,
+		};
+		let selection = selection_with_budget(omp_catalog::ThinkingEffort::High, 16_384);
+		let mut request = request(Arc::from([text_message("hello")]));
+		request.reasoning = Setting::Prefer(pin(None));
+		assert!(super::validate_thinking_selection(&request, Some(&selection)).is_ok());
+		// A pinned bound that agrees with the catalog is accepted.
+		request.reasoning = Setting::Prefer(pin(Some(16_384)));
+		assert!(super::validate_thinking_selection(&request, Some(&selection)).is_ok());
+		// A pinned bound that contradicts it is not.
+		request.reasoning = Setting::Prefer(pin(Some(8_192)));
+		assert!(super::validate_thinking_selection(&request, Some(&selection)).is_err());
 	}
 }

--- a/crates/desktop/src/linux/actor.rs
+++ b/crates/desktop/src/linux/actor.rs
@@ -1,4 +1,7 @@
-use std::sync::{LazyLock, mpsc};
+use std::{
+	sync::{LazyLock, mpsc},
+	thread,
+};
 
 use atspi::ObjectRefOwned;
 use flume::{Receiver, Sender};

--- a/crates/desktop/src/linux/wayland/libei.rs
+++ b/crates/desktop/src/linux/wayland/libei.rs
@@ -9,7 +9,7 @@ use ashpd::desktop::{
 };
 use futures::StreamExt;
 use reis::{
-	ei::{self, button::ButtonState, handshake, keyboard::KeyState},
+	ei::{self, Context, button::ButtonState, handshake, keyboard::KeyState},
 	event::{Device, DeviceCapability, EiEvent},
 	tokio::EiConvertEventStream,
 };

--- a/crates/envd/src/docserver/types.rs
+++ b/crates/envd/src/docserver/types.rs
@@ -677,8 +677,6 @@ impl ServerConfig {
 
 	/// Acquires process authority on the opened project directory.
 	pub fn try_lock_authority(&self) -> Result<AuthorityLock> {
-		use cap_std::fs;
-
 		if self
 			.authority_held
 			.compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
@@ -694,15 +692,7 @@ impl ServerConfig {
 			});
 		}
 		let result = (|| {
-			let root = self
-				.root
-				.try_clone()
-				.map(fs::Dir::into_std_file)
-				.map_err(|source| Error::Io {
-					operation: sf!("clone Environment authority handle"),
-					path: self.environment_root.clone(),
-					source,
-				})?;
+			let root = self.authority_handle()?;
 			root.try_lock().map_err(|source| Error::Io {
 				operation: sf!("lock Environment authority"),
 				path:      self.environment_root.clone(),
@@ -717,6 +707,56 @@ impl ServerConfig {
 				Err(error)
 			},
 		}
+	}
+
+	/// Opens the descriptor the authority lock is taken on.
+	///
+	/// `cap_std::fs::Dir` opens ambient directories with `O_PATH` on Linux and
+	/// the BSDs, and `flock(2)` rejects `O_PATH` descriptors with `EBADF`, so
+	/// the lock uses a fresh descriptor for the same directory and compares its
+	/// identity against the capability root before locking it.
+	#[cfg(unix)]
+	fn authority_handle(&self) -> Result<fs::File> {
+		let root = fs::File::open(&self.environment_root).map_err(|source| Error::Io {
+			operation: sf!("open Environment authority handle"),
+			path: self.environment_root.clone(),
+			source,
+		})?;
+		let opened = root.metadata().map_err(|source| Error::Io {
+			operation: sf!("inspect Environment authority handle"),
+			path: self.environment_root.clone(),
+			source,
+		})?;
+		let capability = self
+			.root
+			.try_clone()
+			.and_then(|root| root.into_std_file().metadata())
+			.map_err(|source| Error::Io {
+				operation: sf!("inspect Environment capability root"),
+				path: self.environment_root.clone(),
+				source,
+			})?;
+		if !same_directory_identity(&capability, &opened) {
+			return Err(Error::InvalidTarget {
+				target: Str::new(self.environment_root.to_string_lossy()),
+				reason: sf!("Environment root changed while acquiring authority"),
+			});
+		}
+		Ok(root)
+	}
+
+	/// Opens the descriptor the authority lock is taken on.
+	#[cfg(not(unix))]
+	fn authority_handle(&self) -> Result<fs::File> {
+		self
+			.root
+			.try_clone()
+			.map(cap_std::fs::Dir::into_std_file)
+			.map_err(|source| Error::Io {
+				operation: sf!("clone Environment authority handle"),
+				path: self.environment_root.clone(),
+				source,
+			})
 	}
 
 	pub(crate) fn clone_root(&self) -> Result<Dir> {

--- a/crates/py/scripts/gen-py-notices.py
+++ b/crates/py/scripts/gen-py-notices.py
@@ -107,9 +107,24 @@ def release_licenses(vendor: Path) -> tuple[str, dict[str, tuple[str, ...]], dic
             safe_release_path(vendor, value, f"native component {', '.join(static_names)}")
             for value in raw_paths
         ]
+        # The release metadata lists every license a component may pull in across
+        # the build matrix — the ``zlib`` module is zlib-ng on some targets and
+        # classic zlib on others — while the archive ships only the corpus of the
+        # target it was built for. Candidates the archive omits are therefore not
+        # part of this build; drop them, unless an audited fallback stands in.
+        shipped = [
+            (relative, path)
+            for relative, path in paths
+            if path.is_file() or relative in AUDITED_LICENSE_FALLBACKS
+        ]
+        if not shipped:
+            fail(
+                f"statically linked {', '.join(static_names)} ships no license text: "
+                + ", ".join(relative for relative, _ in paths)
+            )
         for name in static_names:
-            references.setdefault(name, set()).update(relative for relative, _ in paths)
-        for relative, path in paths:
+            references.setdefault(name, set()).update(relative for relative, _ in shipped)
+        for relative, path in shipped:
             corpus.setdefault(relative, path)
 
     return (

--- a/crates/sandbox/src/backends/landlock.rs
+++ b/crates/sandbox/src/backends/landlock.rs
@@ -150,10 +150,7 @@ pub fn compile(
 	Ok(plan)
 }
 
-pub const fn prepare(
-	spec: &SandboxSpec,
-	prepared: &mut PreparedSandbox,
-) -> Result<(), SandboxError> {
+pub fn prepare(spec: &SandboxSpec, prepared: &mut PreparedSandbox) -> Result<(), SandboxError> {
 	#[cfg(not(target_os = "linux"))]
 	{
 		let _ = (spec, prepared);
@@ -293,7 +290,7 @@ fn write_paths(writer: &mut impl Write, paths: &[PathBuf]) -> io::Result<()> {
 
 /// Returns the running kernel's Landlock ABI, or `None` when unavailable.
 #[must_use]
-pub const fn abi() -> Option<u32> {
+pub fn abi() -> Option<u32> {
 	#[cfg(not(target_os = "linux"))]
 	{
 		None
@@ -345,7 +342,7 @@ pub fn probe() -> BackendStatus {
 /// The caller must dispatch this before launching untrusted work. The helper
 /// reads an owned BPF artifact, optionally applies an owned Landlock manifest,
 /// and then `execve(2)`s the command following the required `--` separator.
-pub const fn run_child_entry() -> Result<(), SandboxError> {
+pub fn run_child_entry() -> Result<(), SandboxError> {
 	#[cfg(not(target_os = "linux"))]
 	{
 		Err(SandboxError::UnsupportedHost { os: std::env::consts::OS })

--- a/crates/shell-builtins/src/support/xattr.rs
+++ b/crates/shell-builtins/src/support/xattr.rs
@@ -1,9 +1,13 @@
-//! Minimal extended-attribute probes used by `ls` and `mkdir`.
+//! Minimal extended-attribute probes and copies used by `ls`, `mkdir`, and
+//! `mv`.
+
+#[cfg(target_os = "linux")]
+use std::{ffi, ptr};
+#[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+use std::{ffi::OsString, io, path::Path};
 
 #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
-use std::path::Path;
-#[cfg(target_os = "linux")]
-use std::{ffi, io, ptr};
+use omp_core::FastHashMap;
 
 /// Returns whether a path has at least one extended ACL or attribute.
 #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
@@ -43,11 +47,78 @@ pub(crate) fn get_acl_perm_bits_from_xattr(path: impl AsRef<Path>) -> u32 {
 		.unwrap_or(0)
 }
 
+/// Reads the extended attributes of `path` as name/value pairs.
+#[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+pub(crate) fn retrieve_xattrs(
+	path: impl AsRef<Path>,
+) -> io::Result<FastHashMap<OsString, Vec<u8>>> {
+	#[cfg(target_os = "linux")]
+	{
+		use std::os::unix::ffi::OsStringExt as _;
+
+		let path = path.as_ref();
+		let names = list_link_xattrs(path)?;
+		let mut attrs = FastHashMap::default();
+		for name in names
+			.split(|byte| *byte == 0)
+			.filter(|name| !name.is_empty())
+		{
+			// An attribute can disappear between listing and reading, which the
+			// `xattr` crate reports as an absent value rather than an error.
+			if let Some(value) = get_link_xattr(path, &name_cstring(name)?)? {
+				attrs.insert(OsString::from_vec(name.to_vec()), value);
+			}
+		}
+		Ok(attrs)
+	}
+	#[cfg(not(target_os = "linux"))]
+	{
+		let _ = path;
+		Ok(FastHashMap::default())
+	}
+}
+
+/// Writes `xattrs` onto `path`.
+#[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+pub(crate) fn apply_xattrs(
+	path: impl AsRef<Path>,
+	xattrs: FastHashMap<OsString, Vec<u8>>,
+) -> io::Result<()> {
+	#[cfg(target_os = "linux")]
+	{
+		use std::os::unix::ffi::OsStrExt as _;
+
+		let path = path.as_ref();
+		for (name, value) in xattrs {
+			set_link_xattr(path, &name_cstring(name.as_bytes())?, &value)?;
+		}
+		Ok(())
+	}
+	#[cfg(not(target_os = "linux"))]
+	{
+		let _ = (path, xattrs);
+		Ok(())
+	}
+}
+
+/// Copies every extended attribute of `source` onto `dest`.
+#[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+pub(crate) fn copy_xattrs(source: impl AsRef<Path>, dest: impl AsRef<Path>) -> io::Result<()> {
+	apply_xattrs(dest, retrieve_xattrs(source)?)
+}
+
 #[cfg(target_os = "linux")]
 fn path_cstring(path: &Path) -> io::Result<ffi::CString> {
 	use std::os::unix::ffi::OsStrExt;
 	ffi::CString::new(path.as_os_str().as_bytes())
 		.map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))
+}
+
+#[cfg(target_os = "linux")]
+fn name_cstring(name: &[u8]) -> io::Result<ffi::CString> {
+	ffi::CString::new(name).map_err(|_| {
+		io::Error::new(io::ErrorKind::InvalidInput, "attribute name contains a NUL byte")
+	})
 }
 
 #[cfg(target_os = "linux")]
@@ -93,6 +164,66 @@ fn get_xattr(path: &Path, name: &[u8]) -> io::Result<Vec<u8>> {
 	}
 	value.truncate(read as usize);
 	Ok(value)
+}
+
+#[cfg(target_os = "linux")]
+fn list_link_xattrs(path: &Path) -> io::Result<Vec<u8>> {
+	let path = path_cstring(path)?;
+	// SAFETY: the C path is valid and a null buffer with length zero performs a
+	// size query.
+	let size = unsafe { libc::llistxattr(path.as_ptr(), ptr::null_mut(), 0) };
+	if size < 0 {
+		return Err(io::Error::last_os_error());
+	}
+	if size == 0 {
+		return Ok(Vec::new());
+	}
+	let mut names = vec![0_u8; size as usize];
+	// SAFETY: `names` is writable for its full reported capacity.
+	let read = unsafe { libc::llistxattr(path.as_ptr(), names.as_mut_ptr().cast(), names.len()) };
+	if read < 0 {
+		return Err(io::Error::last_os_error());
+	}
+	names.truncate(read as usize);
+	Ok(names)
+}
+
+#[cfg(target_os = "linux")]
+fn get_link_xattr(path: &Path, name: &ffi::CStr) -> io::Result<Option<Vec<u8>>> {
+	let path = path_cstring(path)?;
+	// SAFETY: both C strings are valid; a null value pointer performs a size query.
+	let size = unsafe { libc::lgetxattr(path.as_ptr(), name.as_ptr(), ptr::null_mut(), 0) };
+	if size < 0 {
+		let error = io::Error::last_os_error();
+		return match error.raw_os_error() {
+			Some(libc::ENODATA) => Ok(None),
+			_ => Err(error),
+		};
+	}
+	let mut value = vec![0_u8; size as usize];
+	// SAFETY: `value` is writable for the queried size and all pointers remain
+	// live.
+	let read = unsafe {
+		libc::lgetxattr(path.as_ptr(), name.as_ptr(), value.as_mut_ptr().cast(), value.len())
+	};
+	if read < 0 {
+		return Err(io::Error::last_os_error());
+	}
+	value.truncate(read as usize);
+	Ok(Some(value))
+}
+
+#[cfg(target_os = "linux")]
+fn set_link_xattr(path: &Path, name: &ffi::CStr, value: &[u8]) -> io::Result<()> {
+	let path = path_cstring(path)?;
+	// SAFETY: the C strings are valid and `value` is readable for its length.
+	let written = unsafe {
+		libc::lsetxattr(path.as_ptr(), name.as_ptr(), value.as_ptr().cast(), value.len(), 0)
+	};
+	if written != 0 {
+		return Err(io::Error::last_os_error());
+	}
+	Ok(())
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
`omp2` does not build on Linux, its first session cannot attach, and a DeepSeek reasoning turn fails before it leaves the client. This branch fixes the Linux-only compile errors, the docserver authority lock, the reasoning-budget validation, one setup-script assumption, and a test attribute that keeps the workspace test job red everywhere.

## What changed

**`omp-sandbox`** — `landlock::prepare`, `landlock::abi`, and `landlock::run_child_entry` were `const fn` while creating temp files, compiling BPF programs, and querying the kernel's Landlock ABI in a syscall. Nothing there is const-evaluable, so the crate produced 80 errors (E0015/E0493/E0658) on Linux; the macOS build never compiles those bodies. Dropped the three `const`s.

**`omp-desktop`** — the Linux actor called `thread::Builder` without importing `std::thread`, and `ActorLibei::context` named `Context` without importing it from `reis::ei`.

**`omp-shell-builtins`** — `mv` calls `fsxattr::{retrieve,apply,copy}_xattrs` on every unix target that is neither macOS nor redox, but `support::xattr` only carried the ACL probes. Ported the three from uucore 0.8.0's `fsxattr` — the module `mv` is ported from — onto the libc helpers already in that file: attributes are listed, read, and written through the link variants, and an attribute that disappears between listing and reading is reported as absent rather than fatal.

**`omp-envd`** — `ServerConfig::try_lock_authority` flocked a `try_clone()` of the `cap_std::fs::Dir` capability root. cap-std opens ambient directories with `O_PATH` on Linux (and the BSDs/Android) and `flock(2)` rejects `O_PATH` descriptors with `EBADF`, so every attach failed with "document authority failed: I/O operation lock Environment authority failed … Bad file descriptor", the detached `omp envd` child exited 1, and the embedded fallback failed identically. Unix now locks a fresh descriptor for the canonical root after confirming it still names the capability root's directory; other platforms keep the capability-handle path, where a directory can only be opened through cap-std.

**`omp-ai` (reasoning)** — `validate_thinking_selection` required `reasoning.max_tokens` to equal the catalog's resolved budget, so a turn on a route whose thinking policy carries per-effort budgets failed during encoding whenever the caller left the bound unpinned — and pinning it could not help, because an `OpenAiEffort` wire rejects a request that carries a budget at all. `deepseek/deepseek-v4-flash` resolves effort `high` with budget 16384 on an `OpenAiEffort` profile while the driver's `convar_reasoning` passes `max_tokens: None`, so every reasoning turn failed with `CapabilityMismatch during Encoding`. Only a pinned bound is validated now, matching bedrock's check and the driver's contract that codecs spell the resolved effort per route. A regression test pins the accepted/rejected cases.

**`omp-ai` (tests)** — `crates/ai/src/auth/aws.rs` carried `#[tokio::tes]`, so the `omp-ai` test target has not compiled since 2026-09-04 and the workspace test job is red on every platform.

**`crates/py/scripts/gen-py-notices.py`** — `PYTHON.json` lists every license a component may pull in across the build matrix while an archive ships only the corpus of its own target, so `fetch-python.sh` aborted on Linux over the absent `licenses/LICENSE.zlib-ng.txt`; the linked `libz.a` is classic zlib 1.3.2, whose license is present. Candidates the archive omits are now dropped unless an audited fallback covers them, and a component whose candidates are all missing still fails the run.

## Verification

- `cargo check --workspace --locked` — exit 0 (before: `omp-sandbox`, `omp-desktop`, and `omp-shell-builtins` failed).
- `just build` — exit 0; `target/debug/omp --version` prints `0.1.0`.
- Cross-device `mv` driven through `omp-sh` (`/tmp` → `/home/user`) keeps `user.*` attributes on both the file path (`copy_xattrs_if_supported`) and the directory path (`retrieve_xattrs`/`apply_xattrs`), with the source left empty.
- `strace` of `omp envd` before/after the lock fix: `flock(16, LOCK_EX|LOCK_NB) = -1 EBADF` → `= 0`.
- `omp chat` on a real PTY now reaches the UI (`omp v0.1.0`, model and project in the status line) instead of failing to attach; `cargo nextest run -p omp-envd --lib -E 'test(authority)'` passes, including `cloned_config_cannot_reenter_its_authority` and the daemon authority-collision tests.
- `omp print --model deepseek/deepseek-v4-flash "Reply with exactly: ok"` returns `ok` against the live API with a stored key; before the change the same call ended in `CapabilityMismatch during Encoding`. `cargo nextest run -p omp-ai --lib` — 1049 passed.

## Notes

`crates/py/THIRD-PARTY-NOTICES.txt` is platform-dependent: the committed copy was generated on macOS, and regenerating it on Linux rewrites roughly 1200 lines because Linux links far more static components. This branch does not regenerate it.

`omp-envd`'s `exec::tests::fast_output_is_host_bounded_and_complete_in_the_spill_artifact` times out on Linux both with and without the lock change (verified by stashing it), so it is a separate pre-existing failure rather than a regression here.

The `deepseek` credential used above comes from the environment (`OMP_DEEPSEEK_API_KEY`) or `omp auth login deepseek`; the Rust store under `~/.local/share/omp/credentials.db` starts empty.
