### PR TITLE
fix(extensions): ignore disabled items during deduplication

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- `/extensions` now shows an enabled context file as active when its higher-priority competitor is disabled ([#11870](https://github.com/can1357/oh-my-pi/issues/11870)).
 - Claude Code session imports now preserve typed user text stored alongside tool results ([#11854](https://github.com/can1357/oh-my-pi/issues/11854)).
 - Extension commands now settle BTW writes before creating, switching, or branching sessions, preventing side requests from outliving their source session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).
 - Session selection and active-session deletion now settle BTW writes before switching or removing history, preventing stale saves from blocking the next session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -121,11 +121,12 @@ async function loadImpl<T>(
 ): Promise<CapabilityResult<T>> {
 	const allItems: Array<T & { _source: SourceMeta; _shadowed?: boolean }> = [];
 	const suppressedItems = new Set<T & { _source: SourceMeta; _shadowed?: boolean }>();
+	const disabledItems = new Set<T & { _source: SourceMeta; _shadowed?: boolean }>();
 	const allWarnings: string[] = [];
 	const contributingProviders: string[] = [];
-	const disabledExtensionIds = options.includeDisabled
-		? new Set<string>()
-		: new Set<string>(options.disabledExtensions ?? settings?.get("disabledExtensions") ?? []);
+	const disabledExtensionIds = new Set<string>(
+		options.disabledExtensions ?? settings?.get("disabledExtensions") ?? [],
+	);
 
 	const results = await Promise.all(
 		providers.map(async provider => {
@@ -166,12 +167,17 @@ async function loadImpl<T>(
 			}
 
 			const extensionId = capability.toExtensionId?.(itemWithSource);
-			if (extensionId && disabledExtensionIds.has(extensionId)) {
+			const isDisabled = extensionId !== undefined && disabledExtensionIds.has(extensionId);
+			if (isDisabled && !options.includeDisabled) {
 				continue;
 			}
 
 			if (options.filter && !options.filter(itemWithSource)) {
 				continue;
+			}
+
+			if (isDisabled) {
+				disabledItems.add(itemWithSource);
 			}
 
 			if (options.suppress?.(itemWithSource)) {
@@ -203,6 +209,11 @@ async function loadImpl<T>(
 	for (const item of allItems) {
 		const key = capability.key(item);
 
+		if (disabledItems.has(item)) {
+			if (!suppressedItems.has(item)) deduped.push(item);
+			continue;
+		}
+
 		if (suppressedItems.has(item)) {
 			// Claim key ownership (same-name precedence, including disabled
 			// state) without surviving or equivalence-shadowing survivors.
@@ -217,7 +228,10 @@ async function loadImpl<T>(
 
 		const keySeen = seen.has(key);
 		seen.add(key);
-		const aliasSeen = !keySeen && equivalent !== undefined && deduped.some(existing => equivalent(existing, item));
+		const aliasSeen =
+			!keySeen &&
+			equivalent !== undefined &&
+			deduped.some(existing => !disabledItems.has(existing) && equivalent(existing, item));
 		if (keySeen || aliasSeen) {
 			item._shadowed = true;
 		} else {

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -210,6 +210,18 @@ async function loadImpl<T>(
 		const key = capability.key(item);
 
 		if (disabledItems.has(item)) {
+			// Disabled rows never claim their key or equivalence class, so they
+			// can't shadow an enabled survivor (issue #11870). But when an
+			// earlier enabled item already owns the key or an equivalent
+			// identity, the disabled row is a lower-priority loser: mark it
+			// shadowed so the dashboard treats it as a shadowed no-op instead of
+			// an independently toggleable row.
+			const keySeen = key !== undefined && seen.has(key);
+			const aliasSeen =
+				!keySeen &&
+				equivalent !== undefined &&
+				deduped.some(existing => !disabledItems.has(existing) && equivalent(existing, item));
+			if (keySeen || aliasSeen) item._shadowed = true;
 			if (!suppressedItems.has(item)) deduped.push(item);
 			continue;
 		}

--- a/packages/coding-agent/src/capability/types.ts
+++ b/packages/coding-agent/src/capability/types.ts
@@ -104,7 +104,7 @@ export interface LoadOptions<T = unknown> {
 	cwd?: string;
 	/** Include items even if they fail validation. Default: false */
 	includeInvalid?: boolean;
-	/** Include items disabled via settings. Default: false */
+	/** Include disabled items without letting them shadow enabled items. Default: false */
 	includeDisabled?: boolean;
 	/** Explicit disabled extension IDs to apply instead of settings. */
 	disabledExtensions?: string[];

--- a/packages/coding-agent/src/modes/components/extensions/state-manager.ts
+++ b/packages/coding-agent/src/modes/components/extensions/state-manager.ts
@@ -111,7 +111,9 @@ export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): P
 		}
 	}
 
-	const loadOpts = cwd ? { cwd, includeDisabled: true } : { includeDisabled: true };
+	const loadOpts = cwd
+		? { cwd, includeDisabled: true, disabledExtensions: disabledIds }
+		: { includeDisabled: true, disabledExtensions: disabledIds };
 
 	// Load skills
 	try {

--- a/packages/coding-agent/src/modes/components/extensions/state-manager.ts
+++ b/packages/coding-agent/src/modes/components/extensions/state-manager.ts
@@ -74,7 +74,8 @@ function resolveState(
  */
 export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): Promise<Extension[]> {
 	const extensions: Extension[] = [];
-	const disabledExtensions = new Set<string>(disabledIds ?? []);
+	const effectiveDisabledIds = disabledIds ?? [];
+	const disabledExtensions = new Set<string>(effectiveDisabledIds);
 
 	// Helper to convert capability items to extensions
 	function addItems<T extends { name: string; path: string; _source: SourceMeta }>(
@@ -112,8 +113,8 @@ export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): P
 	}
 
 	const loadOpts = cwd
-		? { cwd, includeDisabled: true, disabledExtensions: disabledIds }
-		: { includeDisabled: true, disabledExtensions: disabledIds };
+		? { cwd, includeDisabled: true, disabledExtensions: effectiveDisabledIds }
+		: { includeDisabled: true, disabledExtensions: effectiveDisabledIds };
 
 	// Load skills
 	try {

--- a/packages/coding-agent/test/discovery/disabled-extensions.test.ts
+++ b/packages/coding-agent/test/discovery/disabled-extensions.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { type ContextFile, contextFileCapability } from "@oh-my-pi/pi-coding-agent/capability/context-file";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { initializeWithSettings, loadCapability } from "@oh-my-pi/pi-coding-agent/discovery";
+import { loadAllExtensions } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/state-manager";
 import { __resetDirsFromEnvForTests, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
 
 function restoreEnvValue(key: string, value: string | undefined): void {
@@ -84,5 +85,25 @@ describe("disabledExtensions runtime filtering", () => {
 
 		expect(result.items).toHaveLength(1);
 		expect(path.basename(result.items[0]!.path)).toBe("AGENTS.md");
+	});
+
+	test("keeps the runtime context winner active in the dashboard when its competitor is disabled", async () => {
+		await fs.rm(path.join(tempDir, ".omp", "AGENTS.md"));
+		await fs.writeFile(path.join(tempDir, "AGENTS.md"), "# active project instructions\n");
+		await fs.mkdir(path.join(tempDir, ".gemini"), { recursive: true });
+		await fs.writeFile(path.join(tempDir, ".gemini", "GEMINI.md"), "# disabled project instructions\n");
+
+		const disabledExtensions = ["context-file:project:GEMINI.md", "context-file:user:GEMINI.md"];
+		const settings = Settings.isolated({ disabledExtensions });
+		initializeWithSettings(settings);
+
+		const runtime = await loadCapability<ContextFile>(contextFileCapability.id, { cwd: tempDir });
+		const dashboard = await loadAllExtensions(tempDir, disabledExtensions);
+		const agents = dashboard.find(extension => extension.path === path.join(tempDir, "AGENTS.md"));
+		const gemini = dashboard.find(extension => extension.path === path.join(tempDir, ".gemini", "GEMINI.md"));
+
+		expect(runtime.items.map(file => path.basename(file.path))).toContain("AGENTS.md");
+		expect(agents?.state).toBe("active");
+		expect(gemini?.state).toBe("disabled");
 	});
 });

--- a/packages/coding-agent/test/discovery/disabled-extensions.test.ts
+++ b/packages/coding-agent/test/discovery/disabled-extensions.test.ts
@@ -106,4 +106,22 @@ describe("disabledExtensions runtime filtering", () => {
 		expect(agents?.state).toBe("active");
 		expect(gemini?.state).toBe("disabled");
 	});
+
+	test("deduplicates against the caller's session-local disabled list, not global settings", async () => {
+		await fs.rm(path.join(tempDir, ".omp", "AGENTS.md"));
+		await fs.writeFile(path.join(tempDir, "AGENTS.md"), "# active project instructions\n");
+		await fs.mkdir(path.join(tempDir, ".gemini"), { recursive: true });
+		await fs.writeFile(path.join(tempDir, ".gemini", "GEMINI.md"), "# session-disabled project instructions\n");
+
+		// Process-global settings disable nothing; the disablement is session-local.
+		initializeWithSettings(Settings.isolated({ disabledExtensions: [] }));
+
+		const disabledIds = ["context-file:project:GEMINI.md", "context-file:user:GEMINI.md"];
+		const dashboard = await loadAllExtensions(tempDir, disabledIds);
+		const agents = dashboard.find(extension => extension.path === path.join(tempDir, "AGENTS.md"));
+		const gemini = dashboard.find(extension => extension.path === path.join(tempDir, ".gemini", "GEMINI.md"));
+
+		expect(agents?.state).toBe("active");
+		expect(gemini?.state).toBe("disabled");
+	});
 });

--- a/packages/coding-agent/test/discovery/disabled-extensions.test.ts
+++ b/packages/coding-agent/test/discovery/disabled-extensions.test.ts
@@ -128,6 +128,22 @@ describe("disabledExtensions runtime filtering", () => {
 		expect(gemini?.state).toBe("disabled");
 	});
 
+	test("deduplicates against an empty snapshot when the caller omits disabled IDs", async () => {
+		await fs.rm(path.join(tempDir, ".omp", "AGENTS.md"));
+		await fs.writeFile(path.join(tempDir, "AGENTS.md"), "# lower-priority project instructions\n");
+		await fs.mkdir(path.join(tempDir, ".gemini"), { recursive: true });
+		await fs.writeFile(path.join(tempDir, ".gemini", "GEMINI.md"), "# higher-priority project instructions\n");
+
+		initializeWithSettings(Settings.isolated({ disabledExtensions: ["context-file:project:GEMINI.md"] }));
+
+		const dashboard = await loadAllExtensions(tempDir);
+		const agents = dashboard.find(extension => extension.path === path.join(tempDir, "AGENTS.md"));
+		const gemini = dashboard.find(extension => extension.path === path.join(tempDir, ".gemini", "GEMINI.md"));
+
+		expect(agents?.state).toBe("shadowed");
+		expect(gemini?.state).toBe("active");
+	});
+
 	test("marks a disabled lower-priority row shadowed when an enabled higher-priority item owns the key", async () => {
 		// Enabled builtin .omp/AGENTS.md (priority 100) already exists at project
 		// depth 0 from beforeEach; add a lower-priority .gemini/GEMINI.md at the

--- a/packages/coding-agent/test/discovery/disabled-extensions.test.ts
+++ b/packages/coding-agent/test/discovery/disabled-extensions.test.ts
@@ -5,7 +5,10 @@ import * as path from "node:path";
 import { type ContextFile, contextFileCapability } from "@oh-my-pi/pi-coding-agent/capability/context-file";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { initializeWithSettings, loadCapability } from "@oh-my-pi/pi-coding-agent/discovery";
-import { loadAllExtensions } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/state-manager";
+import {
+	isShadowedExtension,
+	loadAllExtensions,
+} from "@oh-my-pi/pi-coding-agent/modes/components/extensions/state-manager";
 import { __resetDirsFromEnvForTests, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
 
 function restoreEnvValue(key: string, value: string | undefined): void {
@@ -123,5 +126,26 @@ describe("disabledExtensions runtime filtering", () => {
 
 		expect(agents?.state).toBe("active");
 		expect(gemini?.state).toBe("disabled");
+	});
+
+	test("marks a disabled lower-priority row shadowed when an enabled higher-priority item owns the key", async () => {
+		// Enabled builtin .omp/AGENTS.md (priority 100) already exists at project
+		// depth 0 from beforeEach; add a lower-priority .gemini/GEMINI.md at the
+		// same depth and disable it.
+		await fs.mkdir(path.join(tempDir, ".gemini"), { recursive: true });
+		await fs.writeFile(path.join(tempDir, ".gemini", "GEMINI.md"), "# disabled lower-priority instructions\n");
+
+		const disabledIds = ["context-file:project:GEMINI.md"];
+		initializeWithSettings(Settings.isolated({ disabledExtensions: disabledIds }));
+
+		const dashboard = await loadAllExtensions(tempDir, disabledIds);
+		const agents = dashboard.find(extension => extension.path === path.join(tempDir, ".omp", "AGENTS.md"));
+		const gemini = dashboard.find(extension => extension.path === path.join(tempDir, ".gemini", "GEMINI.md"));
+
+		expect(agents?.state).toBe("active");
+		expect(gemini?.state).toBe("disabled");
+		// The disabled loser must stay shadowed so the dashboard does not treat
+		// it as an independently toggleable row.
+		expect(gemini && isShadowedExtension(gemini)).toBe(true);
 	});
 });


### PR DESCRIPTION
## Repro

With same-scope project `GEMINI.md` and `AGENTS.md` files and both GEMINI extension IDs disabled, `bun test packages/coding-agent/test/discovery/disabled-extensions.test.ts` reproduced the mismatch: the runtime load selected `AGENTS.md`, but `loadAllExtensions` returned its dashboard state as `shadowed` instead of `active`.

## Cause

`loadImpl` in `packages/coding-agent/src/capability/index.ts` replaced the disabled-ID set with an empty set for `includeDisabled` loads. That kept disabled rows visible, but also let them claim deduplication keys and semantic equivalence before `/extensions` resolved display state, unlike runtime loads which filter them first.

## Fix

- Keep disabled extension IDs available during dashboard-style loads and include their rows without letting them participate in winner selection.
- Add a regression covering runtime/dashboard parity for competing project `GEMINI.md` and `AGENTS.md` files.
- Document the user-visible correction in the coding-agent changelog.

## Verification

`bun test packages/coding-agent/test/discovery/disabled-extensions.test.ts` passes with 3 tests; the same case failed before the fix with `Expected: "active"; Received: "shadowed"`. `bun test packages/coding-agent/test/discovery/disabled-extensions.test.ts packages/coding-agent/test/discovery/mcp-enabled-import.test.ts packages/coding-agent/test/extension-dashboard-mcp-parity.test.ts` passes with 22 tests, and `bun run check` passes in `packages/coding-agent`. The pre-publish root checks also passed. Interactive TUI verification was unavailable because the worktree build hit `EACCES` reading the existing `packages/natives/native/pi_natives.linux-x64-modern.node`; the regression exercises the production dashboard state loader directly.

Fixes #11870