### PR TITLE
fix(compaction): resume the turn a manual /compact interrupted

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -459,7 +459,7 @@ Post-navigation event exposing new/old leaf and optional summary entry.
 
 ## Runtime behavior and failure semantics
 
-- Manual compaction aborts current agent operation first.
+- Manual compaction aborts current agent operation first. If that abort cut a turn in flight, the committed compaction resumes it (queued steer/follow-up first, otherwise the auto-continue prompt) unless `compaction.autoContinue` is `false` or the caller passed `suppressContinuation` (plan-mode approval dispatches its own execution turn). A manual compaction issued while idle never starts a turn.
 - `abortCompaction()` cancels manual compaction, auto-compaction, and handoff generation controllers.
 - Auto compaction emits start/end session events for UI/state updates.
 - Auto compaction can try multiple model candidates and retry transient failures; long retry delays prefer the next candidate when one is available.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- A manual `/compact` (slash command, RPC `compact`, extension `ctx.compact()`) issued while a turn is in flight now resumes that turn once the summary is committed — a queued steer/follow-up drives the resume, otherwise the same auto-continue nudge context-full compaction uses — instead of leaving the agent idle on a half-finished tool loop until the user types "continue". `compaction.autoContinue: false` still disables the resume; plan-mode "Approve and compact context" keeps dispatching its own execution turn.
+- A manual `/compact` (slash command, RPC `compact`, extension `ctx.compact()`) issued while a turn is in flight now resumes that turn once the summary is committed — a queued steer/follow-up drives the resume, otherwise the same auto-continue nudge context-full compaction uses — instead of leaving the agent idle on a half-finished tool loop until the user types "continue". `compaction.autoContinue: false` still disables the resume; plan-mode "Approve and compact context" keeps dispatching its own execution turn ([#11873](https://github.com/can1357/oh-my-pi/pull/11873) by [@brndnmtthws](https://github.com/brndnmtthws)).
 
 ## [18.1.18] - 2026-09-11
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- A manual `/compact` (slash command, RPC `compact`, extension `ctx.compact()`) issued while a turn is in flight now resumes that turn once the summary is committed — a queued steer/follow-up drives the resume, otherwise the same auto-continue nudge context-full compaction uses — instead of leaving the agent idle on a half-finished tool loop until the user types "continue". `compaction.autoContinue: false` still disables the resume; plan-mode "Approve and compact context" keeps dispatching its own execution turn.
+
 ## [18.1.18] - 2026-09-11
 
 ### Added

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -413,6 +413,14 @@ export interface CompactOptions {
 	 * `customInstructions`.
 	 */
 	internalGuidance?: string;
+	/**
+	 * A manual compaction aborts any turn in flight and, once the summary is
+	 * committed, resumes it (queued steer/follow-up first, else the auto-continue
+	 * nudge). Set this when the caller dispatches its own follow-up turn after
+	 * compaction — plan-mode "Approve and compact context" — so the two don't
+	 * double-prompt. Compactions that interrupt nothing never continue.
+	 */
+	suppressContinuation?: boolean;
 }
 
 /**

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -415,10 +415,12 @@ export interface CompactOptions {
 	internalGuidance?: string;
 	/**
 	 * A manual compaction aborts any turn in flight and, once the summary is
-	 * committed, resumes it (queued steer/follow-up first, else the auto-continue
-	 * nudge). Set this when the caller dispatches its own follow-up turn after
-	 * compaction — plan-mode "Approve and compact context" — so the two don't
-	 * double-prompt. Compactions that interrupt nothing never continue.
+	 * committed, resumes it with the auto-continue nudge. Set this when the caller
+	 * dispatches its own follow-up turn after compaction — plan-mode "Approve and
+	 * compact context" — so the two don't double-prompt. Compactions that
+	 * interrupt nothing never continue. Steer/follow-up messages queued during
+	 * the compaction are unaffected: they always drain once compaction ends
+	 * (issue #5800), before and independent of this option.
 	 */
 	suppressContinuation?: boolean;
 }

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1493,9 +1493,16 @@ export class CommandController {
 		// `customInstructions` channel of the `session_before_compact` extension
 		// hook — extensions treat that field as user focus and would otherwise
 		// bias the summary toward the plan boilerplate (issue #4359). Ride it
-		// through as a CompactOptions field instead.
+		// through as a CompactOptions field instead. That caller also dispatches
+		// the execution turn itself, so the compaction must not resume the
+		// plan-approval turn it aborted.
 		if (internalGuidance) {
-			return this.executeCompaction({ internalGuidance, ...(mode ? { mode } : {}) }, false, beforeFlush, mode);
+			return this.executeCompaction(
+				{ internalGuidance, suppressContinuation: true, ...(mode ? { mode } : {}) },
+				false,
+				beforeFlush,
+				mode,
+			);
 		}
 		return this.executeCompaction(customInstructions, false, beforeFlush, mode);
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6131,8 +6131,9 @@ export class AgentSession {
 		// cleanup finally re-drains the preserved queues. Starting a turn before then
 		// would neither persist nor forward its events and could race the in-flight
 		// history rewrite. `abort` still overtakes compaction; ordinary prompts wait
-		// here. No-op when no manual compaction is active.
-		await this.#maintenance.manualCompactionCleanup;
+		// here, and a waiting prompt supersedes the interrupted-turn resume the
+		// compaction would otherwise schedule. No-op when no manual compaction is active.
+		await this.#maintenance.waitForManualCompactionCleanup();
 		const expandPromptTemplates = options?.expandPromptTemplates ?? true;
 		// Slash/custom-command handling below rewrites `text`; keep the original
 		// so a dropped prompt is handed back exactly as the user typed it.

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -897,7 +897,16 @@ export class SessionMaintenance {
 					`remote compaction is unavailable for ${activeModel.id}; trying the next preferred method`,
 					"compaction",
 				);
-				return await this.compact(customInstructions, options, selectedMethodIndex + 1, compactionAbortController);
+				// The nested call runs on this controller, so it never owns the resume;
+				// mark the commit here like the catch-based retry does.
+				const fallback = await this.compact(
+					customInstructions,
+					options,
+					selectedMethodIndex + 1,
+					compactionAbortController,
+				);
+				compactionCommitted = true;
+				return fallback;
 			}
 			const pathEntries = this.#host.sessionManager.getBranch();
 			const preparation = prepareCompaction(pathEntries, effectiveSettings, activeModel, this.#tokenizer);

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -800,6 +800,11 @@ export class SessionMaintenance {
 		let selectedMethodIndex = -1;
 		let compactionCommitted = false;
 		let methodAttempted = false;
+		// Set when this manual pass aborted a live turn: the turn is resumed once the
+		// summary lands (see the `finally`). Generation is captured after the abort
+		// bump so a reset/new-session in between skips the resume as stale.
+		let resumeInterruptedTurn = false;
+		let interruptedTurnGeneration = 0;
 		const compactionAbortController = retryController ?? new AbortController();
 		const manualCompactionCleanup = ownsCompactionController ? Promise.withResolvers<void>() : undefined;
 		if (ownsCompactionController) {
@@ -812,8 +817,17 @@ export class SessionMaintenance {
 
 		try {
 			if (ownsCompactionController) {
+				// A manual compaction aborts the live turn, tool loop included. Without a
+				// resume the agent sits idle on a half-finished loop (an autoresearch run,
+				// a pending tool result) until the user types "continue" by hand.
+				const interruptedActiveTurn = this.#host.isStreaming();
 				this.#host.disconnectFromAgent();
 				await this.#host.abort({ goalReason: "internal", preserveCompaction: true });
+				resumeInterruptedTurn =
+					interruptedActiveTurn &&
+					options?.suppressContinuation !== true &&
+					this.#host.settings.get("compaction.autoContinue") !== false;
+				interruptedTurnGeneration = this.#host.promptGeneration();
 			}
 			const activeModel = this.#model;
 			if (!activeModel) {
@@ -826,6 +840,7 @@ export class SessionMaintenance {
 				!options?.internalGuidance
 			) {
 				const result = await this.#compactExperimentalContext(activeModel, compactionAbortController);
+				compactionCommitted = true;
 				options?.onComplete?.(result);
 				return result;
 			}
@@ -1170,7 +1185,14 @@ export class SessionMaintenance {
 					`${methods[selectedMethodIndex]} compaction failed; trying the next preferred method`,
 					"compaction",
 				);
-				return await this.compact(customInstructions, options, selectedMethodIndex + 1, compactionAbortController);
+				const retried = await this.compact(
+					customInstructions,
+					options,
+					selectedMethodIndex + 1,
+					compactionAbortController,
+				);
+				compactionCommitted = true;
+				return retried;
 			}
 			options?.onError?.(err);
 			throw error;
@@ -1191,6 +1213,18 @@ export class SessionMaintenance {
 					this.#manualCompactionCleanup = undefined;
 				}
 				manualCompactionCleanup?.resolve();
+				if (compactionCommitted && resumeInterruptedTurn) {
+					// Same continuation the context-full path uses: a queued steer/follow-up
+					// (drained above) drives the resume, otherwise the auto-continue nudge
+					// does. `terminalTextAnswer` is false by construction — the turn was
+					// cut mid-run, so there is no finished answer to preserve.
+					this.#host.scheduleCompactionContinuation({
+						generation: interruptedTurnGeneration,
+						autoContinue: true,
+						terminalTextAnswer: false,
+						suppressContinuation: false,
+					});
+				}
 			}
 		}
 	}

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -820,7 +820,11 @@ export class SessionMaintenance {
 				// A manual compaction aborts the live turn, tool loop included. Without a
 				// resume the agent sits idle on a half-finished loop (an autoresearch run,
 				// a pending tool result) until the user types "continue" by hand.
-				const interruptedActiveTurn = this.#host.isStreaming();
+				// Only a turn the agent actually owns counts: the session-level busy flag
+				// is also true while a prompt is still in async setup (before its message
+				// reaches the agent). The abort bump drops that prompt, so resuming on
+				// its behalf would nudge the model on the previous transcript instead.
+				const interruptedActiveTurn = this.#host.agent.state.isStreaming;
 				this.#host.disconnectFromAgent();
 				await this.#host.abort({ goalReason: "internal", preserveCompaction: true });
 				resumeInterruptedTurn =

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -773,12 +773,17 @@ export class SessionMaintenance {
 	 * Aborts current agent operation first.
 	 * @param customInstructions Optional instructions for the compaction summary
 	 * @param options Optional callbacks for completion/error handling
+	 * @param onCommitted Internal: nested fallback frames report their commit to
+	 * the owning frame the moment the entry lands, so a late rejection (a
+	 * `session_compact` hook or `onComplete` throwing after the append) still
+	 * resumes the interrupted turn exactly as the direct path does.
 	 */
 	async compact(
 		customInstructions?: string,
 		options?: CompactOptions,
 		methodOffset = 0,
 		retryController?: AbortController,
+		onCommitted?: () => void,
 	): Promise<CompactionResult> {
 		const ownsCompactionController = retryController === undefined;
 		if (this.#compactionAbortController && this.#compactionAbortController !== retryController) {
@@ -801,6 +806,10 @@ export class SessionMaintenance {
 		let methods: CompactionMethod[] = [];
 		let selectedMethodIndex = -1;
 		let compactionCommitted = false;
+		const markCommitted = (): void => {
+			compactionCommitted = true;
+			onCommitted?.();
+		};
 		let methodAttempted = false;
 		// Set when this manual pass aborted a live turn: the turn is resumed once the
 		// summary lands (see the `finally`). Generation is captured after the abort
@@ -846,7 +855,7 @@ export class SessionMaintenance {
 				!options?.internalGuidance
 			) {
 				const result = await this.#compactExperimentalContext(activeModel, compactionAbortController);
-				compactionCommitted = true;
+				markCommitted();
 				options?.onComplete?.(result);
 				return result;
 			}
@@ -904,15 +913,14 @@ export class SessionMaintenance {
 					"compaction",
 				);
 				// The nested call runs on this controller, so it never owns the resume;
-				// mark the commit here like the catch-based retry does.
-				const fallback = await this.compact(
+				// it reports its commit back here instead.
+				return await this.compact(
 					customInstructions,
 					options,
 					selectedMethodIndex + 1,
 					compactionAbortController,
+					markCommitted,
 				);
-				compactionCommitted = true;
-				return fallback;
 			}
 			const pathEntries = this.#host.sessionManager.getBranch();
 			const preparation = prepareCompaction(pathEntries, effectiveSettings, activeModel, this.#tokenizer);
@@ -1161,7 +1169,7 @@ export class SessionMaintenance {
 				});
 			}
 
-			compactionCommitted = true;
+			markCommitted();
 			await this.#commitCompactionEntry({
 				summary,
 				shortSummary,
@@ -1200,14 +1208,13 @@ export class SessionMaintenance {
 					`${methods[selectedMethodIndex]} compaction failed; trying the next preferred method`,
 					"compaction",
 				);
-				const retried = await this.compact(
+				return await this.compact(
 					customInstructions,
 					options,
 					selectedMethodIndex + 1,
 					compactionAbortController,
+					markCommitted,
 				);
-				compactionCommitted = true;
-				return retried;
 			}
 			options?.onError?.(err);
 			throw error;

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -365,6 +365,8 @@ export class SessionMaintenance {
 	#compactionAbortController: AbortController | undefined;
 	/** Resolves after an active manual compaction has reconnected the agent subscription. */
 	#manualCompactionCleanup: Promise<void> | undefined;
+	/** Prompts parked in {@link waitForManualCompactionCleanup}; any waiter supersedes the interrupted-turn resume. */
+	#promptsAwaitingCleanup = 0;
 	#autoCompactionAbortController: AbortController | undefined;
 	/**
 	 * Live tool-loop contexts parked after mid-turn maintenance hit a no-progress
@@ -1226,11 +1228,13 @@ export class SessionMaintenance {
 					this.#manualCompactionCleanup = undefined;
 				}
 				manualCompactionCleanup?.resolve();
-				if (compactionCommitted && resumeInterruptedTurn) {
+				if (compactionCommitted && resumeInterruptedTurn && this.#promptsAwaitingCleanup === 0) {
 					// Same continuation the context-full path uses: a queued steer/follow-up
 					// (drained above) drives the resume, otherwise the auto-continue nudge
 					// does. `terminalTextAnswer` is false by construction — the turn was
-					// cut mid-run, so there is no finished answer to preserve.
+					// cut mid-run, so there is no finished answer to preserve. A prompt
+					// parked on the barrier just resolved is still counted here (its
+					// continuation is a microtask away) and takes the session instead.
 					this.#host.scheduleCompactionContinuation({
 						generation: interruptedTurnGeneration,
 						autoContinue: true,
@@ -1581,13 +1585,23 @@ export class SessionMaintenance {
 	}
 
 	/**
-	 * Resolves once an in-flight manual compaction has reconnected the agent
-	 * subscription and re-drained its preserved queues; `undefined` when no manual
-	 * compaction is active. Callers that must not start a turn against the
-	 * disconnected session (e.g. ordinary prompts) await this first.
+	 * Park an ordinary prompt until an in-flight manual compaction has reconnected
+	 * the agent subscription and re-drained its preserved queues; returns at once
+	 * when no manual compaction is active. A prompt waiting here is the user's
+	 * next intent, so it supersedes the interrupted-turn resume: the cleanup
+	 * `finally` skips the synthetic continuation while any waiter is parked,
+	 * otherwise the nudge claims the session first and the prompt lands on
+	 * `AgentBusyError`.
 	 */
-	get manualCompactionCleanup(): Promise<void> | undefined {
-		return this.#manualCompactionCleanup;
+	async waitForManualCompactionCleanup(): Promise<void> {
+		const cleanup = this.#manualCompactionCleanup;
+		if (!cleanup) return;
+		this.#promptsAwaitingCleanup++;
+		try {
+			await cleanup;
+		} finally {
+			this.#promptsAwaitingCleanup--;
+		}
 	}
 
 	/** Cancel only automatic maintenance while preserving a manual compaction. */

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -501,6 +501,64 @@ describe("AgentSession auto-compaction queue resume", () => {
 		expect(promptSpy).not.toHaveBeenCalled();
 	});
 
+	it("lets a prompt submitted during the compaction supersede the resume", async () => {
+		// An RPC/SDK prompt sent while a manual compaction runs parks on the cleanup
+		// barrier. It is the user's next intent: it must dispatch once compaction
+		// ends instead of losing the session to the synthetic resume (and, without
+		// a streamingBehavior, surfacing AgentBusyError).
+		session.settings.set("compaction.keepRecentTokens", 1);
+		session.settings.override("compaction.autoContinue", true);
+		sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "previous answer" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: 1_000,
+				output: 100,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1_100,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		});
+		session.agent.replaceMessages(session.buildDisplaySessionContext().messages);
+
+		session.agent.state.isStreaming = true;
+		vi.spyOn(session, "abort").mockImplementation(async () => {
+			session.agent.state.isStreaming = false;
+		});
+		type Dispatched = { role: string; content?: unknown; synthetic?: boolean };
+		const prompted: Dispatched[][] = [];
+		vi.spyOn(session.agent, "prompt").mockImplementation(async message => {
+			prompted.push((Array.isArray(message) ? message : [message]) as Dispatched[]);
+		});
+
+		// Park the compaction inside its awaited hook so the prompt below arrives
+		// while it is in flight.
+		const gate = Promise.withResolvers<void>();
+		(globalThis as typeof globalThis & { __ompManualCompactGate?: Promise<void> }).__ompManualCompactGate =
+			gate.promise;
+		const compacted = session.compact();
+		while (!getRuntimeSignals().includes("before_compact:enter")) {
+			await Promise.resolve();
+		}
+		const redirected = session.prompt("redirect");
+		gate.resolve();
+		await compacted;
+		await redirected;
+		await session.waitForIdle();
+
+		// Exactly one turn: the user's prompt. No synthetic nudge raced it.
+		expect(prompted).toHaveLength(1);
+		const roles = prompted[0]?.map(message => message.role);
+		expect(roles).toContain("user");
+		expect(prompted[0]?.some(message => message.synthetic === true)).toBe(false);
+	});
+
 	it("cancels an in-flight auto-compaction when manual compact startup aborts", async () => {
 		// Give the branch something to summarize so auto-compaction reaches the
 		// awaited session_before_compact hook, where the test parks it.

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -26,6 +26,9 @@ function getRuntimeSignals(): string[] {
 	return globalWithSignals[runtimeSignalStoreKey];
 }
 
+/** Parks a prompt inside its awaited `before_agent_start` hook. */
+type AgentStartGate = { entered: PromiseWithResolvers<void>; release: PromiseWithResolvers<void> };
+
 /**
  * Regression test: auto-compaction completion should resume the agent loop when
  * there are queued agent-level messages (follow-up/steering/custom).
@@ -65,6 +68,13 @@ describe("AgentSession auto-compaction queue resume", () => {
 							details: {},
 						},
 					};
+				});
+				pi.on("before_agent_start", async () => {
+					const gate = (globalThis as typeof globalThis & { __ompAgentStartGate?: AgentStartGate })
+						.__ompAgentStartGate;
+					if (!gate) return;
+					gate.entered.resolve();
+					await gate.release.promise;
 				});
 				pi.on("auto_compaction_start", event => {
 					getRuntimeSignals().push(`compaction:start:${event.reason}`);
@@ -135,6 +145,8 @@ describe("AgentSession auto-compaction queue resume", () => {
 			} finally {
 				getRuntimeSignals().length = 0;
 				(globalThis as typeof globalThis & { __ompManualCompactGate?: Promise<void> }).__ompManualCompactGate =
+					undefined;
+				(globalThis as typeof globalThis & { __ompAgentStartGate?: AgentStartGate }).__ompAgentStartGate =
 					undefined;
 				vi.restoreAllMocks();
 			}
@@ -397,6 +409,58 @@ describe("AgentSession auto-compaction queue resume", () => {
 		await session.compact();
 		await session.waitForIdle();
 
+		expect(promptSpy).not.toHaveBeenCalled();
+	});
+
+	it("does not resume when compaction lands while a prompt is still in setup", async () => {
+		// Between `session.prompt()` and the message reaching `agent.prompt()` the
+		// session reports busy (in-flight count) while the agent owns no turn. The
+		// compaction abort bumps the generation and drops that prompt; nudging the
+		// model to "resume" would run it on the previous transcript with the user's
+		// input never sent.
+		session.settings.set("compaction.keepRecentTokens", 1);
+		session.settings.override("compaction.autoContinue", true);
+		sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "previous answer" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: 1_000,
+				output: 100,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1_100,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		});
+		session.agent.replaceMessages(session.buildDisplaySessionContext().messages);
+
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockImplementation(async () => {});
+		const dropped: string[] = [];
+		session.setPromptDropped(prompt => dropped.push(prompt.text));
+
+		// Park the prompt inside its awaited before_agent_start hook: in-flight, but
+		// the message has not reached the agent.
+		const gate: AgentStartGate = { entered: Promise.withResolvers<void>(), release: Promise.withResolvers<void>() };
+		(globalThis as typeof globalThis & { __ompAgentStartGate?: AgentStartGate }).__ompAgentStartGate = gate;
+		const pending = session.prompt("new request");
+		await gate.entered.promise;
+		expect(session.isStreaming).toBe(true);
+		expect(session.agent.state.isStreaming).toBe(false);
+
+		const compacted = session.compact();
+		gate.release.resolve();
+		await compacted;
+		await pending;
+		// The abort bumped the generation, so the parked prompt is handed back unsent…
+		expect(dropped).toEqual(["new request"]);
+		await session.waitForIdle();
+
+		// …and nothing "resumes" a turn the agent never owned.
 		expect(promptSpy).not.toHaveBeenCalled();
 	});
 

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -323,6 +323,120 @@ describe("AgentSession auto-compaction queue resume", () => {
 		expect(continueSpy).toHaveBeenCalledTimes(1);
 	});
 
+	it("resumes the turn a manual compaction interrupted", async () => {
+		// /compact mid-turn aborts the live tool loop. Left alone the agent sits idle
+		// on a half-finished loop until the user types "continue" — an autoresearch
+		// run dies this way. The compaction must resume the interrupted turn once the
+		// summary is committed, the same way context-full compaction does.
+		session.settings.set("compaction.keepRecentTokens", 1);
+		session.settings.override("compaction.autoContinue", true);
+		sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "previous answer" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: 1_000,
+				output: 100,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1_100,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		});
+		session.agent.replaceMessages(session.buildDisplaySessionContext().messages);
+
+		// A turn is in flight when /compact lands; the abort ends it.
+		session.agent.state.isStreaming = true;
+		vi.spyOn(session, "abort").mockImplementation(async () => {
+			session.agent.state.isStreaming = false;
+		});
+		type Dispatched = { role: string; attribution?: string; synthetic?: boolean };
+		const prompted: Dispatched[][] = [];
+		vi.spyOn(session.agent, "prompt").mockImplementation(async message => {
+			prompted.push((Array.isArray(message) ? message : [message]) as Dispatched[]);
+		});
+
+		await session.compact();
+		await session.waitForIdle();
+
+		// Exactly one turn starts, driven by the synthetic auto-continue nudge.
+		expect(prompted).toHaveLength(1);
+		const resume = prompted[0]?.filter(message => message.role === "developer" && message.synthetic === true);
+		expect(resume).toHaveLength(1);
+		expect(resume?.[0]?.attribution).toBe("agent");
+	});
+
+	it("does not start a turn when a manual compaction interrupted nothing", async () => {
+		session.settings.set("compaction.keepRecentTokens", 1);
+		session.settings.override("compaction.autoContinue", true);
+		sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "previous answer" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: 1_000,
+				output: 100,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1_100,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		});
+		session.agent.replaceMessages(session.buildDisplaySessionContext().messages);
+
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockImplementation(async () => {});
+
+		await session.compact();
+		await session.waitForIdle();
+
+		expect(promptSpy).not.toHaveBeenCalled();
+	});
+
+	it("leaves the resume to the caller when suppressContinuation is set", async () => {
+		// Plan-mode "Approve and compact context" dispatches the execution turn
+		// itself after compaction; resuming the aborted approval turn on top of it
+		// would double-prompt.
+		session.settings.set("compaction.keepRecentTokens", 1);
+		session.settings.override("compaction.autoContinue", true);
+		sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "previous answer" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: 1_000,
+				output: 100,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1_100,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		});
+		session.agent.replaceMessages(session.buildDisplaySessionContext().messages);
+
+		session.agent.state.isStreaming = true;
+		vi.spyOn(session, "abort").mockImplementation(async () => {
+			session.agent.state.isStreaming = false;
+		});
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockImplementation(async () => {});
+
+		await session.compact(undefined, { suppressContinuation: true });
+		await session.waitForIdle();
+
+		expect(promptSpy).not.toHaveBeenCalled();
+	});
+
 	it("cancels an in-flight auto-compaction when manual compact startup aborts", async () => {
 		// Give the branch something to summarize so auto-compaction reaches the
 		// awaited session_before_compact hook, where the test parks it.


### PR DESCRIPTION
## What

I kept hitting this issue where I wanted to manually compact, but after I did, it would just stop, and I had to send a "continue" to resume. If I interrupt work with a compaction, it should just continue once the compaction completes.

`SessionMaintenance.compact()` (`packages/coding-agent/src/session/session-maintenance.ts`; the manual path: `/compact`, RPC `compact`, extension `ctx.compact()`, model-switch over-context) aborts the live turn before summarizing and, unlike the context-full path, never scheduled a continuation afterwards. The agent was left idle on a half-finished tool loop (autoresearch runs die this way) until the user typed something.

Now `compact()` records whether its abort cut a turn in flight, captures the prompt generation after the abort bump, and — once the compaction entry is committed — hands off to the same `scheduleCompactionContinuation` the auto path uses: a queued steer/follow-up drives the resume, otherwise the `auto-continue.md` developer nudge does. A manual compaction issued while idle never starts a turn. `compaction.autoContinue: false` still disables the resume.

Plan-mode "Approve and compact context" aborts the approval turn and dispatches its own execution turn, so it opts out via the new `CompactOptions.suppressContinuation` (set in `handleCompactCommand`'s `internalGuidance` branch).

## Why

Manual compaction mid-turn silently killed the work in progress. Observed on 18.1.18 with Bedrock `claude-fable-5-1` in autoresearch mode: three sessions each stalled right after a `compaction` entry (method `soft`/`snapcompact`, `advisor context reset reason:"compact"` in the process log) until a `continue` was typed — one sat idle for 3.5 hours.

## Testing

- Reproduced end to end over RPC (`--mode rpc`, Bedrock `gpt-5.6-sol`, `--tools bash`, `compaction.methodOrder: [soft]`): prompt "run `sleep 40 && echo finished`, then reply DONE"; sent `{"type":"compact"}` 3s after `tool_execution_start`.
  - **Installed 18.1.18:** `response compact ok=true`, then nothing for 90s — no `agent_start`, session idle.
  - **This branch (`bun src/cli.ts`):** `response compact ok=true` → `agent_start` → developer message "Resume the user's latest intent…" → the model re-runs the bash tool → `DONE` → `agent_end`, with no further client input.
- New tests in `test/agent-session-auto-compaction-queue.test.ts` (26 pass): resumes when a turn was interrupted (exactly one `agent.prompt`, synthetic developer message), no turn when idle, no turn with `suppressContinuation`, no resume when compaction lands during prompt setup, a prompt parked during compaction supersedes the resume (`prompt()` and `promptCustomMessage()`), a parked local command hands it back, a setup-only busy refusal keeps it, a second manual compaction inherits a withheld resume, a later prompt or an extension `triggerTurn` from a parked command drops it, a no-op rejection ("Nothing to compact") resumes, a `session_before_compact` cancel does not. The positive cases each fail on the commit preceding their fix.
- `agent-session-compaction`, `compaction-cancellation`, `compaction-speculation`, `compaction-hooks`, `plan-reference-compaction`, `issue-986-compaction-auth-fallback`, `plan-mode*`, `skill-command*`, `collab*`, `rpc*` suites: all pass.
- `bun run check` (oxlint, oxfmt, tsgo) clean in `packages/coding-agent`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)

