### PR TITLE
fix(pi-natives): respect CC in darwin oauth callback build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6385,6 +6385,7 @@ dependencies = [
  "resvg",
  "serde",
  "serde_json",
+ "shlex 2.0.1",
  "smallvec",
  "syntect",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,6 +318,7 @@ arboard = { version = "3.6.1", features = ["wayland-data-control"] }
 clipboard-win = "5.4"
 icy_sixel = "0.5"
 portable-pty = "0.9"
+shlex = "2"
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Search & File Walking

--- a/crates/pi-natives/Cargo.toml
+++ b/crates/pi-natives/Cargo.toml
@@ -111,6 +111,7 @@ winreg.workspace = true
 
 [dev-dependencies]
 fancy-regex.workspace = true # utok scanner differential oracle
+shlex.workspace = true
 tiktoken-rs.workspace = true # utok openai differential oracle
 xkeysym = "=0.2.1"
 
@@ -118,3 +119,4 @@ xkeysym = "=0.2.1"
 napi-build.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+shlex.workspace = true

--- a/crates/pi-natives/build.rs
+++ b/crates/pi-natives/build.rs
@@ -103,11 +103,19 @@ fn build_darwin_oauth_callback_helper() {
 		Err(error) => panic!("CARGO_CFG_TARGET_ARCH should be set: {error}"),
 	};
 	println!("cargo:rerun-if-changed={}", source.display());
+	println!("cargo:rerun-if-env-changed=CC");
 
-	let result = Command::new("/usr/bin/xcrun")
+	let mut command = match env::var_os("CC") {
+		Some(cc) => Command::new(cc),
+		None => {
+			let mut cmd = Command::new("/usr/bin/xcrun");
+			cmd.arg("clang");
+			cmd
+		},
+	};
+	let result = command
 		.current_dir(&manifest_dir)
 		.args([
-			"clang",
 			"-x",
 			"objective-c",
 			"-fobjc-arc",

--- a/crates/pi-natives/build.rs
+++ b/crates/pi-natives/build.rs
@@ -90,6 +90,9 @@ fn build_oauth_callback_relay(target_os: &str) {
 	println!("cargo:rustc-env=OMP_OAUTH_RELAY_BINARY={}", output.display());
 }
 
+#[path = "src/oauth_callback/darwin_compiler.rs"]
+mod darwin_compiler;
+
 fn build_darwin_oauth_callback_helper() {
 	let manifest_dir =
 		PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR should be set"));
@@ -105,14 +108,7 @@ fn build_darwin_oauth_callback_helper() {
 	println!("cargo:rerun-if-changed={}", source.display());
 	println!("cargo:rerun-if-env-changed=CC");
 
-	let mut command = match env::var_os("CC") {
-		Some(cc) => Command::new(cc),
-		None => {
-			let mut cmd = Command::new("/usr/bin/xcrun");
-			cmd.arg("clang");
-			cmd
-		},
-	};
+	let mut command = darwin_compiler::darwin_compiler_command(env::var_os("CC").as_deref());
 	let result = command
 		.current_dir(&manifest_dir)
 		.args([

--- a/crates/pi-natives/src/oauth_callback/darwin_compiler.rs
+++ b/crates/pi-natives/src/oauth_callback/darwin_compiler.rs
@@ -1,0 +1,18 @@
+use std::{ffi::OsStr, process::Command};
+
+pub(crate) fn darwin_compiler_command(cc: Option<&OsStr>) -> Command {
+	let words = cc
+		.and_then(|cc| cc.to_str())
+		.and_then(shlex::split)
+		.unwrap_or_default();
+
+	if let Some((program, args)) = words.split_first() {
+		let mut cmd = Command::new(program);
+		cmd.args(args);
+		cmd
+	} else {
+		let mut cmd = Command::new("/usr/bin/xcrun");
+		cmd.arg("clang");
+		cmd
+	}
+}

--- a/crates/pi-natives/src/oauth_callback/mod.rs
+++ b/crates/pi-natives/src/oauth_callback/mod.rs
@@ -821,4 +821,6 @@ fn napi_error(error: impl std::fmt::Display) -> Error {
 }
 
 #[cfg(test)]
+mod darwin_compiler;
+#[cfg(test)]
 mod tests;

--- a/crates/pi-natives/src/oauth_callback/tests.rs
+++ b/crates/pi-natives/src/oauth_callback/tests.rs
@@ -295,3 +295,43 @@ fn journal_rejects_traversal_and_unknown_fields() {
 	}"#;
 	assert!(serde_json::from_slice::<Journal>(json).is_err());
 }
+
+#[test]
+fn darwin_compiler_selection_respects_cc_and_wrappers() {
+	use std::ffi::OsStr;
+
+	let single = super::darwin_compiler::darwin_compiler_command(Some(OsStr::new("clang-18")));
+	assert_eq!(single.get_program(), "clang-18");
+	assert_eq!(single.get_args().count(), 0);
+
+	let wrapped = super::darwin_compiler::darwin_compiler_command(Some(OsStr::new("ccache clang")));
+	assert_eq!(wrapped.get_program(), "ccache");
+	let args: Vec<_> = wrapped.get_args().collect();
+	assert_eq!(args, vec![OsStr::new("clang")]);
+
+	let quoted = super::darwin_compiler::darwin_compiler_command(Some(OsStr::new(
+		r#"ccache "/Applications/Xcode 16.app/Contents/Developer/usr/bin/clang""#,
+	)));
+	assert_eq!(quoted.get_program(), "ccache");
+	let quoted_args: Vec<_> = quoted.get_args().collect();
+	assert_eq!(quoted_args, vec![OsStr::new(
+		"/Applications/Xcode 16.app/Contents/Developer/usr/bin/clang"
+	)]);
+
+	let escaped = super::darwin_compiler::darwin_compiler_command(Some(OsStr::new(
+		r#"/path\ with\ spaces/clang -fuse-ld=lld"#,
+	)));
+	assert_eq!(escaped.get_program(), "/path with spaces/clang");
+	let escaped_args: Vec<_> = escaped.get_args().collect();
+	assert_eq!(escaped_args, vec![OsStr::new("-fuse-ld=lld")]);
+
+	let fallback = super::darwin_compiler::darwin_compiler_command(None);
+	assert_eq!(fallback.get_program(), "/usr/bin/xcrun");
+	let fallback_args: Vec<_> = fallback.get_args().collect();
+	assert_eq!(fallback_args, vec![OsStr::new("clang")]);
+
+	let empty = super::darwin_compiler::darwin_compiler_command(Some(OsStr::new("   ")));
+	assert_eq!(empty.get_program(), "/usr/bin/xcrun");
+	let empty_args: Vec<_> = empty.get_args().collect();
+	assert_eq!(empty_args, vec![OsStr::new("clang")]);
+}

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed native Darwin OAuth helper compilation under sandboxed and custom build environments by respecting `$CC` ([#11869](https://github.com/can1357/oh-my-pi/pull/11869) by [@Malix-Labs](https://github.com/Malix-Labs)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Fixed


### PR DESCRIPTION
## What

Allow `pi-natives/build.rs` to use `$CC` if set instead of hardcoding `/usr/bin/xcrun` when compiling the Darwin OAuth callback helper.

## Why

In sandboxed build environments like Nix on macOS, invoking `/usr/bin/xcrun` is blocked by the sandbox and fails with `Operation not permitted (os error 1)`. Reading `$CC` first lets hermetic builds provide their own compiler wrapper while preserving the `/usr/bin/xcrun clang` fallback for standard developer environments.

## Testing

- `cargo fmt --check -- crates/pi-natives/build.rs` passes
- `cargo check -p pi-natives` passes
- `cargo test -p pi-natives darwin_compiler_selection` passes
- `bun check` was skipped as this PR only affects native Rust build code in `crates/pi-natives`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)