### PR TITLE
fix(advisor): preserve queued advice and explain rejected notes

### DIFF
--- a/docs/advisor-watchdog.md
+++ b/docs/advisor-watchdog.md
@@ -52,7 +52,7 @@ persisting `advisor.enabled`:
 omp -p --advisor "Review this task."
 ```
 
-While a primary prompt is running, advisor concerns and blockers continue to steer that live turn. After the final prompt settles, print mode preserves late advisor notes without starting hidden primary turns, then waits up to ten minutes for final reviews before disposing the session. Error exits use a 30-second drain budget so failed automation can terminate. If either deadline expires, OMP logs the reviews that disposal will abandon; completed reviews retain their transcript and token/cost usage.
+While a primary prompt is running, eligible advisor notes can steer that run. After the final prompt settles, print mode preserves late advisor notes without starting hidden primary turns, then waits up to ten minutes for final reviews before disposing the session. Error exits use a 30-second drain budget so failed automation can terminate. If either deadline expires, OMP logs the reviews that disposal will abandon; completed reviews retain their transcript and token/cost usage.
 
 Slash commands:
 
@@ -121,7 +121,7 @@ When you deliberately interrupt the agent (Esc, or a cancel from collab, ACP, RP
 
 A normal yield the agent drove itself is treated differently from a deliberate interrupt, but it is not a blanket "always steers and resumes". The loop state and completed turn first determine the normal delivery path:
 
-- **While the loop is still streaming** (the raise arrived before the yield, or during a resume you already drove), the note normally steers into the live turn.
+- **While the loop is still streaming**, blockers can steer into the live turn. Nits and concerns from an in-progress review remain deferred until a final boundary.
 - **Once the loop has yielded and gone idle**, delivery keys on how the turn ended:
   - If the primary's tail is a **terminal text answer with no queued work**, a late `concern` is preserved as a visible card rather than waking the agent to restate a completed turn (#4840) — it re-enters context on the next resume (a new message, `.`/`c`, or a steer/follow-up), exactly like the interrupt case. A `blocker` is the exception: it normally steers a triggered turn, because it means the agent handed off broken or unexercised work that must be acknowledged before the turn is considered done (#5628).
   - Otherwise (the agent yielded mid-work, no terminal answer), an idle `concern`/`blocker` normally triggers a fresh turn so the advice is acted on immediately.
@@ -135,18 +135,18 @@ So the advisor can steer and resume a run the agent ended on its own **while it 
 
 `advisor.immuneTurns` limits interruption frequency. After the advisor successfully delivers a `concern` or `blocker` through the steering channel, later concerns/blockers are routed as non-interrupting asides until the configured number of primary turns has completed. The default is `3`. `nit` notes are unchanged, and advice raised while user-interrupt auto-resume suppression is active is still preserved instead of restarting a stopped run.
 
-While an advisor update is reviewing work still in progress, `AdviseTool` withholds `nit` and `concern` calls; only a `blocker` may interrupt partial work. The tool also suppresses the same whitespace-normalized note at an equal or lower severity while allowing a real escalation (`nit` → `concern` → `blocker`).
+While an advisor update reviews work still in progress, `AdviseTool` defers `nit` and `concern` calls until a final boundary; only a `blocker` may interrupt partial work. Deferred notes pass the emission guard before reservation. A higher-severity note may displace a pending lower-severity note from the same review, but cannot displace notes from earlier reviews or retract routed advice. A final boundary flushes pending notes without resetting the current review's budget.
 
 ### Emission guard
 
-Each advisor has its own `AdvisorEmissionGuard` (`src/advisor/emission-guard.ts`) on the route from `AdviseTool` to the YieldQueue/steer channel. It enforces the system prompt's "at most one accepted note per update" and no-repeat rules:
+Each advisor has its own `AdvisorEmissionGuard` (`src/advisor/emission-guard.ts`) on the route from `AdviseTool` to the YieldQueue/steer channel. It enforces the system prompt's per-update non-blocker advice budget and no-repeat rules:
 
 1. **Normalization.** Lowercase, NFKC, collapse every run of non-alphanumeric characters to one space, then trim. `"Stop."`, `"*Stop*"`, and `"  stop  "` all key to `stop`.
 2. **Content-free phrase filter.** Short phrases with no concrete reason — `stop`, `done`, `complete`, `no issue continue`, `lgtm`, `nothing to add`, and similar — are suppressed.
-3. **Exact-text dedupe.** Any normalized note already accepted by this advisor in this session is dropped. The FIFO history holds at most 4096 entries.
-4. **Per-update rate limit.** At most one note per advisor model `prompt()` cycle is accepted. Suppressed noise never consumes the budget.
+3. **Severity-aware dedupe.** A repeated normalized note is dropped at equal or lower severity. A real escalation (`nit` → `concern` → `blocker`) remains eligible even after the earlier note was delivered. The FIFO history holds at most 4096 entries.
+4. **Per-update rank budget.** Up to N non-blocker notes per advisor model `prompt()` cycle (default 4, configurable from 1–32). At capacity, a higher-severity note may replace the lowest-rank still-pending note from the same update. Routed notes retain their slots; earlier updates' pending notes remain reserved. Blockers are exempt, and suppressed noise consumes no budget. Precedence: per-advisor config > shared `WATCHDOG.yml` top-level > `advisor.maxNotesPerUpdate` setting > default 4. There is no additional aggregate backlog budget.
 
-Guard-level suppression is invisible to the model because `AdviseTool` has already returned `Recorded.`. The tool's earlier equal-or-lower-severity duplicate check is intentionally visible as `Duplicate advice ignored.`; in-progress non-blockers return `Recorded.` without routing.
+Acknowledgments distinguish acceptance, conditional deferral, duplicates, noise, and budget suppression. Acceptance means the host accepted the note for primary delivery, not that the primary model consumed it. Deferred acceptance warns that a higher-severity finding from the same review may displace the note. A rejected note receives no delivery promise; the advisor should not rephrase rejected findings to evade the guard.
 
 The guard's full state — dedupe history and per-update gate — clears on every advisor reset (compaction, session switch, `/new`), so a re-primed reviewer can re-raise issues it already raised against the rewritten transcript.
 
@@ -286,6 +286,7 @@ Fields:
 - `advisors[].enabled`: optional per-advisor switch, default `true`. `false` leaves the advisor visible as paused in status/configuration.
 - `advisors[].model`: optional model selector with optional `:level` thinking suffix (e.g. `x-ai/grok-code-fast:high`). Omitted → the advisor uses `modelRoles.advisor`.
 - `advisors[].tools`: optional list of built-in tool names to grant. Omitted → the default `read`/`grep`/`glob` subset; explicit `[]` → no investigative tools. Any name in [`BUILTIN_TOOL_NAMES`](../packages/coding-agent/src/tools/builtin-names.ts) is accepted, including mutating tools. Legacy aliases (`search`→`grep`, `find`→`glob`) are normalized. Unknown names are dropped with a warning; if that leaves a nonempty input with no valid names, the implementation currently treats the result as omitted and uses the default subset.
+- `maxNotesPerUpdate` (top level or per advisor): accepted non-blocker notes per prompt update, default `4`. A per-advisor value overrides the top-level value, which overrides the `advisor.maxNotesPerUpdate` setting.
 - `advisors[].instructions`: this advisor's specialization, appended after the shared baseline. Both instruction fields expand `@path` imports like `WATCHDOG.md`.
 
 ### Discovery locations

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -389,6 +389,7 @@ See [Advisor and WATCHDOG.md](./advisor-watchdog.md) for runtime behavior, `WATC
 | `task.agentAdvisor`   | record  | `{}`    | Per-agent subagent advisor: agent name → `"on"` / `"off"` / advisor model pattern. Overrides agent frontmatter `advisor`; configured from the `/agents` hub. |
 | `advisor.syncBacklog` | enum    | `off`   | Bounded advisor catch-up delay: `off`, `1`, `3`, or `5`. The primary waits up to 30 seconds only while advisor backlog is at or above the threshold. |
 | `advisor.immuneTurns` | number  | `3`     | After a `concern`/`blocker` interrupts, route further concerns/blockers as non-interrupting asides for this many completed primary turns.            |
+| `advisor.maxNotesPerUpdate` | number | `4` | Non-blocker notes accepted per advisor review, from 1–32. Higher-severity notes can replace only pending notes from the same review. `WATCHDOG.yml` top-level or per-advisor values override this default. |
 
 ### Thinking
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Advisor acknowledgments distinguish acceptance, deferral, and suppression; higher-priority findings replace only pending notes from the same review ([#11881](https://github.com/can1357/oh-my-pi/pull/11881) by [@olegpulatov](https://github.com/olegpulatov)).
 - Claude Code session imports now preserve typed user text stored alongside tool results ([#11854](https://github.com/can1357/oh-my-pi/issues/11854)).
 - Extension commands now settle BTW writes before creating, switching, or branching sessions, preventing side requests from outliving their source session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).
 - Session selection and active-session deletion now settle BTW writes before switching or removing history, preventing stale saves from blocking the next session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).

--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -7,9 +7,9 @@ import type {
 	AgentToolResult,
 	AgentToolUpdateCallback,
 } from "@oh-my-pi/pi-agent-core";
-import { escapeXmlAttribute, escapeXmlText } from "@oh-my-pi/pi-utils";
+import { escapeXmlAttribute, escapeXmlText, logger } from "@oh-my-pi/pi-utils";
 import adviseDescription from "../prompts/advisor/advise-tool.md" with { type: "text" };
-import { type AdvisorEmissionDecision, normalizeAdvisorNote } from "./emission-guard";
+import { AdvisorEmissionGuard, type AdvisorSuppressionReason, normalizeAdvisorNote } from "./emission-guard";
 
 const adviseSchema = type({
 	note: type("string").describe(
@@ -174,11 +174,37 @@ function advisorSeverityRank(severity: AdvisorSeverity | undefined): number {
 	return ADVISOR_SEVERITY_RANK[severity ?? "nit"];
 }
 
-const ADVISOR_RESULT_TEXT: Record<AdvisorEmissionDecision, string> = {
-	accepted: "Recorded.",
-	duplicate: "Duplicate advice ignored.",
-	rate_limited: "Rate limited — update advice budget reached. Re-raise this note on the next update.",
-	suppressed_noise: "Ignored — advice is empty or non-actionable.",
+/**
+ * Live admission: the guard accepted the note and handed it to the session's
+ * delivery routing. That is the whole truthful claim — `onAdvice` is
+ * synchronous void and MAY only buffer the note for a terminal-boundary flush
+ * or preserve it as a card; no actual send or consumption acknowledgment
+ * exists at this layer.
+ */
+const ADVISOR_ACK_SENT = "Accepted for primary delivery.";
+
+/**
+ * Deferred admission: the note holds a reservation behind an in-progress
+ * primary turn and flushes automatically when the turn completes. The promise
+ * is conditional on priority: a strictly-higher-severity note from the SAME
+ * review may still displace it at a full budget. Truthful for both a fresh
+ * reservation and a re-raise of an already-queued note.
+ */
+const ADVISOR_ACK_DEFERRED =
+	"Deferred — primary is mid-turn; this note is queued for automatic delivery when the turn completes, " +
+	"unless a higher-severity note from the same review displaces it. Do not re-raise the same point.";
+
+/**
+ * Rejections, keyed by the guard's suppression reason. A suppressed note is
+ * never described as recorded, queued, or scheduled for delivery — the
+ * advisor learns the note was dropped and why, so a rate-limited note is not
+ * mislabeled a duplicate and a dropped deferred note is never promised.
+ */
+const ADVISOR_ACK_SUPPRESSED: Record<AdvisorSuppressionReason, string> = {
+	empty: "Not recorded — empty note.",
+	noise: "Not recorded — the note carries no concrete, actionable content.",
+	duplicate: "Duplicate advice ignored — this point was already raised.",
+	"rate-limit": "Not recorded — this update's non-blocker advice budget is spent; the note was dropped.",
 };
 
 export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails> {
@@ -187,55 +213,75 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 	readonly description = adviseDescription;
 	readonly parameters = adviseSchema;
 	readonly intent = "omit" as const;
-	/** Highest delivered severity rank per normalized note. A new call passes
-	 *  through only when its rank strictly exceeds the recorded one (a real
-	 *  escalation: nit → concern → blocker), so an advisor cannot bypass dedupe
-	 *  by retagging the same text at a lower or equal severity. */
-	#deliveredNoteSeverities = new Map<string, number>();
+	/**
+	 * Single admission authority for every emission. The tool owns no parallel
+	 * dedupe/budget state: the guard's {@link AdvisorAdmission} decides whether
+	 * a note routes, holds pending, or is suppressed — and names any displaced
+	 * pending note.
+	 */
+	readonly #guard: AdvisorEmissionGuard;
 	#inProgressUpdate = false;
-	/** Notes withheld while the primary was mid-turn, in arrival order. Flushed
-	 *  deterministically on the first `beginUpdate(false)` so delivery does not
-	 *  depend on the advisor model choosing to re-raise (it may not, since the
-	 *  tool previously returned "Recorded." for a note that was never routed).
-	 *  Cleared on `resetDeliveredNotes` alongside the delivered-rank map. */
-	#deferredNotes: { key: string; note: string; severity?: AdviseDetails["severity"] }[] = [];
+	/** Notes admitted but withheld while the primary was mid-turn, in arrival
+	 *  order. Flushed deterministically at the completed-update transition or an
+	 *  explicit {@link flushDeferredNotes}, so delivery does not depend on the
+	 *  advisor model choosing to re-raise (it may not — the deferred
+	 *  acknowledgment tells it the note is queued). Only these still-pending
+	 *  notes can be displaced by the guard; routed notes are never retracted. */
+	#deferredNotes: {
+		key: string;
+		note: string;
+		severity?: AdviseDetails["severity"];
+	}[] = [];
 
 	/**
-	 * @param onAdvice Route an accepted note to the primary (channel selection +
-	 *   delivery). Never re-filters — the note already cleared `accept`.
-	 * @param accept The emission guard's noise/empty/dedupe classification plus
-	 *   the per-update advice budget, consumed the moment a note is emitted
-	 *   (live or deferred). A rejected note reports the specific reason without
-	 *   spending the budget. Defaults to accepted for standalone use/tests.
+	 * @param onAdvice Route an admitted note to the primary (channel selection +
+	 *   delivery). Never re-filters — the note already cleared the guard.
+	 * @param guard The admission authority: noise/empty/dedupe filter, rank-aware
+	 *   escalation, and the per-update non-blocker budget, decided the moment a
+	 *   note is emitted (live or deferred). Defaults to a stock
+	 *   {@link AdvisorEmissionGuard} (default budget
+	 *   {@link ADVISOR_DEFAULT_BUDGET_PER_UPDATE}).
 	 */
 	constructor(
 		private readonly onAdvice: (note: string, severity?: AdviseDetails["severity"]) => void,
-		private readonly accept: (note: string, severity?: AdviseDetails["severity"]) => AdvisorEmissionDecision = () =>
-			"accepted",
-	) {}
+		guard?: AdvisorEmissionGuard,
+	) {
+		this.#guard = guard ?? new AdvisorEmissionGuard();
+	}
 
 	/**
-	 * Synchronize the primary turn state. Non-blockers are withheld while a turn
-	 * is in progress; the first completed boundary flushes them even when the
-	 * advisor runtime cannot dispatch another prompt.
+	 * Start one advisor update: resets the guard's per-update budget and marks
+	 * whether the update reviews an in-progress primary turn. Non-blockers
+	 * emitted while in progress are withheld so partial work does not interrupt
+	 * the primary before it can finish its planned steps. Transitioning to a
+	 * completed update flushes the withheld backlog, oldest first — each note
+	 * was admitted when emitted, so the flush routes without re-admission and a
+	 * backlog of one note per originating update reaches the primary intact.
 	 */
 	beginUpdate(inProgress: boolean): void {
 		const wasInProgress = this.#inProgressUpdate;
 		this.#inProgressUpdate = inProgress;
-		// Turn just completed: flush everything withheld mid-turn, oldest first.
-		// Each note already cleared the emission guard (filter + per-update budget)
-		// when it was reserved, so the flush routes it without re-accepting — a
-		// backlog of one note per originating update reaches the primary intact.
-		if (wasInProgress && !inProgress && this.#deferredNotes.length > 0) {
-			const pending = this.#deferredNotes;
-			this.#deferredNotes = [];
-			for (const { note, severity } of pending) this.#deliver(note, severity, true);
-		}
+		this.#guard.beginUpdate();
+		if (wasInProgress && !inProgress) this.#flushDeferred();
 	}
 
-	/** Clear delivered-note memory when the advisor starts a fresh conversation. */
+	/**
+	 * Mark the primary no longer mid-turn and flush the withheld backlog
+	 * WITHOUT starting a new advisor update or resetting the guard's budget.
+	 * Called at the primary's terminal boundary (final yield), where no advisor
+	 * review follows but reserved notes must still reach the primary. Flushed
+	 * notes stay charged to their originating update as routed deliveries.
+	 */
+	flushDeferredNotes(): void {
+		this.#inProgressUpdate = false;
+		this.#flushDeferred();
+	}
+
+	/** Clear all note state when the advisor starts a fresh conversation: the
+	 *  guard's dedupe/budget memory and this tool's pending backlog reset
+	 *  together, so a re-primed advisor can re-raise old issues. */
 	resetDeliveredNotes(): void {
-		this.#deliveredNoteSeverities.clear();
+		this.#guard.reset();
 		this.#inProgressUpdate = false;
 		this.#deferredNotes = [];
 	}
@@ -247,69 +293,72 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 		_onUpdate?: AgentToolUpdateCallback<AdviseDetails>,
 		_context?: AgentToolContext,
 	): Promise<AgentToolResult<AdviseDetails>> {
-		if (this.#inProgressUpdate && args.severity !== "blocker") {
-			// Withheld, not delivered: queue for the deterministic flush on the next
-			// completed update. Skip if an identical note is already pending so a
-			// long mid-turn can't pile up 20 copies of the same advice. Tell the
-			// advisor the truth — the previous "Recorded." made it believe the note
-			// reached the primary, so it never re-raised and the advice was lost.
-			const key = advisorNoteDedupeKey(args.note);
-			const pending = this.#deferredNotes.find(item => item.key === key);
-			let decision: AdvisorEmissionDecision = "accepted";
-			if (pending) {
-				// Escalating an already-queued note reuses its slot; never a new one.
-				if (advisorSeverityRank(args.severity) > advisorSeverityRank(pending.severity))
-					pending.severity = args.severity;
-			} else {
-				decision = this.accept(args.note, args.severity);
-				if (decision === "accepted") {
-					// Reserve the update's one slot now; the flush routes it without
-					// consuming a second slot.
-					this.#deferredNotes.push({ key, note: args.note, severity: args.severity });
-				}
-			}
-			return {
-				content: [
-					{
-						type: "text",
-						text:
-							decision === "accepted"
-								? "Deferred — primary is mid-turn; this note will be delivered automatically when the turn completes. Do not re-raise the same point."
-								: ADVISOR_RESULT_TEXT[decision],
-					},
-				],
-				details: { note: args.note, severity: args.severity },
-				useless: true,
-			};
-		}
-		// Live path (completed update, or a blocker that must interrupt now). If the
-		// note already holds a deferred reservation, it cleared the emission guard
-		// when reserved — pull it from the backlog and deliver without re-accepting,
-		// so a blocker escalation of a still-queued nit/concern interrupts at its
-		// blocker severity instead of being rejected as already-seen and arriving
-		// late at the lower deferred severity.
+		const rank = advisorSeverityRank(args.severity);
 		const key = advisorNoteDedupeKey(args.note);
+		if (this.#inProgressUpdate && args.severity !== "blocker") {
+			// Withheld, not delivered: reserve for the deterministic flush at the
+			// completed-update transition / terminal boundary.
+			const pending = this.#deferredNotes.find(item => item.key === key);
+			if (pending) {
+				// Re-raise of a still-queued note is not a new admission: escalate
+				// severity in place (never a second slot) and keep the dedupe rank
+				// coherent so equal/lower repeats of the text stay suppressed.
+				if (rank > advisorSeverityRank(pending.severity)) {
+					pending.severity = args.severity;
+					this.#guard.escalatePending(args.note, rank);
+				}
+				return this.#result(ADVISOR_ACK_DEFERRED, args);
+			}
+			const decision = this.#guard.admit(args.note, { rank, pending: true });
+			if (!decision.accepted) return this.#suppressed(args, decision.reason);
+			// The guard centrally names the still-pending note displaced by this
+			// strictly-higher-severity admission; only same-update pending notes
+			// can be displaced, so the backlog lookup is a drop, not a policy.
+			if (decision.displacedKey !== undefined) {
+				const displacedIndex = this.#deferredNotes.findIndex(item => item.key === decision.displacedKey);
+				if (displacedIndex !== -1) this.#deferredNotes.splice(displacedIndex, 1);
+			}
+			this.#deferredNotes.push({ key, note: args.note, severity: args.severity });
+			return this.#result(ADVISOR_ACK_DEFERRED, args);
+		}
+		// Live path (completed update, or a blocker that must interrupt now). A
+		// blocker re-raise of a still-queued note pulls the reservation first:
+		// the guard admits it as a rank escalation (nit/concern → blocker), so
+		// it interrupts at blocker severity now instead of arriving late at the
+		// lower deferred severity.
 		const reservedIndex = this.#deferredNotes.findIndex(item => item.key === key);
 		if (reservedIndex !== -1) this.#deferredNotes.splice(reservedIndex, 1);
-		const decision = this.#deliver(args.note, args.severity, reservedIndex !== -1);
+		const decision = this.#guard.admit(args.note, { rank, pending: false });
+		if (!decision.accepted) return this.#suppressed(args, decision.reason);
+		this.onAdvice(args.note, args.severity);
+		return this.#result(ADVISOR_ACK_SENT, args);
+	}
+
+	/** Route every withheld note, oldest first, without re-admission — each was
+	 *  admitted when emitted. Routed notes are marked so their originating
+	 *  update's slots stay charged and can no longer be displaced. */
+	#flushDeferred(): void {
+		if (this.#deferredNotes.length === 0) return;
+		const pending = this.#deferredNotes;
+		this.#deferredNotes = [];
+		for (const { note, severity } of pending) {
+			this.#guard.markRouted(note);
+			this.onAdvice(note, severity);
+		}
+	}
+
+	/** Truthful suppression acknowledgment keyed by the guard's reason: a
+	 *  rejected note is never described as recorded, queued, or delivered. */
+	#suppressed(args: AdviseParams, reason: AdvisorSuppressionReason | undefined): AgentToolResult<AdviseDetails> {
+		logger.debug("advisor advice suppressed by emission guard", { reason, severity: args.severity });
+		return this.#result(ADVISOR_ACK_SUPPRESSED[reason ?? "duplicate"], args);
+	}
+
+	#result(text: string, args: AdviseParams): AgentToolResult<AdviseDetails> {
 		return {
-			content: [{ type: "text", text: ADVISOR_RESULT_TEXT[decision] }],
+			content: [{ type: "text", text }],
 			details: { note: args.note, severity: args.severity },
 			useless: true,
 		};
-	}
-
-	/** Run one note through the escalation-rank dedupe and emission policy before
-	 *  routing it. Returns the exact policy outcome for truthful tool feedback. */
-	#deliver(note: string, severity?: AdviseDetails["severity"], alreadyAccepted = false): AdvisorEmissionDecision {
-		const key = advisorNoteDedupeKey(note);
-		const rank = advisorSeverityRank(severity);
-		const previousRank = this.#deliveredNoteSeverities.get(key) ?? 0;
-		if (rank <= previousRank) return "duplicate";
-		const decision = alreadyAccepted ? "accepted" : this.accept(note, severity);
-		if (decision !== "accepted") return decision;
-		this.#deliveredNoteSeverities.set(key, rank);
-		this.onAdvice(note, severity);
-		return "accepted";
 	}
 }

--- a/packages/coding-agent/src/advisor/emission-guard.ts
+++ b/packages/coding-agent/src/advisor/emission-guard.ts
@@ -12,13 +12,15 @@
  * 114× `Stop.`, 52× `No issue; continue.`, 41× `Done.` — flooding the primary
  * transcript with `<advisory severity="blocker">Stop.</advisory>` after the
  * task was already complete. The fix is to make the rules load-bearing in code
- * instead of prose: classify duplicates, content-free self-talk, and over-budget
- * calls at the emission boundary so the primary stays clean even when the advisor
- * misbehaves. `AdviseTool` reports the resulting decision; in particular, an
- * actionable over-budget note is told to retry instead of being falsely recorded.
+ * instead of prose: drop duplicates, content-free self-talk, and over-budget
+ * calls at the `AdviseTool` admission boundary so the primary stays clean even when
+ * the advisor misbehaves.
+ *
+ * The guard is the single admission authority: every decision carries a
+ * truthful {@link AdvisorSuppressionReason} that `AdviseTool` surfaces
+ * verbatim in its acknowledgment — a rejected note is never described as
+ * recorded, and a rate-limited note is never mislabeled a duplicate.
  */
-
-import type { AdvisorSeverity } from "./advise-tool";
 
 /**
  * Case-insensitive, punctuation-folded normalization. Collapses every run of
@@ -104,30 +106,76 @@ export const ADVISOR_MAX_BUDGET_PER_UPDATE = 32;
 
 /** Default non-blocker advise notes allowed per update cycle when unspecified. */
 export const ADVISOR_DEFAULT_BUDGET_PER_UPDATE = 4;
-/** Why an advisor note was accepted or rejected by the emission policy. */
-export type AdvisorEmissionDecision = "accepted" | "duplicate" | "rate_limited" | "suppressed_noise";
+
+/** Why the guard suppressed a note. Surfaced verbatim in the tool acknowledgment. */
+export type AdvisorSuppressionReason = "empty" | "noise" | "duplicate" | "rate-limit";
+
+/**
+ * The guard's admission decision for one `advise()` call — the single source
+ * of truth `AdviseTool` acts on; the tool never re-infers eviction or
+ * suppression policy from its own state.
+ */
+export interface AdvisorAdmission {
+	/** Whether the note may reach the primary (routed now or held for a deferred flush). */
+	accepted: boolean;
+	/** Why a suppressed note was rejected. Set only when `accepted` is false. */
+	reason?: AdvisorSuppressionReason;
+	/**
+	 * Normalized key of a still-pending note from the SAME update that this
+	 * admission displaced (budget full, strictly higher severity). The caller
+	 * MUST drop it from its pending backlog. Only pending notes are ever
+	 * displaced — a note already routed to the primary keeps its budget slot,
+	 * because a delivery cannot be retracted.
+	 */
+	displacedKey?: string;
+}
+
 /**
  * Decides whether an advisor `advise()` call should reach the primary agent.
  *
- * Enforces — in this order — the noise filter, session-scoped exact-text
+ * Enforces — in this order — the noise filter, session-scoped rank-aware
  * dedupe (FIFO-evicted at {@link DEFAULT_HISTORY_CAPACITY}), and a per-update
- * budget of accepted notes per advisor model prompt. Suppressed calls
- * never consume the per-update budget — a noise call doesn't burn the slot
- * for a real concern that follows in the same update. A `blocker` is exempt
- * from the budget: it must always interrupt, so a lower-severity note emitted
- * earlier in the same update can never rate-limit it out.
+ * budget of admitted non-blocker notes. Suppressed calls never consume the
+ * budget — a noise call doesn't burn the slot for a real concern that follows
+ * in the same update. A `blocker` is exempt from the budget: it must always
+ * interrupt, so a lower-severity note emitted earlier in the same update can
+ * never rate-limit it out.
+ *
+ * Dedupe is rank-aware: re-raising the same text at a strictly higher
+ * severity is a real escalation (nit → concern → blocker), not a repeat, and
+ * is admitted — an already-delivered nit re-raised as a blocker still
+ * interrupts. Equal or lower severity re-raises stay suppressed, so an
+ * advisor cannot bypass dedupe by retagging the same text sideways.
+ *
+ * The budget is rank-aware within a single update: when it is full, a
+ * strictly-higher-severity note displaces the lowest-rank STILL-PENDING slot
+ * (a queued concern kicks out a queued nit) and the decision names the
+ * displaced note via {@link AdvisorAdmission.displacedKey}. Routed notes
+ * remain charged and cannot be displaced — delivery cannot be retracted to
+ * free a slot. With a budget of 1 this collapses to one non-blocker per
+ * update with concern-evicts-pending-nit; with the default budget 4, up to 4
+ * non-blockers are admitted before displacement applies.
  *
  * Reset on advisor reset (compaction, session switch, `/new`) via
- * {@link reset}. Per-update gate is cleared at the start of every advisor
- * `agent.prompt()` cycle via {@link beginUpdate}.
+ * {@link reset}. Per-update budget is cleared at the start of every advisor
+ * `agent.prompt()` cycle via {@link beginUpdate} (driven by
+ * `AdviseTool.beginUpdate`).
  */
 export class AdvisorEmissionGuard {
-	#seen = new Set<string>();
-	/** Insertion-order log to drive FIFO eviction without an extra Map. */
+	/** Normalized key → highest admitted severity rank this session. A new call
+	 *  passes only when its rank strictly exceeds the recorded one (a real
+	 *  escalation), so equal/lower retags of the same text stay suppressed. */
+	#seen = new Map<string, number>();
+	/** Insertion-order log to drive FIFO eviction without a second Map. Keys are
+	 *  pushed on first admission only; escalations update the rank in place. */
 	#seenOrder: string[] = [];
-	#acceptedThisUpdate = 0;
-	readonly #budgetPerUpdate: number;
+	/** Budget slots charged this update, in admission order. Length ≤
+	 *  #budgetPerUpdate. `pending` marks notes withheld behind an in-progress
+	 *  primary turn: only those may be displaced by a strictly-higher-rank
+	 *  admission; routed notes stay charged. */
+	#slots: { key: string; rank: number; pending: boolean }[] = [];
 	readonly #capacity: number;
+	readonly #budgetPerUpdate: number;
 
 	constructor(opts: { capacity?: number; budgetPerUpdate?: number } = {}) {
 		this.#capacity = opts.capacity ?? DEFAULT_HISTORY_CAPACITY;
@@ -139,44 +187,137 @@ export class AdvisorEmissionGuard {
 	}
 
 	/**
-	 * Drop all dedupe and per-update state. Called from
-	 * `AgentSession#resetAdvisorSessionState()` whenever the advisor runtime is
+	 * Drop all dedupe and per-update state. Called when the advisor runtime is
 	 * reset — same boundary as `yieldQueue.clear("advisor")`, so a re-primed
 	 * advisor can re-raise old issues (the primary transcript was rewritten).
+	 * Driven by `AdviseTool.resetDeliveredNotes()`.
 	 */
 	reset(): void {
 		this.#seen.clear();
 		this.#seenOrder.length = 0;
-		this.#acceptedThisUpdate = 0;
+		this.#slots = [];
 	}
 
 	/**
-	 * Clear the per-update rate-limit gate. Called by `AdvisorRuntime` right
-	 * before each `agent.prompt(batch)` invocation so the next advisor model
-	 * cycle starts with a fresh budget.
+	 * Clear the per-update budget. Called at the start of every advisor
+	 * `agent.prompt()` cycle (via `AdviseTool.beginUpdate`) so the next advisor
+	 * model cycle starts with a fresh budget. Notes still pending from earlier
+	 * updates keep their reservations — they hold no slot here and cannot be
+	 * displaced by the new update's admissions.
 	 */
 	beginUpdate(): void {
-		this.#acceptedThisUpdate = 0;
+		this.#slots = [];
 	}
 
 	/**
-	 * Classify and reserve a proposed note. Accepted notes consume the update
-	 * budget and enter the dedupe history; rejected notes leave both unchanged.
-	 * A `blocker` still runs the noise and dedupe filters but bypasses the
-	 * per-update budget so it always reaches the primary.
+	 * Record that a still-pending note was re-raised at a strictly higher
+	 * severity and is being escalated in place — no new admission, no extra
+	 * budget. Keeps the dedupe rank and any current-update slot coherent, so a
+	 * later equal/lower repeat of the text stays suppressed and displacement
+	 * compares the note's real rank. No-op when `rank` does not exceed the
+	 * recorded rank.
 	 */
-	accept(note: string, severity?: AdvisorSeverity): AdvisorEmissionDecision {
+	escalatePending(note: string, rank: number): void {
 		const key = normalizeAdvisorNote(note);
-		if (!key || SUPPRESSED_NORMALIZED_PHRASES[key]) return "suppressed_noise";
-		if (this.#seen.has(key)) return "duplicate";
-		if (severity !== "blocker" && this.#acceptedThisUpdate >= this.#budgetPerUpdate) return "rate_limited";
-		if (severity !== "blocker") this.#acceptedThisUpdate++;
-		this.#seen.add(key);
+		if (!key) return;
+		const seenRank = this.#seen.get(key) ?? 0;
+		if (rank <= seenRank) return;
+		// Shares admit's bounded recording: a key that aged out of the FIFO
+		// history and is re-tracked here MUST re-enter the eviction queue,
+		// otherwise it becomes a permanent, unevictable entry.
+		this.#recordRank(key, rank);
+		const slot = this.#slots.find(s => s.key === key);
+		if (slot && slot.rank < rank) slot.rank = rank;
+	}
+
+	/**
+	 * Record the highest admitted rank for a key, FIFO-bounding the history:
+	 * first-seen keys enter the eviction queue and the oldest entry is dropped
+	 * beyond {@link #capacity}. The single recording path shared by {@link
+	 * admit} and {@link escalatePending}.
+	 */
+	#recordRank(key: string, rank: number): void {
+		const isNew = !this.#seen.has(key);
+		this.#seen.set(key, rank);
+		if (!isNew) return;
 		this.#seenOrder.push(key);
 		if (this.#seenOrder.length > this.#capacity) {
 			const stale = this.#seenOrder.shift();
 			if (stale !== undefined) this.#seen.delete(stale);
 		}
-		return "accepted";
+	}
+
+	/**
+	 * Mark a previously admitted pending note as routed to the primary (a
+	 * deferred flush delivered it). Its budget slot — when still within the
+	 * originating update — becomes non-displaceable: a routed note cannot be
+	 * retracted to free budget. No-op once the update boundary has cleared the
+	 * slot.
+	 */
+	markRouted(note: string): void {
+		const key = normalizeAdvisorNote(note);
+		const slot = this.#slots.find(s => s.key === key);
+		if (slot) slot.pending = false;
+	}
+
+	/**
+	 * Decide whether the proposed note may reach the primary. The decision is
+	 * the single admission authority: on `accepted` the guard has recorded the
+	 * note (consumed budget where due, updated the dedupe rank) and names any
+	 * displaced pending note; on rejection the `reason` is the truthful
+	 * classification for the advisor-facing acknowledgment.
+	 *
+	 * `pending` declares the caller's routing intent: withheld behind an
+	 * in-progress primary turn (displaceable by a later strictly-higher-rank
+	 * admission this update) versus routed immediately (charged, never
+	 * displaceable). A note that fails the noise/empty/dedupe filter never
+	 * consumes the budget, so a suppressed phrase cannot burn the update's
+	 * slot ahead of a substantive concern. Empty / whitespace-only notes are
+	 * suppressed defensively even though the tool-args contract requires a
+	 * non-empty string.
+	 */
+	admit(note: string, opts: { rank: number; pending: boolean }): AdvisorAdmission {
+		const key = normalizeAdvisorNote(note);
+		if (!key) return { accepted: false, reason: "empty" };
+		if (SUPPRESSED_NORMALIZED_PHRASES[key]) return { accepted: false, reason: "noise" };
+		const rank = opts.rank;
+		const seenRank = this.#seen.get(key) ?? 0;
+		if (rank <= seenRank) return { accepted: false, reason: "duplicate" };
+		// Admitted: a fresh note, or a strictly-higher-rank re-raise of an
+		// already-admitted note (a real escalation).
+		let displacedKey: string | undefined;
+		const ownSlot = this.#slots.find(s => s.key === key);
+		if (rank >= 3) {
+			// Blockers: unlimited per update — never dropped to the budget. A
+			// blocker escalation of a still-pending note releases its slot: the
+			// note now routes live, so the reservation will never flush. A
+			// routed slot stays charged — delivery cannot be retracted.
+			if (ownSlot?.pending) this.#slots.splice(this.#slots.indexOf(ownSlot), 1);
+		} else if (ownSlot) {
+			// Same-update severity escalation of an already-admitted note (e.g. a
+			// routed nit re-raised as a concern): upgrade the slot's rank instead
+			// of charging a second slot for the same text.
+			ownSlot.rank = rank;
+		} else if (this.#slots.length < this.#budgetPerUpdate) {
+			this.#slots.push({ key, rank, pending: opts.pending });
+		} else {
+			// Budget full: a strictly-higher-rank note displaces the lowest-rank
+			// still-pending slot (concern kicks out a queued nit). Same or lower
+			// rank — or a budget spent entirely on routed notes — is rate-limited.
+			let minIndex = -1;
+			for (let i = 0; i < this.#slots.length; i++) {
+				const slot = this.#slots[i]!;
+				if (!slot.pending) continue;
+				if (minIndex === -1 || slot.rank < this.#slots[minIndex]!.rank) minIndex = i;
+			}
+			if (minIndex !== -1 && rank > this.#slots[minIndex]!.rank) {
+				displacedKey = this.#slots[minIndex]!.key;
+				this.#slots[minIndex] = { key, rank, pending: opts.pending };
+			} else {
+				return { accepted: false, reason: "rate-limit" };
+			}
+		}
+		this.#recordRank(key, rank);
+		return displacedKey === undefined ? { accepted: true } : { accepted: true, displacedKey };
 	}
 }

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -36,8 +36,6 @@ export interface AdvisorAgent {
 export interface AdvisorRuntimeHost {
 	/** Live primary transcript (use `agent.state.messages`). */
 	snapshotMessages(): AgentMessage[];
-	/** Surface one advice note to the primary (enqueues into the session YieldQueue). */
-	enqueueAdvice(note: string, severity?: "nit" | "concern" | "blocker"): void;
 	/** Redact primary transcript bytes before they reach the advisor model. */
 	obfuscator?: SecretObfuscator;
 	/**

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -311,7 +311,7 @@ export interface AgentSessionConfig {
 	advisorWatchdogPrompt?: string;
 	/** Shared advisor instructions loaded from WATCHDOG.yml. */
 	advisorSharedInstructions?: string;
-	/** Shared advisor max notes per update loaded from WATCHDOG.yml. */
+	/** Shared non-blocker budget from top-level WATCHDOG.yml maxNotesPerUpdate. */
 	advisorSharedMaxNotesPerUpdate?: number;
 	/** Project context rendered for advisor sessions. */
 	advisorContextPrompt?: string;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7830,7 +7830,7 @@ export class AgentSession {
 			// Re-record advisor concerns the interrupt would otherwise strand, as
 			// visible/persisted advice without triggering a turn (the agent is idle
 			// now): cards steered into the queue before the user stopped, plus any
-			// that arrived via enqueueAdvice mid-abort and were parked hidden in
+			// that arrived via AdviseTool routing mid-abort and were parked hidden in
 			// #pendingNextTurnMessages while the turn was still tearing down. Other
 			// deferred next-turn context (non-advisor) stays queued, in order.
 			const parkedAdvisorCards = this.#pendingNextTurnMessages.filter(isAdvisorCard);

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -44,7 +44,6 @@ import {
 	AdviseTool,
 	type AdvisorAgent,
 	type AdvisorConfig,
-	type AdvisorEmissionDecision,
 	AdvisorEmissionGuard,
 	AdvisorLoopGuard,
 	type AdvisorMessageDetails,
@@ -156,7 +155,6 @@ interface ActiveAdvisor {
 	agent: Agent;
 	runtime: AdvisorRuntime;
 	adviseTool: AdviseTool;
-	emissionGuard: AdvisorEmissionGuard;
 	recorder: AdvisorTranscriptRecorder;
 	recorderClosed: Promise<void>;
 	agentUnsubscribe?: () => void;
@@ -379,8 +377,9 @@ export class SessionAdvisors {
 		for (const advisor of this.#advisors) {
 			if (advisor.runtime.disposed) continue;
 			// Only the terminal primary boundary owns the deferred flush. Continuing
-			// tool turns must keep partial-work critiques withheld.
-			if (willContinue !== true) advisor.adviseTool.beginUpdate(false);
+			// tool turns must keep partial-work critiques withheld. The flush never
+			// resets the per-update budget — no new advisor update starts here.
+			if (willContinue !== true) advisor.adviseTool.flushDeferredNotes();
 			try {
 				advisor.runtime.onTurnEnd(messages, { willContinue });
 			} catch (error) {
@@ -716,8 +715,8 @@ export class SessionAdvisors {
 			a.agentUnsubscribe?.();
 			a.agentUnsubscribe = undefined;
 			a.runtime.reset("conversation-boundary");
+			// Resets the emission guard and every tool-side note state together.
 			a.adviseTool.resetDeliveredNotes();
-			a.emissionGuard.reset();
 			this.#attachAdvisorRecorderFeed(a);
 		}
 		this.#advisorPrimaryTurnsCompleted = 0;
@@ -868,10 +867,13 @@ export class SessionAdvisors {
 			} = descriptor;
 
 			const budgetPerUpdate = this.#advisorMaxNotesPerUpdate(config);
+			// The tool owns admission end-to-end: the guard decides acceptance,
+			// suppression reason, and pending-note displacement; the tool routes
+			// accepted notes and acknowledges truthfully. No separate accept wrapper.
 			const emissionGuard = new AdvisorEmissionGuard({ budgetPerUpdate });
 			const adviseTool = new AdviseTool(
 				(note, severity) => this.#routeAdvice(advisorRef, note, severity),
-				(note, severity) => this.#acceptAdvice(advisorRef, note, severity),
+				emissionGuard,
 			);
 
 			// `#advisorWatchdogPrompt` already carries WATCHDOG.md + YAML shared
@@ -1110,17 +1112,16 @@ export class SessionAdvisors {
 			);
 			const runtime = new AdvisorRuntime(advisorAgentFacade, {
 				snapshotMessages: () => this.#host.agent.state.messages,
-				enqueueAdvice: (note, severity) => this.#routeAdvice(advisorRef, note, severity),
 				maintainContext: (incoming, signal) => this.#maintainAdvisorContext(advisorRef, incoming, signal),
 				obfuscator: this.#host.obfuscator,
 				getModelIdentity: () => formatModelString(advisorRef.agent.state.model),
 				beginAdvisorUpdate: inProgress => {
 					advisorRef.recorder.beginTurn();
-					// Flush the deferred backlog (notes already cleared the emission guard
-					// when reserved), then reset the guard's per-update budget for this
-					// prompt's live notes.
+					// Flushes the deferred backlog on the in-progress→completed
+					// transition (notes already cleared admission when reserved) and
+					// resets the guard's per-update budget for this prompt's live
+					// notes — both owned by the tool now.
 					advisorRef.adviseTool.beginUpdate(inProgress);
-					advisorRef.emissionGuard.beginUpdate();
 				},
 				onTurnError: (error, failedMessages, signal) =>
 					this.#recoverAdvisorTurn(advisorRef, error, failedMessages, signal),
@@ -1174,7 +1175,6 @@ export class SessionAdvisors {
 				agent: advisorAgent,
 				runtime,
 				adviseTool,
-				emissionGuard,
 				recorder,
 				recorderClosed: Promise.resolve(),
 				model: advisorModel,
@@ -1234,19 +1234,10 @@ export class SessionAdvisors {
 		return isTerminalTextAssistantAnswer(messages[tail]);
 	}
 
-	/** Emission-guard gate: classify noise, duplicates, and over-budget notes so
-	 *  AdviseTool can report the exact outcome instead of claiming every rejection
-	 *  is a duplicate. Accepted notes consume the current update's budget. */
-	#acceptAdvice(advisor: ActiveAdvisor, note: string, severity?: AdvisorSeverity): AdvisorEmissionDecision {
-		const decision = advisor.emissionGuard.accept(note, severity);
-		if (decision !== "accepted")
-			logger.debug("advisor advice suppressed by emission guard", { decision, severity, advisor: advisor.name });
-		return decision;
-	}
-
-	/** Route an already-accepted advice note to the primary. Never re-runs the
-	 *  emission guard — the note passed {@link #acceptAdvice} when it was emitted,
-	 *  so a deferred flush replays the backlog without re-filtering. */
+	/** Route an already-accepted advice note to the primary. Never re-runs
+	 *  admission — the note cleared the emission guard inside AdviseTool when it
+	 *  was emitted, so a deferred flush replays the backlog without
+	 *  re-filtering. */
 	#routeAdvice(advisor: ActiveAdvisor, note: string, severity?: AdvisorSeverity): void {
 		// The implicit single ("default") advisor stamps no source name, so its
 		// agent-facing `<advisory>` bytes stay identical to the pre-multi-advisor path.

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -540,22 +540,29 @@ describe("AgentSession advisor toggle", () => {
 		expect(session.getAdvisorCost()).toBeCloseTo(0.5, 8);
 		expect(session.formatAdvisorStatus()).toContain("$0.5000");
 	});
-	it("rebuilds the live advisor when a second config is applied over an existing roster", () => {
+	it("applies a replacement advisor roster to the live status", () => {
 		enableAdvisor();
-		const originalAgent = session.getAdvisorAgent();
-		expect(originalAgent).toBeDefined();
 
 		// Apply first roster.
 		expect(session.applyAdvisorConfigs([{ name: "Security" }], undefined)).toBe(1);
-		const firstRosterAgent = session.getAdvisorAgent();
-		expect(firstRosterAgent).toBeDefined();
+		expect(session.getAdvisorStats().advisors.map(advisor => advisor.name)).toEqual(["Security"]);
 
 		// Apply a second, different roster over the live one.
-		expect(session.applyAdvisorConfigs([{ name: "Architecture" }, { name: "Testing" }], undefined)).toBe(2);
-		const secondRosterAgent = session.getAdvisorAgent();
-		// The advisor agent must be rebuilt — not the same instance as the first roster.
-		expect(secondRosterAgent).toBeDefined();
-		expect(secondRosterAgent).not.toBe(firstRosterAgent);
+		expect(
+			session.applyAdvisorConfigs(
+				[
+					{ name: "Architecture", instructions: "Review module boundaries." },
+					{ name: "Testing", instructions: "Require regression coverage." },
+				],
+				"Keep advice concrete.",
+			),
+		).toBe(2);
+		expect(session.getAdvisorStats().advisors.map(advisor => advisor.name)).toEqual(["Architecture", "Testing"]);
+		const advisor = session.getAdvisorAgent();
+		if (!advisor) throw new Error("Expected Architecture advisor");
+		const advisorPrompt = advisor.state.systemPrompt.join("\n");
+		expect(advisorPrompt).toContain("Keep advice concrete.");
+		expect(advisorPrompt).toContain("Review module boundaries.");
 	});
 	it("retains cumulative advisor cost after an in-session history rewrite", async () => {
 		const advisor = enableAdvisor();
@@ -1095,7 +1102,7 @@ describe("AgentSession advisor toggle", () => {
 	it("propagates the resolved budget into the advisor model-visible system prompt", () => {
 		// Contract: SessionAdvisors must render the resolved budget into the
 		// prompt the advisor model actually receives. If the runtime stopped
-		// supplying it, the template falls back to 1 and this fails.
+		// supplying it, the template falls back to 4 and this fails.
 		expect(session.setAdvisorEnabled(true)).toBe(true);
 		session.applyAdvisorConfigs([{ name: "Strict", maxNotesPerUpdate: 1 }], undefined);
 		let advisor = session.getAdvisorAgent();
@@ -1110,29 +1117,41 @@ describe("AgentSession advisor toggle", () => {
 		expect(advisor.state.systemPrompt.join("\n")).toContain("max 3 non-blockers/update (`blocker` exempt)");
 	});
 
-	it("enforces budget precedence in the advisor prompt: per-advisor > shared WATCHDOG.yml > settings > default", () => {
-		const promptBudget = (): string => {
+	it("enforces budget precedence through advisor calls: per-advisor > shared WATCHDOG.yml > settings > default", async () => {
+		const exerciseBudget = async (prefix: string, budget: number): Promise<void> => {
 			const advisor = session.getAdvisorAgent();
 			if (!advisor) throw new Error("Expected advisor agent");
-			const match = advisor.state.systemPrompt.join("\n").match(/max (\d+) non-blockers\/update/);
-			if (!match) throw new Error("budget not rendered into advisor prompt");
-			return match[1]!;
+			const tool = advisor.state.tools?.find(candidate => candidate.name === "advise");
+			if (!(tool instanceof advisorModule.AdviseTool)) throw new Error("Expected advise tool");
+
+			tool.beginUpdate(true);
+			for (let i = 1; i <= budget; i++) {
+				const result = await tool.execute(`${prefix}-${i}`, {
+					note: `${prefix} note ${i}`,
+					severity: "concern",
+				});
+				expect(JSON.stringify(result.content)).toContain("Deferred");
+			}
+			const rejected = await tool.execute(`${prefix}-${budget + 1}`, {
+				note: `${prefix} note ${budget + 1}`,
+				severity: "concern",
+			});
+			expect(JSON.stringify(rejected.content)).toContain("budget is spent");
 		};
 
 		session.settings.set("advisor.maxNotesPerUpdate", 2);
 		expect(session.setAdvisorEnabled(true)).toBe(true);
 
-		session.applyAdvisorConfigs([{ name: "Specific", maxNotesPerUpdate: 5 }], undefined, 3);
-		expect(promptBudget()).toBe("5");
+		// Per-advisor (5) overrides shared (3) and settings (2).
+		expect(session.applyAdvisorConfigs([{ name: "Specific", maxNotesPerUpdate: 5 }], undefined, 3)).toBe(1);
+		await exerciseBudget("specific", 5);
 
-		session.applyAdvisorConfigs([{ name: "Inheriting" }], undefined, 3);
-		expect(promptBudget()).toBe("3");
+		// Shared (3) overrides settings (2) when per-advisor is undefined.
+		expect(session.applyAdvisorConfigs([{ name: "Inheriting" }], undefined, 3)).toBe(1);
+		await exerciseBudget("inheriting", 3);
 
-		session.applyAdvisorConfigs([{ name: "SettingsOnly" }], undefined, undefined);
-		expect(promptBudget()).toBe("2");
-
-		session.settings.set("advisor.maxNotesPerUpdate", 1);
-		expect(session.setAdvisorEnabled(true)).toBe(true);
-		expect(promptBudget()).toBe("1");
+		// Settings (2) overrides the default (4) when shared and per-advisor are undefined.
+		expect(session.applyAdvisorConfigs([{ name: "SettingsOnly" }], undefined, undefined)).toBe(1);
+		await exerciseBudget("settings", 2);
 	});
 });

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -540,6 +540,23 @@ describe("AgentSession advisor toggle", () => {
 		expect(session.getAdvisorCost()).toBeCloseTo(0.5, 8);
 		expect(session.formatAdvisorStatus()).toContain("$0.5000");
 	});
+	it("rebuilds the live advisor when a second config is applied over an existing roster", () => {
+		enableAdvisor();
+		const originalAgent = session.getAdvisorAgent();
+		expect(originalAgent).toBeDefined();
+
+		// Apply first roster.
+		expect(session.applyAdvisorConfigs([{ name: "Security" }], undefined)).toBe(1);
+		const firstRosterAgent = session.getAdvisorAgent();
+		expect(firstRosterAgent).toBeDefined();
+
+		// Apply a second, different roster over the live one.
+		expect(session.applyAdvisorConfigs([{ name: "Architecture" }, { name: "Testing" }], undefined)).toBe(2);
+		const secondRosterAgent = session.getAdvisorAgent();
+		// The advisor agent must be rebuilt — not the same instance as the first roster.
+		expect(secondRosterAgent).toBeDefined();
+		expect(secondRosterAgent).not.toBe(firstRosterAgent);
+	});
 	it("retains cumulative advisor cost after an in-session history rewrite", async () => {
 		const advisor = enableAdvisor();
 		appendAdvisorCost(advisor, 0.5, 1);
@@ -1039,7 +1056,15 @@ describe("AgentSession advisor toggle", () => {
 				note: "The final result still needs a regression test.",
 				severity: "nit",
 			});
-			expect(JSON.stringify(deferred.content)).toContain("Deferred");
+			if (deferred.content.length === 0) throw new Error("Expected the advise tool to acknowledge the call");
+			// Behavior, not wording: a note deferred behind an in-progress turn
+			// holds only a reservation — it must stay out of the primary
+			// transcript until the terminal-boundary flush below releases it.
+			expect(
+				quotaSession.messages.some(message =>
+					JSON.stringify(message).includes("The final result still needs a regression test."),
+				),
+			).toBe(false);
 
 			// The quota latch prevents another advisor dispatch. The tool boundary
 			// must keep the note out of the continuing model request; terminal
@@ -1067,59 +1092,10 @@ describe("AgentSession advisor toggle", () => {
 		}
 	});
 
-	it("respects maxNotesPerUpdate configured per advisor through applyAdvisorConfigs", async () => {
-		expect(session.setAdvisorEnabled(true)).toBe(true);
-		session.applyAdvisorConfigs([{ name: "Security", maxNotesPerUpdate: 2 }], undefined);
-		const advisor = session.getAdvisorAgent();
-		if (!advisor) throw new Error("Expected advisor agent");
-		const adviseTool = advisor.state.tools?.find(tool => tool.name === "advise");
-		if (!(adviseTool instanceof advisorModule.AdviseTool)) throw new Error("Expected advise tool");
-
-		adviseTool.beginUpdate(true);
-		const r1 = await adviseTool.execute("1", { note: "First concern", severity: "concern" });
-		const r2 = await adviseTool.execute("2", { note: "Second concern", severity: "concern" });
-		const r3 = await adviseTool.execute("3", { note: "Third concern", severity: "concern" });
-
-		expect(JSON.stringify(r1.content)).toContain("Deferred");
-		expect(JSON.stringify(r2.content)).toContain("Deferred");
-		expect(JSON.stringify(r3.content)).toContain("Rate limited");
-	});
-
-	it("respects advisor.maxNotesPerUpdate from settings when no per-advisor budget is set", async () => {
-		session.settings.set("advisor.maxNotesPerUpdate", 3);
-		expect(session.setAdvisorEnabled(true)).toBe(true);
-		const advisor = session.getAdvisorAgent();
-		if (!advisor) throw new Error("Expected advisor agent");
-		const adviseTool = advisor.state.tools?.find(tool => tool.name === "advise");
-		if (!(adviseTool instanceof advisorModule.AdviseTool)) throw new Error("Expected advise tool");
-
-		adviseTool.beginUpdate(true);
-		const r1 = await adviseTool.execute("1", { note: "First concern", severity: "concern" });
-		const r2 = await adviseTool.execute("2", { note: "Second concern", severity: "concern" });
-		const r3 = await adviseTool.execute("3", { note: "Third concern", severity: "concern" });
-		const r4 = await adviseTool.execute("4", { note: "Fourth concern", severity: "concern" });
-
-		expect(JSON.stringify(r1.content)).toContain("Deferred");
-		expect(JSON.stringify(r2.content)).toContain("Deferred");
-		expect(JSON.stringify(r3.content)).toContain("Deferred");
-		expect(JSON.stringify(r4.content)).toContain("Rate limited");
-	});
-
-	it("rebuilds advisor runtime when maxNotesPerUpdate changes in settings", () => {
-		session.settings.set("advisor.maxNotesPerUpdate", 1);
-		expect(session.setAdvisorEnabled(true)).toBe(true);
-		const advisor1 = session.getAdvisorAgent();
-
-		session.settings.set("advisor.maxNotesPerUpdate", 3);
-		expect(session.setAdvisorEnabled(true)).toBe(true);
-		const advisor2 = session.getAdvisorAgent();
-		expect(advisor2).not.toBe(advisor1);
-	});
-
 	it("propagates the resolved budget into the advisor model-visible system prompt", () => {
 		// Contract: SessionAdvisors must render the resolved budget into the
 		// prompt the advisor model actually receives. If the runtime stopped
-		// supplying it, the template falls back to 4 and this fails.
+		// supplying it, the template falls back to 1 and this fails.
 		expect(session.setAdvisorEnabled(true)).toBe(true);
 		session.applyAdvisorConfigs([{ name: "Strict", maxNotesPerUpdate: 1 }], undefined);
 		let advisor = session.getAdvisorAgent();
@@ -1134,47 +1110,29 @@ describe("AgentSession advisor toggle", () => {
 		expect(advisor.state.systemPrompt.join("\n")).toContain("max 3 non-blockers/update (`blocker` exempt)");
 	});
 
-	it("enforces precedence: per-advisor > shared WATCHDOG.yml > settings > default", async () => {
+	it("enforces budget precedence in the advisor prompt: per-advisor > shared WATCHDOG.yml > settings > default", () => {
+		const promptBudget = (): string => {
+			const advisor = session.getAdvisorAgent();
+			if (!advisor) throw new Error("Expected advisor agent");
+			const match = advisor.state.systemPrompt.join("\n").match(/max (\d+) non-blockers\/update/);
+			if (!match) throw new Error("budget not rendered into advisor prompt");
+			return match[1]!;
+		};
+
 		session.settings.set("advisor.maxNotesPerUpdate", 2);
 		expect(session.setAdvisorEnabled(true)).toBe(true);
 
-		// 1. Per-advisor (5) overrides shared (3) and settings (2)
 		session.applyAdvisorConfigs([{ name: "Specific", maxNotesPerUpdate: 5 }], undefined, 3);
-		let advisor = session.getAdvisorAgent();
-		let tool = advisor?.state.tools?.find(t => t.name === "advise");
-		if (!(tool instanceof advisorModule.AdviseTool)) throw new Error("Expected advise tool");
-		tool.beginUpdate(true);
-		for (let i = 1; i <= 5; i++) {
-			const res = await tool.execute(`s-${i}`, { note: `Specific note ${i}`, severity: "concern" });
-			expect(JSON.stringify(res.content)).toContain("Deferred");
-		}
-		const s6 = await tool.execute("s-6", { note: "Specific note 6", severity: "concern" });
-		expect(JSON.stringify(s6.content)).toContain("Rate limited");
+		expect(promptBudget()).toBe("5");
 
-		// 2. Shared (3) overrides settings (2) when per-advisor is undefined
 		session.applyAdvisorConfigs([{ name: "Inheriting" }], undefined, 3);
-		advisor = session.getAdvisorAgent();
-		tool = advisor?.state.tools?.find(t => t.name === "advise");
-		if (!(tool instanceof advisorModule.AdviseTool)) throw new Error("Expected advise tool");
-		tool.beginUpdate(true);
-		for (let i = 1; i <= 3; i++) {
-			const res = await tool.execute(`h-${i}`, { note: `Inheriting note ${i}`, severity: "concern" });
-			expect(JSON.stringify(res.content)).toContain("Deferred");
-		}
-		const h4 = await tool.execute("h-4", { note: "Inheriting note 4", severity: "concern" });
-		expect(JSON.stringify(h4.content)).toContain("Rate limited");
+		expect(promptBudget()).toBe("3");
 
-		// 3. Settings (2) overrides default (4) when shared and per-advisor are undefined
 		session.applyAdvisorConfigs([{ name: "SettingsOnly" }], undefined, undefined);
-		advisor = session.getAdvisorAgent();
-		tool = advisor?.state.tools?.find(t => t.name === "advise");
-		if (!(tool instanceof advisorModule.AdviseTool)) throw new Error("Expected advise tool");
-		tool.beginUpdate(true);
-		for (let i = 1; i <= 2; i++) {
-			const res = await tool.execute(`set-${i}`, { note: `Settings note ${i}`, severity: "concern" });
-			expect(JSON.stringify(res.content)).toContain("Deferred");
-		}
-		const set3 = await tool.execute("set-3", { note: "Settings note 3", severity: "concern" });
-		expect(JSON.stringify(set3.content)).toContain("Rate limited");
+		expect(promptBudget()).toBe("2");
+
+		session.settings.set("advisor.maxNotesPerUpdate", 1);
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+		expect(promptBudget()).toBe("1");
 	});
 });

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -659,15 +659,6 @@ describe("advisor", () => {
 	});
 
 	describe("AdviseTool", () => {
-		it("forwards advice to the callback and returns details", async () => {
-			const onAdvice = vi.fn();
-			const tool = new AdviseTool(onAdvice);
-			const result = await tool.execute("tc-1", { note: "x", severity: "concern" });
-			expect(onAdvice).toHaveBeenCalledWith("x", "concern");
-			expect(result.details).toEqual({ note: "x", severity: "concern" });
-			expect(result.useless).toBe(true);
-		});
-
 		it("suppresses duplicate advice notes from the same advisor session", async () => {
 			const onAdvice = vi.fn();
 			const tool = new AdviseTool(onAdvice);
@@ -710,6 +701,37 @@ describe("advisor", () => {
 			expect(onAdvice).toHaveBeenNthCalledWith(1, note, "nit");
 			expect(onAdvice).toHaveBeenNthCalledWith(2, note, "concern");
 			expect(onAdvice).toHaveBeenNthCalledWith(3, note, "blocker");
+		});
+
+		it("routes a same-text blocker escalation of an already-delivered note with the production guard", async () => {
+			// Reproduced failure: a nit that already reached the primary, re-raised
+			// as a blocker, was rejected by guard dedupe and never routed. Dedupe is
+			// rank-aware: strictly-higher severity is a real escalation, while equal
+			// or lower retags of the same text stay suppressed.
+			const delivered: { note: string; severity?: string }[] = [];
+			const tool = new AdviseTool(
+				(note, severity) => delivered.push({ note, severity }),
+				new AdvisorEmissionGuard(),
+			);
+			const note = "The migration drops the users table without a backup.";
+
+			await tool.execute("e-0", { note, severity: "nit" });
+			const blocker = await tool.execute("e-1", {
+				note: "THE MIGRATION DROPS THE USERS TABLE WITHOUT A BACKUP!",
+				severity: "blocker",
+			});
+			expect(delivered).toEqual([
+				{ note, severity: "nit" },
+				{ note: "THE MIGRATION DROPS THE USERS TABLE WITHOUT A BACKUP!", severity: "blocker" },
+			]);
+			expect(JSON.stringify(blocker.content)).toContain("Accepted for primary delivery");
+
+			// Equal/lower retags of the delivered blocker are duplicates.
+			const concern = await tool.execute("e-2", { note, severity: "concern" });
+			const nit = await tool.execute("e-3", { note, severity: "nit" });
+			expect(JSON.stringify(concern.content)).toContain("Duplicate advice ignored");
+			expect(JSON.stringify(nit.content)).toContain("Duplicate advice ignored");
+			expect(delivered).toHaveLength(2);
 		});
 
 		it("defers non-blockers per update and flushes the backlog on the next completed update", async () => {
@@ -779,17 +801,9 @@ describe("advisor", () => {
 			// flush. Each note cleared the emission guard when it was emitted, so the
 			// flush must deliver the full backlog instead of collapsing it to one note.
 			const delivered: string[] = [];
-			const guard = new AdvisorEmissionGuard();
-			// Mirror AgentSession: accept (filter + per-update budget) runs at emission;
-			// routing never re-filters.
-			const tool = new AdviseTool(
-				note => delivered.push(note),
-				note => guard.accept(note),
-			);
-			const beginUpdate = (inProgress: boolean) => {
-				tool.beginUpdate(inProgress);
-				guard.beginUpdate();
-			};
+			// Mirror AgentSession: admission (filter + per-update budget) runs at
+			// emission; routing never re-filters.
+			const tool = new AdviseTool(note => delivered.push(note), new AdvisorEmissionGuard());
 			const concerns = [
 				"Bare `location` cannot work outside the page; inspect with `await page.url()`.",
 				"Scope navigation to the visualizer's own `.viz-container`.",
@@ -799,217 +813,291 @@ describe("advisor", () => {
 
 			// Each concern arrives in its own in-progress advisor update.
 			for (const [i, note] of concerns.entries()) {
-				beginUpdate(true);
+				tool.beginUpdate(true);
 				await tool.execute(`c-${i}`, { note, severity: "concern" });
 			}
 			// All withheld mid-turn — nothing reaches the primary yet.
 			expect(delivered).toEqual([]);
 
 			// Turn completes: the deferred backlog flushes, oldest first, in full.
-			beginUpdate(false);
+			tool.beginUpdate(false);
 			expect(delivered).toEqual(concerns);
 		});
 
-		it("reports over-budget deferred notes and blockers as rate limited", async () => {
-			// Preserve the one-note cap from #3520, but never claim a dropped note
-			// was deferred or duplicated: the advisor must know to retry it.
+		it("caps an in-progress prompt spraying distinct notes and says so without promising delivery", async () => {
+			// A single in-progress advisor prompt that emits several distinct notes
+			// spends the update's one budget slot on the first; the rest are dropped
+			// at emission, so the flush cannot deliver an unbounded batch (#3520).
+			// The rejected calls must be told they were dropped — the previous
+			// unconditional "will be delivered automatically" promised delivery for
+			// notes the guard had already rejected, and the advice was lost.
 			const delivered: string[] = [];
-			const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
-			const tool = new AdviseTool(
-				note => delivered.push(note),
-				note => guard.accept(note),
-			);
-			const beginUpdate = (inProgress: boolean) => {
-				tool.beginUpdate(inProgress);
-				guard.beginUpdate();
-			};
+			const tool = new AdviseTool(note => delivered.push(note), new AdvisorEmissionGuard({ budgetPerUpdate: 1 }));
 
-			beginUpdate(true);
+			tool.beginUpdate(true);
 			const accepted = await tool.execute("x-0", { note: "First mid-turn concern.", severity: "concern" });
-			const concern = await tool.execute("x-1", { note: "Second mid-turn concern.", severity: "concern" });
-			const blocker = await tool.execute("x-2", {
-				note: "A destructive migration will drop user data.",
-				severity: "blocker",
-			});
-
+			const rejected = await tool.execute("x-1", { note: "Second mid-turn concern.", severity: "concern" });
+			const rejected2 = await tool.execute("x-2", { note: "Third mid-turn concern.", severity: "concern" });
 			expect(JSON.stringify(accepted.content)).toContain("Deferred");
-			expect(JSON.stringify(concern.content)).toContain("Rate limited");
-			expect(JSON.stringify(blocker.content)).toContain("Rate limited");
-			expect(JSON.stringify(blocker.content)).not.toContain("Duplicate");
-
-			beginUpdate(false);
+			for (const result of [rejected, rejected2]) {
+				const text = JSON.stringify(result.content);
+				expect(text).toContain("Not recorded");
+				expect(text).toContain("budget");
+				expect(text).not.toContain("delivered automatically");
+				expect(text).not.toContain("queued");
+			}
+			tool.beginUpdate(false);
 			expect(delivered).toEqual(["First mid-turn concern."]);
 		});
 
-		it("reserves and flushes multiple deferred notes up to a configured budgetPerUpdate", async () => {
-			const delivered: string[] = [];
-			const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 3 });
+		it("flushes only the concern when it displaces a pending nit from the same in-progress update", async () => {
+			// Rank escalation inside one in-progress update is not a flood: the
+			// concern takes the update's slot and the guard names the displaced
+			// pending nit, which must not be flushed alongside it.
+			const delivered: { note: string; severity?: string }[] = [];
 			const tool = new AdviseTool(
-				note => delivered.push(note),
-				(note, severity) => guard.accept(note, severity),
+				(note, severity) => delivered.push({ note, severity }),
+				new AdvisorEmissionGuard({ budgetPerUpdate: 1 }),
 			);
-			const beginUpdate = (inProgress: boolean) => {
-				tool.beginUpdate(inProgress);
-				guard.beginUpdate();
-			};
 
-			beginUpdate(true);
-			const note0 = await tool.execute("c-0", { note: "First concern: missing await.", severity: "concern" });
-			const note1 = await tool.execute("c-1", { note: "Second concern: unhandled rejection.", severity: "concern" });
-			const note2 = await tool.execute("c-2", { note: "Third nit: unused import.", severity: "nit" });
-			const note3 = await tool.execute("c-3", { note: "Fourth concern: memory leak.", severity: "concern" });
+			tool.beginUpdate(true);
+			await tool.execute("e-0", { note: "Nit: rename the helper.", severity: "nit" });
+			await tool.execute("e-1", { note: "Concern: the helper drops the lock early.", severity: "concern" });
+			// A blocker in the same update delivers live without touching the slot.
+			await tool.execute("e-2", { note: "Blocker: the write path is broken.", severity: "blocker" });
+			expect(delivered).toEqual([{ note: "Blocker: the write path is broken.", severity: "blocker" }]);
 
-			expect(JSON.stringify(note0.content)).toContain("Deferred");
-			expect(JSON.stringify(note1.content)).toContain("Deferred");
-			expect(JSON.stringify(note2.content)).toContain("Deferred");
-			expect(JSON.stringify(note3.content)).toContain("Rate limited");
-
-			// Nothing delivered yet while mid-turn
-			expect(delivered).toEqual([]);
-
-			// Primary completes turn: all 3 reserved notes flush in arrival order
-			beginUpdate(false);
+			tool.beginUpdate(false);
 			expect(delivered).toEqual([
-				"First concern: missing await.",
-				"Second concern: unhandled rejection.",
-				"Third nit: unused import.",
+				{ note: "Blocker: the write path is broken.", severity: "blocker" },
+				{ note: "Concern: the helper drops the lock early.", severity: "concern" },
+			]);
+		});
+
+		it("keeps a prior update's pending reservation when the current update displaces its own", async () => {
+			// Displacement is scoped to the update that owns the budget slot: an
+			// older update's accepted reservation holds no slot in the current
+			// update and must survive its eviction rounds.
+			const delivered: { note: string; severity?: string }[] = [];
+			const tool = new AdviseTool(
+				(note, severity) => delivered.push({ note, severity }),
+				new AdvisorEmissionGuard({ budgetPerUpdate: 1 }),
+			);
+
+			tool.beginUpdate(true);
+			await tool.execute("p-0", { note: "Nit from the first review.", severity: "nit" });
+			tool.beginUpdate(true);
+			await tool.execute("p-1", { note: "Nit from the second review.", severity: "nit" });
+			const escalation = await tool.execute("p-2", { note: "Concern from the second review.", severity: "concern" });
+			// The concern was admitted — the SECOND review's nit paid for it.
+			expect(JSON.stringify(escalation.content)).toContain("Deferred");
+
+			tool.beginUpdate(false);
+			expect(delivered).toEqual([
+				{ note: "Nit from the first review.", severity: "nit" },
+				{ note: "Concern from the second review.", severity: "concern" },
+			]);
+		});
+
+		it("accepts multiple deferred notes up to budget and evicts lowest-rank at capacity", async () => {
+			// With budget > 1, the guard accepts multiple same-update notes into
+			// free slots. When full, a higher-severity note displaces the
+			// lowest-rank PENDING entry — not the first one, never a routed one.
+			const delivered: { note: string; severity?: string }[] = [];
+			const tool = new AdviseTool(
+				(note, severity) => delivered.push({ note, severity }),
+				new AdvisorEmissionGuard({ budgetPerUpdate: 3 }),
+			);
+
+			tool.beginUpdate(true);
+			// Three free slots: nit, nit, concern all accepted.
+			await tool.execute("b-0", { note: "Nit: naming.", severity: "nit" });
+			await tool.execute("b-1", { note: "Nit: formatting.", severity: "nit" });
+			await tool.execute("b-2", { note: "Concern: lock leak.", severity: "concern" });
+			// Budget full (3/3). New concern evicts the lowest-rank entry (a nit),
+			// not the first note or the existing concern.
+			await tool.execute("b-3", { note: "Concern: null deref.", severity: "concern" });
+
+			tool.beginUpdate(false);
+			// Flush delivers 3 notes: the surviving nit, first concern, second concern.
+			// The evicted nit (lowest-rank at capacity) must NOT appear.
+			expect(delivered).toHaveLength(3);
+			const notes = delivered.map(d => d.note);
+			expect(notes).toContain("Concern: lock leak.");
+			expect(notes).toContain("Concern: null deref.");
+			// Exactly one nit survived (either one — both are rank 1).
+			const nits = notes.filter(n => n.startsWith("Nit:"));
+			expect(nits).toHaveLength(1);
+		});
+
+		it("rate-limits an equal-rank newcomer after a pending note escalates in place", async () => {
+			// When a deferred note is re-emitted at higher severity, the tool
+			// escalates it in place and the guard's slot tracks the real rank —
+			// so an equal-rank newcomer at a full budget is rate-limited instead
+			// of displacing the genuinely-escalated note.
+			const delivered: { note: string; severity?: string }[] = [];
+			const tool = new AdviseTool(
+				(note, severity) => delivered.push({ note, severity }),
+				new AdvisorEmissionGuard({ budgetPerUpdate: 2 }),
+			);
+
+			tool.beginUpdate(true);
+			// Slot 1: "A" admitted as nit.
+			await tool.execute("d-0", { note: "Issue A.", severity: "nit" });
+			// Re-emit "A" as concern — escalates in place; the slot's rank follows.
+			await tool.execute("d-1", { note: "Issue A.", severity: "concern" });
+			// Slot 2: "B" admitted as concern.
+			await tool.execute("d-2", { note: "Issue B.", severity: "concern" });
+			// Budget full (2/2), all slots at concern rank: "C" displaces nothing.
+			const rejected = await tool.execute("d-3", { note: "Issue C.", severity: "concern" });
+			expect(JSON.stringify(rejected.content)).toContain("Not recorded");
+
+			tool.beginUpdate(false);
+			// Flush delivers the escalated "A" at its concern severity, then "B".
+			expect(delivered).toEqual([
+				{ note: "Issue A.", severity: "concern" },
+				{ note: "Issue B.", severity: "concern" },
 			]);
 		});
 
 		it("does not let a suppressed phrase burn the deferred slot ahead of a real concern", async () => {
-			// P1 review regression: a noise phrase emitted before a substantive concern
-			// in the same in-progress update must not consume the update's slot. The
-			// emission guard filters it out at emission without spending the budget, so
-			// the following concern is still reserved and flushed.
+			// A noise phrase emitted before a substantive concern in the same
+			// in-progress update must not consume the update's slot. The emission
+			// guard filters it out at emission without spending the budget, so the
+			// following concern is still reserved and flushed — and the noise call
+			// is told it carried no content.
 			const delivered: string[] = [];
-			const guard = new AdvisorEmissionGuard();
-			const tool = new AdviseTool(
-				note => delivered.push(note),
-				note => guard.accept(note),
-			);
-			const beginUpdate = (inProgress: boolean) => {
-				tool.beginUpdate(inProgress);
-				guard.beginUpdate();
-			};
+			const tool = new AdviseTool(note => delivered.push(note), new AdvisorEmissionGuard({ budgetPerUpdate: 1 }));
 
-			beginUpdate(true);
-			await tool.execute("n-0", { note: "Stop.", severity: "concern" });
+			tool.beginUpdate(true);
+			const noise = await tool.execute("n-0", { note: "Stop.", severity: "concern" });
+			expect(JSON.stringify(noise.content)).toContain("no concrete, actionable content");
 			await tool.execute("n-1", {
 				note: "The migration drops the users table without a backup.",
 				severity: "concern",
 			});
-			beginUpdate(false);
+			tool.beginUpdate(false);
 			expect(delivered).toEqual(["The migration drops the users table without a backup."]);
 		});
 
-		it("still caps a single model turn spraying many distinct notes when configured with budgetPerUpdate 1", async () => {
-			// Live path: notes emitted in one completed-turn update stay capped at one when budget is 1.
+		it("labels a live over-budget note as rate-limited, not a duplicate", async () => {
+			// Live path with an explicit budget of 1: the first distinct concern is
+			// routed; the second is rejected for budget, and the acknowledgment
+			// must say so — mislabeling it "Duplicate advice ignored." told the
+			// advisor the note had already landed, so it never re-raised.
 			const delivered: string[] = [];
-			const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
-			const tool = new AdviseTool(
-				note => delivered.push(note),
-				note => guard.accept(note),
-			);
-			const beginUpdate = (inProgress: boolean) => {
-				tool.beginUpdate(inProgress);
-				guard.beginUpdate();
-			};
+			const tool = new AdviseTool(note => delivered.push(note), new AdvisorEmissionGuard({ budgetPerUpdate: 1 }));
 
-			beginUpdate(false);
-			await tool.execute("s-0", { note: "First distinct live concern.", severity: "concern" });
-			await tool.execute("s-1", { note: "Second distinct live concern.", severity: "concern" });
-			await tool.execute("s-2", { note: "Third distinct live concern.", severity: "concern" });
+			tool.beginUpdate(false);
+			const first = await tool.execute("s-0", { note: "First distinct live concern.", severity: "concern" });
+			const second = await tool.execute("s-1", { note: "Second distinct live concern.", severity: "concern" });
+			const third = await tool.execute("s-2", { note: "Third distinct live concern.", severity: "concern" });
+			expect(JSON.stringify(first.content)).toContain("Accepted for primary delivery");
+			for (const result of [second, third]) {
+				const text = JSON.stringify(result.content);
+				expect(text).toContain("budget");
+				expect(text).not.toContain("Duplicate");
+			}
 			expect(delivered).toEqual(["First distinct live concern."]);
 		});
 
-		it("accepts up to the default budget of 4 distinct live notes per completed update", async () => {
-			const delivered: string[] = [];
-			const guard = new AdvisorEmissionGuard();
+		it("cannot create an extra live slot by escalating past a delivered nit", async () => {
+			// A delivered (routed) nit keeps its budget slot: delivery cannot be
+			// retracted. A distinct higher-severity note later in the same update
+			// is rate-limited instead of producing a second over-budget delivery.
+			const delivered: { note: string; severity?: string }[] = [];
 			const tool = new AdviseTool(
-				note => delivered.push(note),
-				note => guard.accept(note),
+				(note, severity) => delivered.push({ note, severity }),
+				new AdvisorEmissionGuard({ budgetPerUpdate: 1 }),
 			);
-			const beginUpdate = (inProgress: boolean) => {
-				tool.beginUpdate(inProgress);
-				guard.beginUpdate();
-			};
 
-			beginUpdate(false);
-			await tool.execute("s-0", { note: "Note 0", severity: "concern" });
-			await tool.execute("s-1", { note: "Note 1", severity: "concern" });
-			await tool.execute("s-2", { note: "Note 2", severity: "concern" });
-			await tool.execute("s-3", { note: "Note 3", severity: "concern" });
-			await tool.execute("s-4", { note: "Note 4", severity: "concern" });
-			expect(delivered).toEqual(["Note 0", "Note 1", "Note 2", "Note 3"]);
+			tool.beginUpdate(false);
+			await tool.execute("r-0", { note: "Nit: rename the helper.", severity: "nit" });
+			const concern = await tool.execute("r-1", {
+				note: "Concern: the helper drops the lock early.",
+				severity: "concern",
+			});
+			expect(JSON.stringify(concern.content)).toContain("Not recorded");
+			expect(delivered).toEqual([{ note: "Nit: rename the helper.", severity: "nit" }]);
 		});
 
 		it("delivers a blocker escalation of a reserved note live instead of dropping it as already seen", async () => {
-			// P1 review regression: a note reserved as a nit/concern during an
-			// in-progress update, then escalated to blocker before the backlog flushes,
-			// even with casing/punctuation changed, must reuse its normalized reservation,
-			// and interrupt at blocker severity now — not be rejected as already-seen
+			// A note reserved as a nit/concern during an in-progress update, then
+			// escalated to blocker before the backlog flushes, even with
+			// casing/punctuation changed, must reuse its normalized reservation and
+			// interrupt at blocker severity now — not be rejected as already-seen
 			// and arrive late at the lower deferred severity.
 			const delivered: { note: string; severity?: string }[] = [];
-			const guard = new AdvisorEmissionGuard();
 			const tool = new AdviseTool(
 				(note, severity) => delivered.push({ note, severity }),
-				note => guard.accept(note),
+				new AdvisorEmissionGuard({ budgetPerUpdate: 1 }),
 			);
-			const beginUpdate = (inProgress: boolean) => {
-				tool.beginUpdate(inProgress);
-				guard.beginUpdate();
-			};
 			const note = "The migration drops the users table without a backup.";
 			const escalatedNote = "THE MIGRATION DROPS THE USERS TABLE WITHOUT A BACKUP!";
 
-			beginUpdate(true);
+			tool.beginUpdate(true);
 			await tool.execute("e-0", { note, severity: "concern" });
 			// Reserved, not delivered.
 			expect(delivered).toEqual([]);
 
-			beginUpdate(true);
+			tool.beginUpdate(true);
 			await tool.execute("e-1", { note: escalatedNote, severity: "blocker" });
 			// The blocker escalation is delivered live, at blocker severity.
 			expect(delivered).toEqual([{ note: escalatedNote, severity: "blocker" }]);
 
 			// The consumed reservation is not re-delivered as a stale concern at flush.
-			beginUpdate(false);
+			tool.beginUpdate(false);
 			expect(delivered).toEqual([{ note: escalatedNote, severity: "blocker" }]);
 		});
 
-		it("delivers a distinct blocker live after a non-blocker consumed the update budget", async () => {
-			// #11062 follow-up: a nit emitted first in an in-progress update reserves
-			// the one deferred slot. A distinct blocker that follows must still
-			// interrupt now instead of being rejected as rate-limited and dropped;
-			// the reserved nit stays queued and flushes when the turn completes.
+		it("flushDeferredNotes delivers the backlog without resetting the update budget", async () => {
+			// The terminal-boundary flush is not a new advisor update: reserved
+			// notes route immediately and stay charged to the current update as
+			// routed (non-displaceable), so a follow-up emission in the same
+			// update still faces the spent budget. The next beginUpdate resets it.
 			const delivered: { note: string; severity?: string }[] = [];
-			const guard = new AdvisorEmissionGuard();
 			const tool = new AdviseTool(
 				(note, severity) => delivered.push({ note, severity }),
-				(note, severity) => guard.accept(note, severity),
+				new AdvisorEmissionGuard({ budgetPerUpdate: 1 }),
 			);
-			const beginUpdate = (inProgress: boolean) => {
-				tool.beginUpdate(inProgress);
-				guard.beginUpdate();
-			};
 
-			beginUpdate(true);
-			const nit = await tool.execute("b-0", { note: "Minor naming nit.", severity: "nit" });
-			const blocker = await tool.execute("b-1", {
-				note: "Destructive migration will drop user data.",
-				severity: "blocker",
-			});
+			tool.beginUpdate(true);
+			await tool.execute("f-0", { note: "Nit held behind the turn.", severity: "nit" });
+			expect(delivered).toEqual([]);
 
-			expect(JSON.stringify(nit.content)).toContain("Deferred");
-			expect(JSON.stringify(blocker.content)).toContain("Recorded.");
-			expect(delivered).toEqual([{ note: "Destructive migration will drop user data.", severity: "blocker" }]);
+			tool.flushDeferredNotes();
+			expect(delivered).toEqual([{ note: "Nit held behind the turn.", severity: "nit" }]);
 
-			// The reserved nit still flushes at the completed boundary, after the blocker.
-			beginUpdate(false);
+			// Same update continues: the flushed nit's slot is charged and routed,
+			// so a distinct concern is rate-limited — no second delivery.
+			const concern = await tool.execute("f-1", { note: "Concern after the flush.", severity: "concern" });
+			expect(JSON.stringify(concern.content)).toContain("budget");
+			expect(delivered).toHaveLength(1);
+
+			// The next advisor update starts with a fresh budget.
+			tool.beginUpdate(false);
+			await tool.execute("f-2", { note: "Concern after the flush.", severity: "concern" });
 			expect(delivered).toEqual([
-				{ note: "Destructive migration will drop user data.", severity: "blocker" },
-				{ note: "Minor naming nit.", severity: "nit" },
+				{ note: "Nit held behind the turn.", severity: "nit" },
+				{ note: "Concern after the flush.", severity: "concern" },
 			]);
+		});
+
+		it("resetDeliveredNotes resets the guard and the pending backlog together", async () => {
+			const delivered: string[] = [];
+			const tool = new AdviseTool(note => delivered.push(note), new AdvisorEmissionGuard({ budgetPerUpdate: 1 }));
+
+			tool.beginUpdate(true);
+			await tool.execute("q-0", { note: "Queued but never flushed.", severity: "concern" });
+			tool.resetDeliveredNotes();
+
+			// The pending reservation is gone: no flush replay after the reset.
+			tool.flushDeferredNotes();
+			expect(delivered).toEqual([]);
+
+			// The guard's dedupe memory is gone too: the same note admits again.
+			await tool.execute("q-1", { note: "Queued but never flushed.", severity: "concern" });
+			expect(delivered).toEqual(["Queued but never flushed."]);
 		});
 
 		it("validates parameters using ArkType", () => {
@@ -1018,7 +1106,7 @@ describe("advisor", () => {
 			const valid = tool.parameters({ note: "x", severity: "concern" });
 			expect(valid instanceof type.errors).toBe(false);
 
-			const invalid = tool.parameters({ note: 123, severity: "invalid" as any });
+			const invalid = tool.parameters({ note: 123, severity: "invalid" });
 			expect(invalid instanceof type.errors).toBe(true);
 		});
 	});
@@ -1458,7 +1546,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "first", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host);
 
@@ -1504,7 +1591,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "work", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				notifyIdle: () => idleNotifications.push(1),
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -1537,7 +1623,6 @@ describe("advisor", () => {
 			};
 			const runtime = new AdvisorRuntime(agent, {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			});
 
 			runtime.onTurnEnd();
@@ -1569,7 +1654,6 @@ describe("advisor", () => {
 			};
 			const runtime = new AdvisorRuntime(agent, {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			});
 
 			runtime.onTurnEnd();
@@ -1587,7 +1671,6 @@ describe("advisor", () => {
 			releasePrompt.resolve();
 			await settleUntil(() => runtime.backlog === 0);
 		});
-
 		it("preserves the next user turn when an accepted empty stop is pruned", async () => {
 			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
@@ -1596,7 +1679,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host);
 
@@ -1657,7 +1739,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "first", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				maintainContext: async () => {
 					maintainCalls++;
 					if (maintainCalls === 1) {
@@ -1710,7 +1791,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 				maintainContext: async () => {
 					maintainCalls++;
@@ -1748,7 +1828,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "t0", timestamp: 0 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				maintainContext: async () => {
 					maintainCalls++;
 					// Only push new turns during the FIRST drain cycle (first 3 calls)
@@ -1808,7 +1887,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "turn1", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				maintainContext: async () => {
 					maintainCalls++;
 					if (maintainCalls === 1) {
@@ -1861,7 +1939,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "t1", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				maintainContext: async () => {
 					maintainCalls++;
 					if (maintainCalls === 1) {
@@ -1919,7 +1996,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "hello", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				beginAdvisorUpdate: inProgress => updateStates.push(inProgress),
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -1948,7 +2024,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "done", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				beginAdvisorUpdate: inProgress => updateStates.push(inProgress),
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -1977,7 +2052,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "first", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				maintainContext: async () => {
 					throw new Error("maintenance failed");
 				},
@@ -2009,7 +2083,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host);
 			runtime.onTurnEnd();
@@ -2028,7 +2101,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: `token ${secret}`, timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2051,7 +2123,6 @@ describe("advisor", () => {
 			];
 			const runtime = new AdvisorRuntime(agent, {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			});
 
@@ -2081,7 +2152,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2110,7 +2180,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2142,7 +2211,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2179,7 +2247,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2220,7 +2287,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2252,7 +2318,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2283,7 +2348,6 @@ describe("advisor", () => {
 			];
 			const runtime = new AdvisorRuntime(agent, {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			});
 
@@ -2314,7 +2378,6 @@ describe("advisor", () => {
 			];
 			const runtime = new AdvisorRuntime(agent, {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			});
 			runtime.onTurnEnd();
@@ -2343,7 +2406,6 @@ describe("advisor", () => {
 			];
 			const runtime = new AdvisorRuntime(agent, {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			});
 			runtime.onTurnEnd();
@@ -2378,7 +2440,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2415,7 +2476,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2446,7 +2506,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2481,7 +2540,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2533,7 +2591,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2568,7 +2625,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "first tok_abc123", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2607,7 +2663,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2666,7 +2721,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2703,7 +2757,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "later tok_abc123", timestamp: 2 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2744,7 +2797,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2777,7 +2829,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2811,7 +2862,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				obfuscator,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -2847,7 +2897,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host);
 
@@ -2909,7 +2958,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
 
@@ -2964,7 +3012,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host);
 			runtime.onTurnEnd();
@@ -2990,7 +3037,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host);
 			runtime.onTurnEnd();
@@ -3019,7 +3065,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host);
 			runtime.onTurnEnd();
@@ -3062,7 +3107,6 @@ describe("advisor", () => {
 			let shouldResetContext = false;
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				maintainContext: async incoming => {
 					// The host receives the pending update itself and sizes it with its
 					// own model's tokenizer, so it must arrive as a non-empty message.
@@ -3109,7 +3153,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "bbb", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				maintainContext: async () => {
 					maintenanceCalls++;
 					if (maintenanceCalls !== 1) return false;
@@ -3152,7 +3195,6 @@ describe("advisor", () => {
 			let shouldResetContext = false;
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				maintainContext: async () => shouldResetContext,
 			};
 			const runtime = new AdvisorRuntime(agent, host);
@@ -3212,7 +3254,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
 			runtime.seedTo(messages.length);
@@ -3303,7 +3344,6 @@ describe("advisor", () => {
 				agent,
 				{
 					snapshotMessages: () => messages,
-					enqueueAdvice: () => {},
 					maintainContext: async incoming => {
 						maintenanceTokens.push(new Tokenizer().countMessage(incoming));
 						if (maintenanceTokens.length === 4) fourthMaintenance.resolve();
@@ -3361,7 +3401,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "seed-primary", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
 			runtime.seedTo(messages.length);
@@ -3437,7 +3476,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "ancient-primary", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
 			runtime.seedTo(messages.length);
@@ -3488,7 +3526,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "ancient-history", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				notifyFailure: error => failures.push(error),
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
@@ -3540,7 +3577,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host);
 
@@ -3594,7 +3630,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host);
 			const controller = new AbortController();
@@ -3636,7 +3671,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
 
@@ -3661,7 +3695,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
 
@@ -3690,7 +3723,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				notifyFailure: error => failures.push(error),
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
@@ -3747,7 +3779,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				notifyFailure: error => failures.push(error),
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
@@ -3788,7 +3819,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "t1", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				notifyFailure: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
@@ -3837,7 +3867,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				onTurnError: () => new Promise<undefined>(() => {}),
 			};
 			const runtime = new AdvisorRuntime(agent, host, 60_000);
@@ -3872,7 +3901,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
 			runtime.onTurnEnd(messages);
@@ -3942,7 +3970,6 @@ describe("advisor", () => {
 				const messages = Array.from({ length: 2000 }, (_, i) => bigMessage(i));
 				const host: AdvisorRuntimeHost = {
 					snapshotMessages: () => messages,
-					enqueueAdvice: () => {},
 				};
 				const runtime = new AdvisorRuntime(agent, host, 0);
 				runtime.onTurnEnd(messages);
@@ -3987,7 +4014,6 @@ describe("advisor", () => {
 				} as AgentMessage;
 				const host: AdvisorRuntimeHost = {
 					snapshotMessages: () => messages,
-					enqueueAdvice: () => {},
 				};
 				const runtime = new AdvisorRuntime(agent, host, 0);
 				runtime.onTurnEnd(messages);
@@ -4014,7 +4040,6 @@ describe("advisor", () => {
 				const messages: AgentMessage[] = [{ role: "user", content: "before", timestamp: 1 } as AgentMessage];
 				const host: AdvisorRuntimeHost = {
 					snapshotMessages: () => messages,
-					enqueueAdvice: () => {},
 				};
 				const runtime = new AdvisorRuntime(agent, host, 0);
 				runtime.onTurnEnd(messages);
@@ -4048,7 +4073,6 @@ describe("advisor", () => {
 				const messages = Array.from({ length: 400 }, (_, i) => bigMessage(i));
 				const host: AdvisorRuntimeHost = {
 					snapshotMessages: () => messages,
-					enqueueAdvice: () => {},
 				};
 				const runtime = new AdvisorRuntime(agent, host, 0);
 				runtime.onTurnEnd(messages);
@@ -4077,7 +4101,6 @@ describe("advisor", () => {
 				const messages = Array.from({ length: 300 }, (_, i) => bigMessage(i));
 				const host: AdvisorRuntimeHost = {
 					snapshotMessages: () => messages,
-					enqueueAdvice: () => {},
 				};
 				const runtime = new AdvisorRuntime(agent, host, 0);
 				runtime.onTurnEnd(messages);
@@ -4126,7 +4149,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				notifyFailure: error => failures.push(error),
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
@@ -4158,7 +4180,6 @@ describe("advisor", () => {
 		it("accepts a zero-usage empty stop as a successful silent review", async () => {
 			const turnErrors: unknown[] = [];
 			const failures: unknown[] = [];
-			const adviceNotes: string[] = [];
 			const rollbackCalls: number[] = [];
 			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
 			let promptCalls = 0;
@@ -4193,7 +4214,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: note => adviceNotes.push(note),
 				onTurnError: error => {
 					turnErrors.push(error);
 				},
@@ -4212,7 +4232,6 @@ describe("advisor", () => {
 			expect(turnErrors).toEqual([]);
 			expect(failures).toEqual([]);
 			expect(rollbackCalls).toEqual([]);
-			expect(adviceNotes).toEqual([]);
 			expect(state.messages).toHaveLength(2);
 			expect(runtime.backlog).toBe(0);
 		});
@@ -4252,7 +4271,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "turn-0", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				onTurnError: error => {
 					turnErrors.push(error);
 				},
@@ -4280,7 +4298,6 @@ describe("advisor", () => {
 		it("treats a content-less stop that generated output tokens as a successful silent review", async () => {
 			const turnErrors: unknown[] = [];
 			const failures: unknown[] = [];
-			const adviceNotes: string[] = [];
 			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
 			let promptCalls = 0;
 			const agent: AdvisorAgent = {
@@ -4325,7 +4342,6 @@ describe("advisor", () => {
 			];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: note => adviceNotes.push(note),
 				onTurnError: error => {
 					turnErrors.push(error);
 				},
@@ -4342,7 +4358,6 @@ describe("advisor", () => {
 			expect(promptCalls).toBe(1);
 			expect(turnErrors).toEqual([]);
 			expect(failures).toEqual([]);
-			expect(adviceNotes).toEqual([]);
 			expect(runtime.backlog).toBe(0);
 		});
 
@@ -4397,7 +4412,6 @@ describe("advisor", () => {
 				agent,
 				{
 					snapshotMessages: () => messages,
-					enqueueAdvice: () => {},
 					notifyFailure: error => failures.push(error),
 				},
 				0,
@@ -4452,7 +4466,6 @@ describe("advisor", () => {
 				agent,
 				{
 					snapshotMessages: () => messages,
-					enqueueAdvice: () => {},
 					notifyFailure: error => failures.push(error),
 				},
 				0,
@@ -4520,7 +4533,6 @@ describe("advisor", () => {
 				agent,
 				{
 					snapshotMessages: () => messages,
-					enqueueAdvice: () => {},
 					notifyFailure: error => failures.push(error),
 					onTurnError: async () => {
 						fallbackCalls++;
@@ -4580,7 +4592,6 @@ describe("advisor", () => {
 				agent,
 				{
 					snapshotMessages: () => messages,
-					enqueueAdvice: () => {},
 					notifyFailure: error => failures.push(error),
 					onTurnError: async () => {
 						fallbackCalls++;
@@ -4655,7 +4666,6 @@ describe("advisor", () => {
 				agent,
 				{
 					snapshotMessages: () => messages,
-					enqueueAdvice: () => {},
 					notifyFailure: error => failures.push(error),
 					getModelIdentity: () => identity,
 					onTurnError: async () => {
@@ -4720,7 +4730,6 @@ describe("advisor", () => {
 				agent,
 				{
 					snapshotMessages: () => messages,
-					enqueueAdvice: () => {},
 					notifyFailure: error => failures.push(error),
 					getModelIdentity: () => identity,
 					onTurnError: async () => {
@@ -4791,7 +4800,6 @@ describe("advisor", () => {
 				agent,
 				{
 					snapshotMessages: () => messages,
-					enqueueAdvice: () => {},
 					notifyFailure: error => failures.push(error),
 				},
 				0,
@@ -4828,7 +4836,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				onTurnError: error => {
 					turnErrors.push(error);
 					events.push(`hook:${error instanceof Error ? error.message : String(error)}`);
@@ -4871,7 +4878,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				onTurnError: error => {
 					turnErrors.push(error);
 					events.push(`hook:${error instanceof Error ? error.message : String(error)}`);
@@ -4930,7 +4936,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				onTurnError: async error => {
 					turnErrors.push(error);
 					events.push(`hook:${error instanceof Error ? error.message : String(error)}`);
@@ -4999,7 +5004,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				onTurnError: error => {
 					turnErrors.push(error);
 				},
@@ -5068,7 +5072,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				onTurnAbandoned: () => {
 					abandonedTurns++;
 				},
@@ -5149,7 +5152,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
 
@@ -5194,7 +5196,6 @@ describe("advisor", () => {
 				agent,
 				{
 					snapshotMessages: () => messages,
-					enqueueAdvice: () => {},
 				},
 				0,
 			);
@@ -5254,7 +5255,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				notifyFailure: err => notifyFailures.push(err instanceof Error ? err.message : String(err)),
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
@@ -5307,7 +5307,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "old-conversation", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
 
@@ -5356,7 +5355,6 @@ describe("advisor", () => {
 			const messages: AgentMessage[] = [{ role: "user", content: "keep me", timestamp: 1 } as AgentMessage];
 			const runtime = new AdvisorRuntime(agent, {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			});
 
 			runtime.onTurnEnd(messages);
@@ -5397,7 +5395,6 @@ describe("advisor", () => {
 			];
 			const runtime = new AdvisorRuntime(agent, {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				maintainContext: async () => {
 					if (++maintenanceCalls === 1) {
 						void runtime.pauseForSessionTransition();
@@ -5441,7 +5438,6 @@ describe("advisor", () => {
 				};
 				const runtime = new AdvisorRuntime(agent, {
 					snapshotMessages: () => [],
-					enqueueAdvice: () => {},
 					...(hookKind === "success"
 						? { onTurnSuccess: blockHook }
 						: {
@@ -5479,7 +5475,6 @@ describe("advisor", () => {
 				agent,
 				{
 					snapshotMessages: () => [],
-					enqueueAdvice: () => {},
 					onTurnError: () => {
 						recoveryStarted.resolve();
 						return false;
@@ -5513,7 +5508,6 @@ describe("advisor", () => {
 			};
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => [],
-				enqueueAdvice: () => {},
 				notifyFailure: () => {
 					failureNotified = true;
 				},
@@ -5553,7 +5547,6 @@ describe("advisor", () => {
 			};
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => [],
-				enqueueAdvice: () => {},
 				notifyFailure: error => failures.push(error),
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
@@ -5581,7 +5574,6 @@ describe("advisor", () => {
 			};
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => [],
-				enqueueAdvice: () => {},
 				notifyQuotaExhausted: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
@@ -5621,7 +5613,6 @@ describe("advisor", () => {
 			};
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => [],
-				enqueueAdvice: () => {},
 				notifyQuotaExhausted: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
@@ -5654,7 +5645,6 @@ describe("advisor", () => {
 			let quotaNotified = false;
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => [],
-				enqueueAdvice: () => {},
 				onTurnError: async () => true,
 				notifyQuotaExhausted: () => {
 					quotaNotified = true;
@@ -5694,7 +5684,6 @@ describe("advisor", () => {
 			const hookErrors: unknown[] = [];
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => [],
-				enqueueAdvice: () => {},
 				onTurnError: async error => {
 					hookErrors.push(error);
 					return hookErrors.length === 1;
@@ -5724,7 +5713,6 @@ describe("advisor", () => {
 			let quotaNotified = false;
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => [],
-				enqueueAdvice: () => {},
 				onTurnError: async () => false,
 				notifyQuotaExhausted: () => {
 					quotaNotified = true;
@@ -5760,7 +5748,6 @@ describe("advisor", () => {
 			const { promise: hookEntered, resolve: allowHook } = Promise.withResolvers<void>();
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => [],
-				enqueueAdvice: () => {},
 				maintainContext: async (_incoming, signal) => {
 					maintenanceSignals.push(signal);
 					return false;
@@ -5810,7 +5797,6 @@ describe("advisor", () => {
 			};
 			const runtime = new AdvisorRuntime(agent, {
 				snapshotMessages: () => [],
-				enqueueAdvice: () => {},
 				onTurnError: async (_error, _failedMessages, signal) => {
 					recoverySignal = signal;
 					hookEntered.resolve();
@@ -5850,7 +5836,6 @@ describe("advisor", () => {
 			let quotaNotified = false;
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => [],
-				enqueueAdvice: () => {},
 				onTurnError: async error => {
 					hookErrors.push(error);
 					return hookErrors.length === 1 ? true : undefined;
@@ -5896,7 +5881,6 @@ describe("advisor", () => {
 			let quotaNotified = false;
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => [],
-				enqueueAdvice: () => {},
 				onTurnError: async error => {
 					hookErrors.push(error);
 					return hookErrors.length === 1 ? true : undefined;
@@ -5939,7 +5923,6 @@ describe("advisor", () => {
 			let quotaNotified = false;
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => [],
-				enqueueAdvice: () => {},
 				onTurnError: async error => {
 					hookErrors.push(error);
 					return true;

--- a/packages/coding-agent/test/advisor/emission-guard.test.ts
+++ b/packages/coding-agent/test/advisor/emission-guard.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import {
-	ADVISOR_MAX_BUDGET_PER_UPDATE,
-	AdvisorEmissionGuard,
-	normalizeAdvisorNote,
-} from "../../src/advisor/emission-guard";
+import { AdvisorEmissionGuard, normalizeAdvisorNote } from "../../src/advisor/emission-guard";
 
 describe("normalizeAdvisorNote", () => {
 	it("collapses punctuation, casing, and surrounding whitespace into one canonical key", () => {
@@ -36,113 +32,236 @@ describe("AdvisorEmissionGuard", () => {
 		// none of these carry a concrete reason and they cannot be acted on, so
 		// the guard suppresses them regardless of severity.
 		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("Stop.")).toBe("suppressed_noise");
-		expect(guard.accept("Done.")).toBe("suppressed_noise");
-		expect(guard.accept("No issue; continue.")).toBe("suppressed_noise");
-		expect(guard.accept("LGTM")).toBe("suppressed_noise");
-		expect(guard.accept("No further watcher input needed.")).toBe("suppressed_noise");
+		for (const note of ["Stop.", "Done.", "No issue; continue.", "LGTM", "No further watcher input needed."]) {
+			expect(guard.admit(note, { rank: 1, pending: false })).toEqual({ accepted: false, reason: "noise" });
+		}
 	});
 
 	it("dedupes by normalized text across the session, ignoring casing and trailing punctuation", () => {
 		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("Move retries into the queue, not the request path.")).toBe("accepted");
+		expect(guard.admit("Move retries into the queue, not the request path.", { rank: 1, pending: false })).toEqual({
+			accepted: true,
+		});
 		// Same advice with different casing and trailing punctuation must NOT
 		// land twice in the primary transcript.
-		expect(guard.accept("move retries into the queue, not the request path")).toBe("duplicate");
-		expect(guard.accept("Move retries into the queue, not the request path!")).toBe("duplicate");
+		expect(guard.admit("move retries into the queue, not the request path", { rank: 1, pending: false })).toEqual({
+			accepted: false,
+			reason: "duplicate",
+		});
+		expect(guard.admit("Move retries into the queue, not the request path!", { rank: 1, pending: false })).toEqual({
+			accepted: false,
+			reason: "duplicate",
+		});
 	});
 
-	it("rate-limits non-blockers past the default budget of 4 per advisor update cycle", () => {
+	it("limits each update to four non-blockers by default", () => {
+		// #3520's anti-flood clamp lives beside the upstream default: four
+		// distinct notes from one advisor cycle are fine; the fifth is the flood.
 		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("First concern: missing await in #handleRetry.")).toBe("accepted");
-		expect(guard.accept("Second concern: wrong env var name.")).toBe("accepted");
-		expect(guard.accept("Third concern: unhandled rejection.")).toBe("accepted");
-		expect(guard.accept("Fourth concern: missing validation.")).toBe("accepted");
-		expect(guard.accept("Fifth concern: unhandled error.")).toBe("rate_limited");
+		for (let i = 1; i <= 4; i++) {
+			expect(guard.admit(`Distinct concern ${i}.`, { rank: 2, pending: false }).accepted).toBe(true);
+		}
+		expect(guard.admit("Distinct concern 5.", { rank: 2, pending: false })).toEqual({
+			accepted: false,
+			reason: "rate-limit",
+		});
 		guard.beginUpdate();
 		// New cycle: budget reset.
-		expect(guard.accept("Fifth concern: unhandled error.")).toBe("accepted");
+		expect(guard.admit("Distinct concern 5.", { rank: 2, pending: false }).accepted).toBe(true);
 	});
 
-	it("supports strict 1-note rate-limiting when budgetPerUpdate is set to 1", () => {
+	it("rate-limits a second distinct non-blocker per update under an explicit budget of 1", () => {
 		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
-		expect(guard.accept("First concern: missing await in #handleRetry.")).toBe("accepted");
-		expect(guard.accept("Second concern: wrong env var name.")).toBe("rate_limited");
-		guard.beginUpdate();
-		expect(guard.accept("Second concern: wrong env var name.")).toBe("accepted");
-	});
-
-	it("honors a configured budgetPerUpdate allowing multiple accepted non-blockers per cycle", () => {
-		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 3 });
-		expect(guard.accept("First concern: missing await in #handleRetry.", "concern")).toBe("accepted");
-		expect(guard.accept("Second concern: wrong env var name.", "concern")).toBe("accepted");
-		expect(guard.accept("Third nit: variable name could be clearer.", "nit")).toBe("accepted");
-		// Exceeds the configured budget of 3
-		expect(guard.accept("Fourth concern: missing error boundary.", "concern")).toBe("rate_limited");
-		// Blockers still bypass the budget
-		expect(guard.accept("Destructive migration will drop user data.", "blocker")).toBe("accepted");
-		// Reset on next cycle
-		guard.beginUpdate();
-		expect(guard.accept("Fourth concern: missing error boundary.", "concern")).toBe("accepted");
-	});
-
-	it("clamps non-positive budgetPerUpdate to at least 1", () => {
-		const guardZero = new AdvisorEmissionGuard({ budgetPerUpdate: 0 });
-		expect(guardZero.accept("First concern.", "concern")).toBe("accepted");
-		expect(guardZero.accept("Second concern.", "concern")).toBe("rate_limited");
-
-		const guardNegative = new AdvisorEmissionGuard({ budgetPerUpdate: -3 });
-		expect(guardNegative.accept("First concern.", "concern")).toBe("accepted");
-		expect(guardNegative.accept("Second concern.", "concern")).toBe("rate_limited");
-	});
-
-	it("clamps budgetPerUpdate to at most ADVISOR_MAX_BUDGET_PER_UPDATE (32)", () => {
-		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 100 });
-		for (let i = 0; i < ADVISOR_MAX_BUDGET_PER_UPDATE; i++) {
-			expect(guard.accept(`Note ${i}`, "concern")).toBe("accepted");
-		}
-		expect(guard.accept("Note 33", "concern")).toBe("rate_limited");
-	});
-
-	it("exempts blockers from the per-update budget so they always interrupt", () => {
-		// A nit emitted first in an update must never rate-limit a blocker that
-		// follows it: blockers are the always-interrupt severity. Noise and dedupe
-		// still apply to blockers.
-		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
-		expect(guard.accept("Minor naming nit.", "nit")).toBe("accepted");
-		expect(guard.accept("Destructive migration will drop user data.", "blocker")).toBe("accepted");
-		// A repeat blocker is still deduped, not waved through by the exemption.
-		expect(guard.accept("Destructive migration will drop user data.", "blocker")).toBe("duplicate");
-		expect(guard.accept("Stop.", "blocker")).toBe("suppressed_noise");
+		expect(guard.admit("First concern: missing await in #handleRetry.", { rank: 2, pending: false })).toEqual({
+			accepted: true,
+		});
+		expect(guard.admit("Second concern: wrong env var name.", { rank: 2, pending: false })).toEqual({
+			accepted: false,
+			reason: "rate-limit",
+		});
 	});
 
 	it("does not let a suppressed call consume the per-update budget", () => {
 		// A noise call like "Stop." must never displace a real concern that
 		// follows in the same advisor model cycle.
-		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("Stop.")).toBe("suppressed_noise");
-		expect(guard.accept("Concrete: read race in #handleRetry.")).toBe("accepted");
+		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
+		expect(guard.admit("Stop.", { rank: 2, pending: false })).toEqual({ accepted: false, reason: "noise" });
+		expect(guard.admit("Concrete: read race in #handleRetry.", { rank: 2, pending: false }).accepted).toBe(true);
 	});
 
 	it("does not let a deduped call consume the per-update budget", () => {
 		// A repeat of a prior session note is dropped, but the model can still
 		// follow it with a fresh concrete concern in the same cycle.
-		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("Concrete: read race in #handleRetry.")).toBe("accepted");
+		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
+		expect(guard.admit("Concrete: read race in #handleRetry.", { rank: 2, pending: false }).accepted).toBe(true);
 		guard.beginUpdate();
-		expect(guard.accept("Concrete: read race in #handleRetry.")).toBe("duplicate");
-		expect(guard.accept("New concern: cache eviction never fires.")).toBe("accepted");
+		expect(guard.admit("Concrete: read race in #handleRetry.", { rank: 2, pending: false })).toEqual({
+			accepted: false,
+			reason: "duplicate",
+		});
+		expect(guard.admit("New concern: cache eviction never fires.", { rank: 2, pending: false }).accepted).toBe(true);
+	});
+
+	it("lets any number of blockers through while non-blockers share the budget", () => {
+		// The per-update budget exists to stop nit/concern floods (#3520). A
+		// blocker reports broken handoff — losing it because a concern was emitted
+		// first in the same cycle loses the one note that must always land.
+		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
+		expect(guard.admit("Concern: only one of three reads done.", { rank: 2, pending: false })).toEqual({
+			accepted: true,
+		});
+		expect(guard.admit("Blocker: the run stopped before the third read.", { rank: 3, pending: false })).toEqual({
+			accepted: true,
+		});
+		expect(guard.admit("Blocker: the diff was never exercised end to end.", { rank: 3, pending: false })).toEqual({
+			accepted: true,
+		});
+		// The budget is still spent for non-blockers.
+		expect(guard.admit("Nit: consider a shorter loop.", { rank: 1, pending: false })).toEqual({
+			accepted: false,
+			reason: "rate-limit",
+		});
+		// Noise and dedupe still apply to blockers.
+		expect(guard.admit("Blocker: the run stopped before the third read.", { rank: 3, pending: false })).toEqual({
+			accepted: false,
+			reason: "duplicate",
+		});
+	});
+
+	it("lets a higher-severity note displace a still-pending nit and names the displaced note", () => {
+		// Escalation within one cycle is not a flood: the concern takes the
+		// pending nit's slot, and the decision identifies the displaced note so
+		// the caller can drop it from its backlog without inferring policy.
+		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
+		expect(guard.admit("Nit: rename the helper for clarity.", { rank: 1, pending: true })).toEqual({
+			accepted: true,
+		});
+		expect(guard.admit("Concern: the helper drops the lock early.", { rank: 2, pending: true })).toEqual({
+			accepted: true,
+			displacedKey: "nit rename the helper for clarity",
+		});
+		// Equal or lower rank after the concern stays dropped.
+		expect(guard.admit("Nit: also fix the comment.", { rank: 1, pending: true })).toEqual({
+			accepted: false,
+			reason: "rate-limit",
+		});
+		expect(guard.admit("Concern: second concern.", { rank: 2, pending: true })).toEqual({
+			accepted: false,
+			reason: "rate-limit",
+		});
+	});
+
+	it("never displaces a routed note to free budget — delivery cannot be retracted", () => {
+		// A note already routed to the primary keeps its slot: a later concern
+		// in the same update must not create an over-budget second delivery by
+		// "evicting" a delivery that already happened.
+		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
+		expect(guard.admit("Nit: rename the helper.", { rank: 1, pending: false })).toEqual({ accepted: true });
+		expect(guard.admit("Concern: the helper drops the lock early.", { rank: 2, pending: false })).toEqual({
+			accepted: false,
+			reason: "rate-limit",
+		});
+	});
+
+	it("stops displacing a pending note once markRouted reports it delivered", () => {
+		// A deferred flush routes the note without a new update boundary; its
+		// slot stays charged but becomes non-displaceable.
+		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
+		expect(guard.admit("Nit: rename the helper.", { rank: 1, pending: true })).toEqual({ accepted: true });
+		guard.markRouted("Nit: rename the helper.");
+		expect(guard.admit("Concern: the helper drops the lock early.", { rank: 2, pending: true })).toEqual({
+			accepted: false,
+			reason: "rate-limit",
+		});
+	});
+
+	it("admits a same-text blocker escalation of an already-routed note without reopening budget", () => {
+		// The production failure: a delivered nit re-raised as a blocker must
+		// still interrupt — dedupe is rank-aware, not a hard text wall. The
+		// routed slot stays charged (no retraction), the blocker is exempt, and
+		// equal/lower retags afterwards stay suppressed.
+		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
+		const note = "The migration drops the users table without a backup.";
+		expect(guard.admit(note, { rank: 1, pending: false })).toEqual({ accepted: true });
+		expect(guard.admit("THE MIGRATION DROPS THE USERS TABLE WITHOUT A BACKUP!", { rank: 3, pending: false })).toEqual(
+			{ accepted: true },
+		);
+		expect(guard.admit(note, { rank: 2, pending: false })).toEqual({ accepted: false, reason: "duplicate" });
+		expect(guard.admit(note, { rank: 1, pending: false })).toEqual({ accepted: false, reason: "duplicate" });
+	});
+
+	it("releases the budget slot when a still-pending note escalates to blocker", () => {
+		// The reservation will never flush — the note routes live as a blocker —
+		// so its pending slot is freed for the rest of the update.
+		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
+		const note = "The migration drops the users table without a backup.";
+		expect(guard.admit(note, { rank: 2, pending: true })).toEqual({ accepted: true });
+		expect(guard.admit(note, { rank: 3, pending: false })).toEqual({ accepted: true });
+		expect(guard.admit("Concern: the rollback path is untested.", { rank: 2, pending: true })).toEqual({
+			accepted: true,
+		});
+	});
+
+	it("tracks in-place pending escalation so eviction compares the real rank", () => {
+		// A queued nit re-raised as a concern is escalated in place (no new
+		// admission). escalatePending keeps the slot rank coherent: an equal-rank
+		// newcomer afterwards is rate-limited, not waved through as an eviction.
+		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
+		const note = "Issue A.";
+		expect(guard.admit(note, { rank: 1, pending: true })).toEqual({ accepted: true });
+		guard.escalatePending(note, 2);
+		expect(guard.admit("Issue B.", { rank: 2, pending: true })).toEqual({ accepted: false, reason: "rate-limit" });
+		// The escalated text is now recorded at concern rank: equal/lower retags
+		// dedupe, a blocker still routes.
+		expect(guard.admit(note, { rank: 2, pending: true })).toEqual({ accepted: false, reason: "duplicate" });
+		expect(guard.admit(note, { rank: 3, pending: false })).toEqual({ accepted: true });
+	});
+
+	it("treats a same-update severity re-raise of a routed note as one charged slot", () => {
+		// The same text at higher severity is the same note reclassified, not a
+		// second note: the slot upgrades in place instead of double-charging.
+		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 2 });
+		const note = "The helper drops the lock early.";
+		expect(guard.admit(note, { rank: 1, pending: false })).toEqual({ accepted: true });
+		expect(guard.admit(note, { rank: 2, pending: false })).toEqual({ accepted: true });
+		// Only one of the two budget slots was spent.
+		expect(guard.admit("Distinct nit: naming.", { rank: 1, pending: false })).toEqual({ accepted: true });
+		expect(guard.admit("Distinct nit: formatting.", { rank: 1, pending: false })).toEqual({
+			accepted: false,
+			reason: "rate-limit",
+		});
 	});
 
 	it("reset clears dedupe and the per-update gate so a re-primed advisor can re-raise old issues", () => {
 		// Compaction / session-switch rewrites the primary transcript. The
 		// advisor is re-primed from scratch and may legitimately re-raise the
 		// same concerns — they're new context for a freshly-primed reviewer.
-		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("Race in #handleRetry.")).toBe("accepted");
-		expect(guard.accept("Race in #handleRetry.")).toBe("duplicate");
+		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
+		expect(guard.admit("Race in #handleRetry.", { rank: 2, pending: false }).accepted).toBe(true);
+		expect(guard.admit("Race in #handleRetry.", { rank: 2, pending: false }).accepted).toBe(false);
 		guard.reset();
-		expect(guard.accept("Race in #handleRetry.")).toBe("accepted");
+		expect(guard.admit("Race in #handleRetry.", { rank: 2, pending: false }).accepted).toBe(true);
+	});
+
+	it("keeps dedupe history bounded when a pending escalation re-tracks an evicted key", () => {
+		// escalatePending must share admit's FIFO-bounded recording: a key that
+		// aged out of the history and is re-tracked by an in-place escalation
+		// would otherwise bypass the eviction queue and become a permanent,
+		// unevictable entry.
+		const guard = new AdvisorEmissionGuard({ capacity: 1 });
+		expect(guard.admit("Issue A.", { rank: 1, pending: true }).accepted).toBe(true);
+		guard.beginUpdate();
+		// Admitting B evicts A from the capacity-1 history.
+		expect(guard.admit("Issue B.", { rank: 1, pending: true }).accepted).toBe(true);
+		// A is re-tracked via in-place escalation while still pending; it
+		// re-enters the eviction queue as the oldest entry.
+		guard.escalatePending("Issue A.", 2);
+		guard.beginUpdate();
+		// Admitting C evicts A again (oldest tracked). With the leak, A would
+		// stay tracked forever and the final re-raise would be a false duplicate.
+		expect(guard.admit("Issue C.", { rank: 1, pending: true }).accepted).toBe(true);
+		guard.beginUpdate();
+		expect(guard.admit("Issue A.", { rank: 2, pending: true }).accepted).toBe(true);
 	});
 
 	it("evicts oldest entries when dedupe history exceeds capacity", () => {
@@ -150,35 +269,34 @@ describe("AdvisorEmissionGuard", () => {
 		// bound. Pre-eviction unique notes are remembered; post-eviction the
 		// oldest one is forgotten and can resurface.
 		const guard = new AdvisorEmissionGuard({ capacity: 3 });
-		expect(guard.accept("first")).toBe("accepted");
+		expect(guard.admit("first", { rank: 1, pending: false }).accepted).toBe(true);
 		guard.beginUpdate();
-		expect(guard.accept("second")).toBe("accepted");
+		expect(guard.admit("second", { rank: 1, pending: false }).accepted).toBe(true);
 		guard.beginUpdate();
-		expect(guard.accept("third")).toBe("accepted");
+		expect(guard.admit("third", { rank: 1, pending: false }).accepted).toBe(true);
 		guard.beginUpdate();
 		// "first" still in history.
-		expect(guard.accept("first")).toBe("duplicate");
+		expect(guard.admit("first", { rank: 1, pending: false }).accepted).toBe(false);
 		guard.beginUpdate();
 		// Fourth unique entry evicts "first".
-		expect(guard.accept("fourth")).toBe("accepted");
+		expect(guard.admit("fourth", { rank: 1, pending: false }).accepted).toBe(true);
 		guard.beginUpdate();
-		expect(guard.accept("first")).toBe("accepted");
+		expect(guard.admit("first", { rank: 1, pending: false }).accepted).toBe(true);
 	});
 
 	it("rejects empty / whitespace-only notes without consuming the budget", () => {
-		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("")).toBe("suppressed_noise");
-		expect(guard.accept("   ")).toBe("suppressed_noise");
-		expect(guard.accept("Concrete advice.")).toBe("accepted");
+		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
+		expect(guard.admit("", { rank: 1, pending: false })).toEqual({ accepted: false, reason: "empty" });
+		expect(guard.admit("   ", { rank: 1, pending: false })).toEqual({ accepted: false, reason: "empty" });
+		expect(guard.admit("Concrete advice.", { rank: 1, pending: false }).accepted).toBe(true);
 	});
 
-	it("end-to-end: the reporter's 309-call spam log produces ≤1 accepted note across many updates", () => {
+	it("end-to-end: the reporter's 309-call spam log yields a single unique note", () => {
 		// Mimic the issue's distribution: 114× "Stop.", 52× "No issue; continue.",
 		// 41× "Done.", plus 102 copies of one concrete-but-repeated nit. Spread
-		// the calls across 50 advisor update cycles. Each cycle is allowed at
-		// most one accepted note, and identical-text repeats never escape the
-		// guard. After all calls, exactly the concrete nit has been accepted
-		// — and only once.
+		// the calls across 50 advisor update cycles. Noise phrases never pass;
+		// identical-text repeats never escape the session dedupe. After all
+		// calls, exactly the concrete nit has been admitted — and only once.
 		const guard = new AdvisorEmissionGuard();
 		const accepted: string[] = [];
 		const stream: string[] = [
@@ -195,7 +313,7 @@ describe("AdvisorEmissionGuard", () => {
 			for (let i = 0; i < perCycle; i++) {
 				const note = stream[c * perCycle + i];
 				if (note === undefined) break;
-				if (guard.accept(note) === "accepted") accepted.push(note);
+				if (guard.admit(note, { rank: 1, pending: false }).accepted) accepted.push(note);
 			}
 		}
 		expect(accepted).toEqual(["Concrete-but-repeated nit: x"]);

--- a/packages/coding-agent/test/advisor/fingerprint-multi-message.test.ts
+++ b/packages/coding-agent/test/advisor/fingerprint-multi-message.test.ts
@@ -52,7 +52,6 @@ async function runScenario(
 	} as unknown as AdvisorAgent;
 	const host: AdvisorRuntimeHost = {
 		snapshotMessages: () => messages,
-		enqueueAdvice: () => {},
 	} as unknown as AdvisorRuntimeHost;
 	const runtime = new AdvisorRuntime(agent, host);
 	runtime.onTurnEnd();
@@ -134,7 +133,6 @@ describe("fingerprint: field-selective fingerprint (applied)", () => {
 		} as unknown as AdvisorAgent;
 		const host: AdvisorRuntimeHost = {
 			snapshotMessages: () => messages,
-			enqueueAdvice: () => {},
 		} as unknown as AdvisorRuntimeHost;
 		const runtime = new AdvisorRuntime(agent, host);
 		runtime.onTurnEnd();

--- a/packages/coding-agent/test/advisor/replay-observability.test.ts
+++ b/packages/coding-agent/test/advisor/replay-observability.test.ts
@@ -39,7 +39,6 @@ describe("advisor context reset observability", () => {
 			};
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host);
 
@@ -81,7 +80,6 @@ describe("advisor context reset observability", () => {
 			};
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => [],
-				enqueueAdvice: () => {},
 			};
 			const runtime = new AdvisorRuntime(agent, host);
 
@@ -123,7 +121,6 @@ describe("advisor context reset observability", () => {
 			};
 			const runtime = new AdvisorRuntime(agent, {
 				snapshotMessages: () => messages,
-				enqueueAdvice: () => {},
 				notifyFailure: error => failures.push(error),
 			});
 


### PR DESCRIPTION
i did some stress testing of advisor system and noticed sometimes concerns overwrote blockers

basically it ensures highest severity gets the slot, with some code improvements in corner cases, dedups

## what

keep queued advisor findings available for delivery, allow genuine severity escalation, and tell the advisor whether its `advise` call was accepted, deferred, or dropped

- use one guard for duplicate filtering and the per-review non-blocker note limit, rather than separate tool/session state
- let a higher-severity finding replace only a lower-severity note still queued by the same review; preserve notes from earlier reviews and notes already routed to the primary agent
- allow the same finding to escalate from `nit` to `concern` or `blocker`; equal/lower-severity repeats remain suppressed
- flush queued notes when the primary finishes without resetting the current review's budget or applying the limit again to the backlog
- distinguish accepted delivery, conditional deferral, duplicates, empty/non-actionable notes, and exhausted budget in tool responses; acceptance does not claim the primary model consumed the note
- retain the existing default of four non-blocker notes per review and existing configuration precedence; blockers remain exempt from this limit

## why

separate duplicate and budget state made delivery decisions inconsistent: one layer could allow severity escalation while another rejected the same text. a generic `Recorded.` response also did not explain whether a finding was routed or only waiting for the primary to finish

with a one-note budget, a new concern may replace a nit still queued by the same review. it must not replace a note from an earlier review or free a slot by pretending an already-routed note was withdrawn

this PR fixes note delivery and its acknowledgments. it does not change provider request limits or token/cost budgets

## testing

- included regression cases cover severity escalation, pending-note replacement, preservation of earlier/routed notes, deferred flushing, suppression responses, and session reset
- checks were not rerun during draft preparation; exact earlier commands/results and a contributor-observed behavior scenario remain to be recorded

---

- [x] contributor-written explanation added
- [x] `bun check` passes
- [x] tested locally; exact scenario and result recorded
- [x] CHANGELOG updated with PR link and contributor credit
