### PR TITLE
fix(advisor): preserve healthy WATCHDOG entries and surface warnings

### DIFF
--- a/docs/advisor-watchdog.md
+++ b/docs/advisor-watchdog.md
@@ -255,7 +255,9 @@ Later project files sit closer to the end of the advisor prompt, so narrower dir
 
 ## WATCHDOG.yml
 
-`WATCHDOG.yml` (or `WATCHDOG.yaml`) is the advisor roster. Where `WATCHDOG.md` supplies review priorities, `WATCHDOG.yml` declares the advisors themselves — one entry per name, each with its own enable flag, model, tool grant, and specialization prompt. The interactive `/advisor configure` overlay edits this file in place. Files that fail to parse or fail schema validation are logged and skipped so one bad project config cannot kill the session.
+`WATCHDOG.yml` (or `WATCHDOG.yaml`) is the advisor roster. Each named entry can set its own enabled state, model, tools, and specialization prompt; `WATCHDOG.md` supplies shared review guidance.
+
+Discovery and `/advisor configure` use the same per-entry validation: malformed entries are skipped with named warnings while healthy advisors remain usable. Invalid YAML or a non-mapping document is skipped with a file warning. Problems appear in an aggregated startup/editor warning and remain visible inside the editor after switching project/user scope. Saving the editor document writes only valid entries.
 
 Example:
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Invalid `WATCHDOG.yml` entries now produce startup/editor warnings while healthy advisors remain available ([#11882](https://github.com/can1357/oh-my-pi/pull/11882) by [@olegpulatov](https://github.com/olegpulatov)).
 - Claude Code session imports now preserve typed user text stored alongside tool results ([#11854](https://github.com/can1357/oh-my-pi/issues/11854)).
 - Extension commands now settle BTW writes before creating, switching, or branching sessions, preventing side requests from outliving their source session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).
 - Session selection and active-session deletion now settle BTW writes before switching or removing history, preventing stale saves from blocking the next session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).

--- a/packages/coding-agent/src/advisor/config.ts
+++ b/packages/coding-agent/src/advisor/config.ts
@@ -54,6 +54,12 @@ export interface DiscoveredAdvisors {
 	advisors: AdvisorConfig[];
 	sharedInstructions: string | undefined;
 	sharedMaxNotesPerUpdate?: number;
+	/**
+	 * Human-readable config problems collected during the walk: unparseable
+	 * files and dropped entries. Surfaced as one aggregated session warning so
+	 * a broken roster entry never fails silently.
+	 */
+	warnings: string[];
 }
 
 const advisorEntrySchema = type({
@@ -65,11 +71,52 @@ const advisorEntrySchema = type({
 	"maxNotesPerUpdate?": "number",
 });
 
-const watchdogYamlSchema = type({
-	"instructions?": "string",
-	"maxNotesPerUpdate?": "number",
-	"advisors?": advisorEntrySchema.array(),
-});
+type AdvisorYamlEntry = typeof advisorEntrySchema.infer;
+
+/**
+ * Validate one parsed `WATCHDOG.yml` document per entry instead of as a whole:
+ * a single malformed advisor drops out with a warning naming it, while the
+ * healthy entries still load. Also reports non-string `instructions` and a
+ * non-list `advisors` key — both previously failed the whole file silently.
+ */
+function parseWatchdogDoc(
+	doc: Record<string, unknown>,
+	path: string,
+): {
+	instructions: string | undefined;
+	entries: AdvisorYamlEntry[];
+	sharedMaxNotesPerUpdate: number | undefined;
+	warnings: string[];
+} {
+	const warnings: string[] = [];
+	const rawInstructions = doc.instructions;
+	const instructions = typeof rawInstructions === "string" ? rawInstructions : undefined;
+	if (rawInstructions !== undefined && instructions === undefined) {
+		warnings.push(`${path}: instructions must be a string — ignored`);
+	}
+	const rawMaxNotes = doc.maxNotesPerUpdate;
+	const sharedMaxNotesPerUpdate =
+		typeof rawMaxNotes === "number" && Number.isFinite(rawMaxNotes) && rawMaxNotes >= 1
+			? Math.trunc(rawMaxNotes)
+			: undefined;
+	const rawAdvisors = doc.advisors;
+	if (rawAdvisors !== undefined && !Array.isArray(rawAdvisors)) {
+		warnings.push(`${path}: advisors must be a list — ignored`);
+	}
+	const entries: AdvisorYamlEntry[] = [];
+	for (const [index, rawEntry] of (Array.isArray(rawAdvisors) ? rawAdvisors : []).entries()) {
+		const result = advisorEntrySchema(rawEntry);
+		if (result instanceof type.errors) {
+			const rawName =
+				rawEntry && typeof rawEntry === "object" ? (rawEntry as Record<string, unknown>).name : undefined;
+			const label = typeof rawName === "string" && rawName.trim() ? `"${rawName}"` : `#${index + 1}`;
+			warnings.push(`${path}: advisor ${label} dropped — ${result.summary}`);
+			continue;
+		}
+		entries.push(result);
+	}
+	return { instructions, entries, sharedMaxNotesPerUpdate, warnings };
+}
 
 /**
  * Normalize an advisor name into a filesystem-/id-safe slug used for its
@@ -148,54 +195,56 @@ export async function discoverAdvisorConfigs(cwd: string, agentDir?: string): Pr
 	const advisors = new Map<string, AdvisorConfig>();
 	const sharedParts: string[] = [];
 	let sharedMaxNotesPerUpdate: number | undefined;
+	const warnings: string[] = [];
+	const warn = (message: string, context?: Record<string, unknown>): void => {
+		warnings.push(message);
+		logger.warn("Advisor config", { ...context, error: message });
+	};
+
 	for (const item of items) {
 		let parsed: unknown;
 		try {
 			parsed = YAML.parse(item.content);
 		} catch (err) {
-			logger.warn("Advisor config: failed to parse YAML", { path: item.path, error: String(err) });
+			warn(`${item.path}: failed to parse YAML (${String(err)}) — file skipped`, { path: item.path });
 			continue;
 		}
 		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-			logger.warn("Advisor config: expected a YAML mapping", { path: item.path });
+			warn(`${item.path}: expected a YAML mapping — file skipped`, { path: item.path });
 			continue;
 		}
-		const result = watchdogYamlSchema(parsed);
-		if (result instanceof type.errors) {
-			logger.warn("Advisor config: invalid schema", { path: item.path, error: result.summary });
-			continue;
-		}
+		const {
+			instructions,
+			entries,
+			sharedMaxNotesPerUpdate: docSharedMaxNotes,
+			warnings: docWarnings,
+		} = parseWatchdogDoc(parsed as Record<string, unknown>, item.path);
+		for (const message of docWarnings) warn(message, { path: item.path });
 
-		if (result.instructions?.trim()) {
-			const expanded = (await expandAtImports(result.instructions, item.path)).trim();
+		if (instructions?.trim()) {
+			const expanded = (await expandAtImports(instructions, item.path)).trim();
 			if (expanded) sharedParts.push(expanded);
 		}
 
-		if (
-			typeof result.maxNotesPerUpdate === "number" &&
-			Number.isFinite(result.maxNotesPerUpdate) &&
-			result.maxNotesPerUpdate >= 1
-		) {
-			sharedMaxNotesPerUpdate = Math.trunc(result.maxNotesPerUpdate);
-		}
+		if (docSharedMaxNotes !== undefined) sharedMaxNotesPerUpdate = docSharedMaxNotes;
 
-		for (const entry of result.advisors ?? []) {
+		for (const entry of entries) {
 			const slug = slugifyAdvisorName(entry.name);
-			const instructions = entry.instructions?.trim()
+			const entryInstructions = entry.instructions?.trim()
 				? (await expandAtImports(entry.instructions, item.path)).trim() || undefined
 				: undefined;
 			advisors.set(slug, {
 				name: entry.name,
 				model: entry.model?.trim() || undefined,
 				tools: filterAdvisorTools(entry.tools, item.path),
-				instructions,
-				enabled: entry.enabled,
 				maxNotesPerUpdate:
 					typeof entry.maxNotesPerUpdate === "number" &&
 					Number.isFinite(entry.maxNotesPerUpdate) &&
 					entry.maxNotesPerUpdate >= 1
 						? Math.trunc(entry.maxNotesPerUpdate)
 						: undefined,
+				enabled: entry.enabled,
+				instructions: entryInstructions,
 			});
 		}
 	}
@@ -204,6 +253,7 @@ export async function discoverAdvisorConfigs(cwd: string, agentDir?: string): Pr
 		advisors: [...advisors.values()],
 		sharedInstructions: sharedParts.length > 0 ? sharedParts.join("\n\n") : undefined,
 		sharedMaxNotesPerUpdate,
+		warnings,
 	};
 }
 
@@ -220,6 +270,8 @@ export interface WatchdogConfigDoc {
 	instructions?: string;
 	maxNotesPerUpdate?: number;
 	advisors: AdvisorConfig[];
+	/** Per-entry problems found while loading (dropped entries). Shown when the file becomes active in the editor. */
+	warnings?: string[];
 }
 
 /**
@@ -252,9 +304,11 @@ export async function resolveAdvisorConfigEditPath(
 }
 
 /**
- * Load one `WATCHDOG.yml` file for editing — raw, un-merged, un-expanded. Missing,
- * unparseable, or schema-invalid files yield an empty doc (never throws) so the
- * editor opens cleanly on a fresh or broken file.
+ * Load one `WATCHDOG.yml` file for editing — raw, un-merged, un-expanded. Missing
+ * or unparseable files yield an empty doc (never throws) so the editor opens
+ * cleanly on a fresh or broken file. Validation is per entry, matching
+ * discovery: malformed entries drop out of `advisors` and land in `warnings`
+ * instead of blanking the whole editor.
  */
 export async function loadWatchdogConfigFile(filePath: string): Promise<WatchdogConfigDoc> {
 	let text: string;
@@ -270,15 +324,20 @@ export async function loadWatchdogConfigFile(filePath: string): Promise<Watchdog
 		parsed = YAML.parse(text);
 	} catch (err) {
 		logger.warn("Advisor config: failed to parse for edit", { path: filePath, error: String(err) });
-		return { advisors: [] };
+		return { advisors: [], warnings: [`${filePath}: failed to parse YAML (${String(err)})`] };
 	}
-	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return { advisors: [] };
-	const result = watchdogYamlSchema(parsed);
-	if (result instanceof type.errors) {
-		logger.warn("Advisor config: invalid schema for edit", { path: filePath, error: result.summary });
-		return { advisors: [] };
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		// Parity with discovery: a non-mapping document is reported, not silently blanked.
+		const message = `${filePath}: expected a YAML mapping — file skipped`;
+		logger.warn("Advisor config", { path: filePath, error: message });
+		return { advisors: [], warnings: [message] };
 	}
-	const advisors = (result.advisors ?? []).map(a => {
+	const { instructions, entries, sharedMaxNotesPerUpdate, warnings } = parseWatchdogDoc(
+		parsed as Record<string, unknown>,
+		filePath,
+	);
+	for (const message of warnings) logger.warn("Advisor config", { path: filePath, error: message });
+	const advisors = entries.map(a => {
 		const advisor: AdvisorConfig = { name: a.name };
 		if (a.model?.trim()) advisor.model = a.model;
 		if (a.tools !== undefined) advisor.tools = [...a.tools];
@@ -290,14 +349,9 @@ export async function loadWatchdogConfigFile(filePath: string): Promise<Watchdog
 		return advisor;
 	});
 	const doc: WatchdogConfigDoc = { advisors };
-	if (result.instructions?.trim()) doc.instructions = result.instructions;
-	if (
-		typeof result.maxNotesPerUpdate === "number" &&
-		Number.isFinite(result.maxNotesPerUpdate) &&
-		result.maxNotesPerUpdate >= 1
-	) {
-		doc.maxNotesPerUpdate = Math.trunc(result.maxNotesPerUpdate);
-	}
+	if (instructions?.trim()) doc.instructions = instructions;
+	if (sharedMaxNotesPerUpdate !== undefined) doc.maxNotesPerUpdate = sharedMaxNotesPerUpdate;
+	if (warnings.length > 0) doc.warnings = warnings;
 	return doc;
 }
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -106,6 +106,7 @@ import { createPersistedSubagentReviverFactory } from "./task/persisted-revive";
 import { createTelemetryExportConfig, initTelemetryExport, isTelemetryExportEnabled } from "./telemetry-export";
 import { concreteThinkingLevel, parseConfiguredThinkingLevel } from "./thinking";
 import type { LspStartupServerInfo } from "./tools";
+import { sanitizeDisplayWarning } from "./tools/render-utils";
 import { getChangelogPath, resolveStartupChangelogForDisplay, type StartupChangelogSelection } from "./utils/changelog";
 import { EventBus } from "./utils/event-bus";
 
@@ -604,7 +605,7 @@ async function runInteractiveMode(
 	if (advisorConfigWarnings.length > 0) {
 		// Pulled here, not pushed from SessionAdvisors: the constructor-time
 		// `emitNotice` fired before the UI subscribed and was silently lost.
-		mode.showWarning(`WATCHDOG.yml: ${advisorConfigWarnings.join("; ")}`);
+		mode.showWarning(`WATCHDOG.yml: ${advisorConfigWarnings.map(sanitizeDisplayWarning).join("; ")}`);
 	}
 
 	for (const notify of notifs) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -600,6 +600,13 @@ async function runInteractiveMode(
 		}
 	});
 
+	const advisorConfigWarnings = session.getAdvisorConfigWarnings();
+	if (advisorConfigWarnings.length > 0) {
+		// Pulled here, not pushed from SessionAdvisors: the constructor-time
+		// `emitNotice` fired before the UI subscribed and was silently lost.
+		mode.showWarning(`WATCHDOG.yml: ${advisorConfigWarnings.join("; ")}`);
+	}
+
 	for (const notify of notifs) {
 		if (!notify) {
 			continue;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -106,7 +106,7 @@ import { createPersistedSubagentReviverFactory } from "./task/persisted-revive";
 import { createTelemetryExportConfig, initTelemetryExport, isTelemetryExportEnabled } from "./telemetry-export";
 import { concreteThinkingLevel, parseConfiguredThinkingLevel } from "./thinking";
 import type { LspStartupServerInfo } from "./tools";
-import { sanitizeDisplayWarning } from "./tools/render-utils";
+import { sanitizeDisplayWarnings } from "./tools/render-utils";
 import { getChangelogPath, resolveStartupChangelogForDisplay, type StartupChangelogSelection } from "./utils/changelog";
 import { EventBus } from "./utils/event-bus";
 
@@ -605,7 +605,7 @@ async function runInteractiveMode(
 	if (advisorConfigWarnings.length > 0) {
 		// Pulled here, not pushed from SessionAdvisors: the constructor-time
 		// `emitNotice` fired before the UI subscribed and was silently lost.
-		mode.showWarning(`WATCHDOG.yml: ${advisorConfigWarnings.map(sanitizeDisplayWarning).join("; ")}`);
+		mode.showWarning(`WATCHDOG.yml: ${sanitizeDisplayWarnings(advisorConfigWarnings).join("; ")}`);
 	}
 
 	for (const notify of notifs) {

--- a/packages/coding-agent/src/modes/components/advisor-config.ts
+++ b/packages/coding-agent/src/modes/components/advisor-config.ts
@@ -42,6 +42,7 @@ import type { PerAdvisorStat } from "../../session/agent-session";
 import type { OAuthAccountIdentity } from "../../session/auth-storage";
 import { formatCompactQuota } from "../controllers/command-controller";
 import { getSelectListTheme, theme } from "../theme/theme";
+import { sanitizeDisplayWarning } from "../../tools/render-utils";
 import { HookEditorComponent } from "./hook-editor";
 import { buildBrowserItems, ModelBrowser, sortModelItems } from "./model-browser";
 import {
@@ -274,7 +275,9 @@ export class AdvisorConfigOverlayComponent implements Component {
 		const warnings = this.#doc.warnings?.length
 			? [
 					theme.fg("warning", "⚠ Config problems — dropped while loading:"),
-					...this.#doc.warnings.flatMap(w => wrap(w, bodyWidth).map(line => theme.fg("warning", line))),
+					...this.#doc.warnings.flatMap(w =>
+						wrap(sanitizeDisplayWarning(w), bodyWidth).map(line => theme.fg("warning", line)),
+					),
 					"",
 				].map(line => truncateToWidth(line, bodyWidth))
 			: [];
@@ -437,7 +440,7 @@ export class AdvisorConfigOverlayComponent implements Component {
 			// the initial scope's warnings when the overlay opens, so only switches
 			// report here — no double-showing the opening file.
 			if (doc.warnings?.length) {
-				const message = `WATCHDOG.yml: ${doc.warnings.join("; ")}`;
+				const message = `WATCHDOG.yml: ${doc.warnings.map(sanitizeDisplayWarning).join("; ")}`;
 				if (this.#cb.warn) this.#cb.warn(message);
 				else this.#cb.notify(message);
 			}

--- a/packages/coding-agent/src/modes/components/advisor-config.ts
+++ b/packages/coding-agent/src/modes/components/advisor-config.ts
@@ -66,6 +66,11 @@ export interface AdvisorConfigCallbacks {
 	requestRender: () => void;
 	/** Surface a transient status/warning line to the user. */
 	notify: (message: string) => void;
+	/**
+	 * Surface a sticky warning (e.g. malformed entries in the file just made
+	 * active by a scope switch). Falls back to `notify` when omitted.
+	 */
+	warn?: (message: string) => void;
 	/** Live advisor usage stats; lets the preview show tokens/cost per advisor. */
 	getAdvisorStats?: () => PerAdvisorStat[];
 	getUsageReports?: () => Promise<UsageReport[] | null>;
@@ -263,15 +268,25 @@ export class AdvisorConfigOverlayComponent implements Component {
 	}
 
 	#previewContent(bodyWidth: number): string[] {
+		// The fullscreen overlay hides the host's chat-mounted warning toasts, so
+		// the active file's load problems are pinned at the top of the preview
+		// until a successful save rewrites the file without them.
+		const warnings = this.#doc.warnings?.length
+			? [
+					theme.fg("warning", "⚠ Config problems — dropped while loading:"),
+					...this.#doc.warnings.flatMap(w => wrap(w, bodyWidth).map(line => theme.fg("warning", line))),
+					"",
+				].map(line => truncateToWidth(line, bodyWidth))
+			: [];
 		const list = this.#active;
 		const value = list instanceof SelectList ? (list.getSelectedItem()?.value ?? "") : "";
 		const match = /^advisor:(\d+)$/.exec(value);
 		if (match) {
 			const advisor = this.#doc.advisors[Number(match[1])];
-			if (advisor) return this.#advisorPreview(advisor, bodyWidth);
+			if (advisor) return [...warnings, ...this.#advisorPreview(advisor, bodyWidth)];
 		}
 		if (value === "shared") {
-			const lines = [theme.bold("Shared instructions"), ""];
+			const lines = [...warnings, theme.bold("Shared instructions"), ""];
 			const text = this.#doc.instructions?.trim();
 			lines.push(...(text ? wrap(text, bodyWidth) : [theme.fg("muted", "(none)")]));
 			return lines.map(line => truncateToWidth(line, bodyWidth));
@@ -286,7 +301,7 @@ export class AdvisorConfigOverlayComponent implements Component {
 						: value === "close"
 							? "Close the editor. Unsaved changes are discarded."
 							: "";
-		return wrap(help, bodyWidth).map(line => truncateToWidth(theme.fg("muted", line), bodyWidth));
+		return [...warnings, ...wrap(help, bodyWidth).map(line => truncateToWidth(theme.fg("muted", line), bodyWidth))];
 	}
 
 	#advisorPreview(advisor: AdvisorConfig, bodyWidth: number): string[] {
@@ -415,15 +430,27 @@ export class AdvisorConfigOverlayComponent implements Component {
 				return;
 			}
 			const next = this.#otherScope();
-			this.#doc = await this.#cb.loadDoc(next);
-			this.#ensureRosterVisible();
+			const doc = await this.#cb.loadDoc(next);
+			this.#doc = doc;
 			this.#scope = next;
+			// Surface malformed entries in the file just made active. The host shows
+			// the initial scope's warnings when the overlay opens, so only switches
+			// report here — no double-showing the opening file.
+			if (doc.warnings?.length) {
+				const message = `WATCHDOG.yml: ${doc.warnings.join("; ")}`;
+				if (this.#cb.warn) this.#cb.warn(message);
+				else this.#cb.notify(message);
+			}
+			this.#ensureRosterVisible();
 			this.#showList();
 			return;
 		}
 		if (value === "save") {
 			const doc = this.#hasSyntheticDefaultAdvisor(this.#doc) ? { ...this.#doc, advisors: [] } : this.#doc;
 			await this.#cb.save(this.#scope, doc);
+			// The saved file contains only the normalized entries, so the load-time
+			// warnings no longer apply to it. (On failure the throw skips this.)
+			this.#doc.warnings = undefined;
 			this.#dirty = false;
 			this.#showList();
 			return;

--- a/packages/coding-agent/src/modes/components/advisor-config.ts
+++ b/packages/coding-agent/src/modes/components/advisor-config.ts
@@ -42,7 +42,7 @@ import type { PerAdvisorStat } from "../../session/agent-session";
 import type { OAuthAccountIdentity } from "../../session/auth-storage";
 import { formatCompactQuota } from "../controllers/command-controller";
 import { getSelectListTheme, theme } from "../theme/theme";
-import { sanitizeDisplayWarning } from "../../tools/render-utils";
+import { sanitizeDisplayWarnings } from "../../tools/render-utils";
 import { HookEditorComponent } from "./hook-editor";
 import { buildBrowserItems, ModelBrowser, sortModelItems } from "./model-browser";
 import {
@@ -275,8 +275,8 @@ export class AdvisorConfigOverlayComponent implements Component {
 		const warnings = this.#doc.warnings?.length
 			? [
 					theme.fg("warning", "⚠ Config problems — dropped while loading:"),
-					...this.#doc.warnings.flatMap(w =>
-						wrap(sanitizeDisplayWarning(w), bodyWidth).map(line => theme.fg("warning", line)),
+					...sanitizeDisplayWarnings(this.#doc.warnings).flatMap(warning =>
+						wrap(warning, bodyWidth).map(line => theme.fg("warning", line)),
 					),
 					"",
 				].map(line => truncateToWidth(line, bodyWidth))
@@ -440,7 +440,7 @@ export class AdvisorConfigOverlayComponent implements Component {
 			// the initial scope's warnings when the overlay opens, so only switches
 			// report here — no double-showing the opening file.
 			if (doc.warnings?.length) {
-				const message = `WATCHDOG.yml: ${doc.warnings.map(sanitizeDisplayWarning).join("; ")}`;
+				const message = `WATCHDOG.yml: ${sanitizeDisplayWarnings(doc.warnings).join("; ")}`;
 				if (this.#cb.warn) this.#cb.warn(message);
 				else this.#cb.notify(message);
 			}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -79,7 +79,7 @@ import {
 	type ToolSession,
 } from "../../tools";
 import { AskTool, type AskToolDetails, type AskToolInput } from "../../tools/ask";
-import { shortenPath } from "../../tools/render-utils";
+import { sanitizeDisplayWarning, shortenPath } from "../../tools/render-utils";
 import { ToolAbortError } from "../../tools/tool-errors";
 import { applyHyperlinkSetting } from "../../tui/hyperlink";
 import { copyToClipboard } from "../../utils/clipboard";
@@ -327,7 +327,7 @@ export class SelectorController {
 			const dirs = { projectDir, agentDir };
 			const initialDoc = await loadWatchdogConfigFile(await resolveAdvisorConfigEditPath(initialScope, dirs));
 			if (initialDoc.warnings?.length) {
-				this.ctx.showWarning(`WATCHDOG.yml: ${initialDoc.warnings.join("; ")}`);
+				this.ctx.showWarning(`WATCHDOG.yml: ${initialDoc.warnings.map(sanitizeDisplayWarning).join("; ")}`);
 			}
 			// Fullscreen editor on the alternate screen (the /settings idiom): the
 			// overlay holds the alt buffer + mouse tracking; the transcript stays put.
@@ -366,7 +366,7 @@ export class SelectorController {
 					);
 					this.ctx.statusLine.invalidate();
 					if (discovered.warnings.length > 0) {
-						this.ctx.showWarning(`WATCHDOG.yml: ${discovered.warnings.join("; ")}`);
+						this.ctx.showWarning(`WATCHDOG.yml: ${discovered.warnings.map(sanitizeDisplayWarning).join("; ")}`);
 					}
 					this.ctx.showStatus(
 						count > 0

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -326,6 +326,9 @@ export class SelectorController {
 			}
 			const dirs = { projectDir, agentDir };
 			const initialDoc = await loadWatchdogConfigFile(await resolveAdvisorConfigEditPath(initialScope, dirs));
+			if (initialDoc.warnings?.length) {
+				this.ctx.showWarning(`WATCHDOG.yml: ${initialDoc.warnings.join("; ")}`);
+			}
 			// Fullscreen editor on the alternate screen (the /settings idiom): the
 			// overlay holds the alt buffer + mouse tracking; the transcript stays put.
 			const done = () => {
@@ -362,6 +365,9 @@ export class SelectorController {
 						discovered.sharedMaxNotesPerUpdate,
 					);
 					this.ctx.statusLine.invalidate();
+					if (discovered.warnings.length > 0) {
+						this.ctx.showWarning(`WATCHDOG.yml: ${discovered.warnings.join("; ")}`);
+					}
 					this.ctx.showStatus(
 						count > 0
 							? `Saved ${scope} WATCHDOG.yml — ${count} advisor${count === 1 ? "" : "s"} active.`
@@ -372,6 +378,9 @@ export class SelectorController {
 				close: done,
 				requestRender: () => this.ctx.ui.requestRender(),
 				notify: message => this.ctx.showStatus(message),
+				// Scope switches happen inside the overlay; the initial file's warnings
+				// were already shown above, so only newly activated files arrive here.
+				warn: message => this.ctx.showWarning(message),
 				getAdvisorStats: () => this.ctx.session.getAdvisorStats().advisors,
 				getUsageReports: async () => this.ctx.session.fetchUsageReports?.() ?? null,
 				resolveActiveAccount: (provider, sessionId) =>

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -79,7 +79,7 @@ import {
 	type ToolSession,
 } from "../../tools";
 import { AskTool, type AskToolDetails, type AskToolInput } from "../../tools/ask";
-import { sanitizeDisplayWarning, shortenPath } from "../../tools/render-utils";
+import { sanitizeDisplayWarnings, shortenPath } from "../../tools/render-utils";
 import { ToolAbortError } from "../../tools/tool-errors";
 import { applyHyperlinkSetting } from "../../tui/hyperlink";
 import { copyToClipboard } from "../../utils/clipboard";
@@ -327,7 +327,7 @@ export class SelectorController {
 			const dirs = { projectDir, agentDir };
 			const initialDoc = await loadWatchdogConfigFile(await resolveAdvisorConfigEditPath(initialScope, dirs));
 			if (initialDoc.warnings?.length) {
-				this.ctx.showWarning(`WATCHDOG.yml: ${initialDoc.warnings.map(sanitizeDisplayWarning).join("; ")}`);
+				this.ctx.showWarning(`WATCHDOG.yml: ${sanitizeDisplayWarnings(initialDoc.warnings).join("; ")}`);
 			}
 			// Fullscreen editor on the alternate screen (the /settings idiom): the
 			// overlay holds the alt buffer + mouse tracking; the transcript stays put.
@@ -366,7 +366,7 @@ export class SelectorController {
 					);
 					this.ctx.statusLine.invalidate();
 					if (discovered.warnings.length > 0) {
-						this.ctx.showWarning(`WATCHDOG.yml: ${discovered.warnings.map(sanitizeDisplayWarning).join("; ")}`);
+						this.ctx.showWarning(`WATCHDOG.yml: ${sanitizeDisplayWarnings(discovered.warnings).join("; ")}`);
 					}
 					this.ctx.showStatus(
 						count > 0

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3743,6 +3743,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			advisorSharedInstructions: discoveredAdvisors.sharedInstructions,
 			advisorSharedMaxNotesPerUpdate: discoveredAdvisors.sharedMaxNotesPerUpdate,
 			advisorConfigs: discoveredAdvisors.advisors,
+			advisorConfigWarnings: discoveredAdvisors.warnings,
 			agent,
 			pruneToolDescriptions: inlineToolDescriptors,
 			thinkingLevel: autoThinking ? AUTO_THINKING : effectiveThinkingLevel,

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -319,6 +319,8 @@ export interface AgentSessionConfig {
 	advisorMemoryPrompt?: string;
 	/** Advisors discovered from WATCHDOG.yml. */
 	advisorConfigs?: AdvisorConfig[];
+	/** Config problems collected during WATCHDOG.yml discovery. */
+	advisorConfigWarnings?: string[];
 	/** Strip tool descriptions from provider-bound side-request tool specs. */
 	pruneToolDescriptions?: boolean;
 	/** Disconnect the MCP manager owned by this session during disposal. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1817,6 +1817,7 @@ export class AgentSession {
 			contextPrompt: config.advisorContextPrompt,
 			memoryPrompt: config.advisorMemoryPrompt,
 			configs: config.advisorConfigs,
+			configWarnings: config.advisorConfigWarnings,
 			streamFn: config.advisorStreamFn,
 			transformProviderContext: config.transformProviderContext,
 		});
@@ -10801,6 +10802,11 @@ export class AgentSession {
 	 */
 	getAdvisorAgent(): Agent | undefined {
 		return this.#advisors.getAdvisorAgent();
+	}
+
+	/** WATCHDOG.yml problems from startup discovery; shown by the UI once it is ready. */
+	getAdvisorConfigWarnings(): readonly string[] {
+		return this.#advisors.configWarnings;
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -230,6 +230,8 @@ export interface SessionAdvisorsOptions {
 	/** Active memory backend's developer instructions, wrapped for advisors. */
 	memoryPrompt?: string;
 	configs?: AdvisorConfig[];
+	/** WATCHDOG.yml problems found during discovery; surfaced once as a warning. */
+	configWarnings?: string[];
 	streamFn?: StreamFn;
 	transformProviderContext?: (context: Context, model: Model) => Context | Promise<Context>;
 }
@@ -329,6 +331,7 @@ export class SessionAdvisors {
 	#transformProviderContext: ((context: Context, model: Model) => Context | Promise<Context>) | undefined;
 	#advisors: ActiveAdvisor[] = [];
 	#advisorConfigs: AdvisorConfig[] | undefined;
+	#advisorConfigWarnings: string[];
 	#advisorStatuses = new Map<string, { name: string; status: AdvisorRuntimeStatus }>();
 	#advisorProviderSessionIds = new Map<string, string>();
 	#advisorCosts = new Map<string, number>();
@@ -364,6 +367,7 @@ export class SessionAdvisors {
 		this.#advisorContextPrompt = options.contextPrompt;
 		this.#advisorMemoryPrompt = options.memoryPrompt;
 		this.#advisorConfigs = options.configs;
+		this.#advisorConfigWarnings = options.configWarnings ?? [];
 		this.#advisorStreamFn = options.streamFn;
 		this.#transformProviderContext = options.transformProviderContext;
 		if (this.#advisorEnabled) this.#buildAdvisorRuntime();
@@ -1887,6 +1891,16 @@ export class SessionAdvisors {
 	 */
 	toggleAdvisorEnabled(): boolean {
 		return this.setAdvisorEnabled(!this.#advisorEnabled);
+	}
+
+	/**
+	 * WATCHDOG.yml problems found during startup discovery (dropped entries,
+	 * unparseable files). Pulled by the interactive mode AFTER the UI subscribes
+	 * to session events — a constructor-time `emitNotice` would fire before any
+	 * listener exists and be lost.
+	 */
+	get configWarnings(): readonly string[] {
+		return this.#advisorConfigWarnings;
 	}
 
 	/**

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -836,17 +836,30 @@ export function shortenPath(filePath: unknown, homeDir?: string): string {
 	return filePath;
 }
 
-/** Shorten any home-prefixed segments inside free text, preserving surrounding
- *  punctuation so error strings with embedded paths stay readable. */
-export function shortenEmbeddedPaths(text: string): string {
-	return text
+/** Shorten home-prefixed paths inside free text, preserving surrounding
+ * punctuation so error strings with embedded paths stay readable. */
+export function shortenEmbeddedPaths(text: string, homeDir = os.homedir()): string {
+	const shortenedHome = homeDir.length > 1 ? shortenPath(homeDir, homeDir) : homeDir;
+	const windowsStyle = /^[A-Za-z]:[\\/]/.test(homeDir) || homeDir.startsWith("\\\\");
+	const escapedHome = homeDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const homePattern = new RegExp(
+		`(?<=^|[\\s("'\`\\[])${escapedHome}(?:[\\\\/]|(?=$|[\\s"'(),.;:\\[\\]]))`,
+		windowsStyle ? "gi" : "g",
+	);
+	const textWithShortenedHome =
+		shortenedHome !== homeDir ? text.replace(homePattern, match => shortenPath(match, homeDir)) : text;
+	return textWithShortenedHome
 		.split(" ")
 		.map(segment => {
 			const leading = segment.match(/^[("'`[]*/)?.[0] ?? "";
 			const trailing = segment.match(/[)"'`,.;:\]]*$/)?.[0] ?? "";
 			const end = segment.length - trailing.length;
 			if (leading.length >= end) return segment;
-			return `${leading}${shortenPath(segment.slice(leading.length, end))}${trailing}`;
+			const shortened = shortenPath(segment.slice(leading.length, end), homeDir);
+			const normalized = shortened.startsWith("~")
+				? shortened.replaceAll(path.win32.sep, path.posix.sep)
+				: shortened;
+			return `${leading}${normalized}${trailing}`;
 		})
 		.join(" ");
 }
@@ -858,6 +871,16 @@ export function sanitizeDisplayWarning(text: string): string {
 			.replace(/[\r\n]+/g, " ")
 			.trim(),
 	);
+}
+
+/** Sanitize and bound warning text before showing it in TUI. */
+export function sanitizeDisplayWarnings(warnings: readonly string[]): string[] {
+	const visible = warnings
+		.slice(0, PREVIEW_LIMITS.COLLAPSED_ITEMS)
+		.map(warning => truncateToWidth(sanitizeDisplayWarning(warning), TRUNCATE_LENGTHS.LONG));
+	const hidden = warnings.length - visible.length;
+	if (hidden > 0) visible.push(`… ${hidden} more ${pluralize("warning", hidden)}`);
+	return visible;
 }
 
 export function formatToolWorkingDirectory(workdir: string | undefined, projectDir: string): string | undefined {

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -851,6 +851,15 @@ export function shortenEmbeddedPaths(text: string): string {
 		.join(" ");
 }
 
+/** Sanitize warning text before showing it in TUI, including embedded home paths. */
+export function sanitizeDisplayWarning(text: string): string {
+	return shortenEmbeddedPaths(
+		replaceTabs(sanitizeText(text))
+			.replace(/[\r\n]+/g, " ")
+			.trim(),
+	);
+}
+
 export function formatToolWorkingDirectory(workdir: string | undefined, projectDir: string): string | undefined {
 	if (!workdir) return undefined;
 	const resolvedProjectDir = path.resolve(projectDir);

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -6312,15 +6312,6 @@ describe("advisor", () => {
 			expect(text).toContain("Architecture");
 		});
 
-		it("seeds a visible default advisor (labeled with the role model) when the config is empty", async () => {
-			const uiTheme = await getThemeByName("dark");
-			if (!uiTheme) throw new Error("theme unavailable");
-			setThemeInstance(uiTheme);
-			const overlay = make({ advisors: [] }, { defaultModelLabel: "anthropic/claude-opus" });
-			const text = strip(overlay.render(200));
-			expect(text).toContain("default");
-			expect(text).toContain("anthropic/claude-opus");
-		});
 		it("shows disabled advisors with a dim circle marker and toggles them in the detail editor", async () => {
 			const uiTheme = await getThemeByName("dark");
 			if (!uiTheme) throw new Error("theme unavailable");
@@ -6337,87 +6328,6 @@ describe("advisor", () => {
 			expect(text).toContain("○ Disabled");
 			// The preview of the highlighted (first) advisor shows its enabled status.
 			expect(text).toContain("● on");
-		});
-
-		it("preserves top-level maxNotesPerUpdate while stripping the synthetic default advisor on save", async () => {
-			let savedDoc: WatchdogConfigDoc | undefined;
-			const overlay = new AdvisorConfigOverlayComponent(
-				{} as unknown as TUI,
-				{ ...deps },
-				"project",
-				{ maxNotesPerUpdate: 3, advisors: [] },
-				{
-					...callbacks,
-					save: async (_scope, doc) => {
-						savedDoc = doc;
-					},
-				},
-			);
-			overlay.render(200);
-			// Arrow down 4 times to "Save & apply" (advisor:0, add, shared, scope, save)
-			overlay.handleInput("\x1b[B");
-			overlay.handleInput("\x1b[B");
-			overlay.handleInput("\x1b[B");
-			overlay.handleInput("\x1b[B");
-			overlay.handleInput("\r");
-			await Promise.resolve();
-			expect(savedDoc).toBeDefined();
-			expect(savedDoc?.maxNotesPerUpdate).toBe(3);
-			expect(savedDoc?.advisors).toEqual([]);
-		});
-
-		it("preserves customized default advisor and top-level maxNotesPerUpdate on save", async () => {
-			let savedDoc: WatchdogConfigDoc | undefined;
-			const overlay = new AdvisorConfigOverlayComponent(
-				{} as unknown as TUI,
-				{ ...deps },
-				"project",
-				{ maxNotesPerUpdate: 3, advisors: [{ name: "default", instructions: "custom" }] },
-				{
-					...callbacks,
-					save: async (_scope, doc) => {
-						savedDoc = doc;
-					},
-				},
-			);
-			overlay.render(200);
-			// Arrow down 4 times to "Save & apply" (advisor:0, add, shared, scope, save)
-			overlay.handleInput("\x1b[B");
-			overlay.handleInput("\x1b[B");
-			overlay.handleInput("\x1b[B");
-			overlay.handleInput("\x1b[B");
-			overlay.handleInput("\r");
-			await Promise.resolve();
-			expect(savedDoc).toBeDefined();
-			expect(savedDoc?.maxNotesPerUpdate).toBe(3);
-			expect(savedDoc?.advisors).toEqual([{ name: "default", instructions: "custom" }]);
-		});
-
-		it("preserves top-level instructions while stripping the synthetic default advisor on save", async () => {
-			let savedDoc: WatchdogConfigDoc | undefined;
-			const overlay = new AdvisorConfigOverlayComponent(
-				{} as unknown as TUI,
-				{ ...deps },
-				"project",
-				{ instructions: "baseline rules", advisors: [] },
-				{
-					...callbacks,
-					save: async (_scope, doc) => {
-						savedDoc = doc;
-					},
-				},
-			);
-			overlay.render(200);
-			// Arrow down 4 times to "Save & apply" (advisor:0, add, shared, scope, save)
-			overlay.handleInput("\x1b[B");
-			overlay.handleInput("\x1b[B");
-			overlay.handleInput("\x1b[B");
-			overlay.handleInput("\x1b[B");
-			overlay.handleInput("\r");
-			await Promise.resolve();
-			expect(savedDoc).toBeDefined();
-			expect(savedDoc?.instructions).toBe("baseline rules");
-			expect(savedDoc?.advisors).toEqual([]);
 		});
 	});
 });

--- a/packages/coding-agent/test/advisor/config.test.ts
+++ b/packages/coding-agent/test/advisor/config.test.ts
@@ -83,12 +83,68 @@ describe("discoverAdvisorConfigs", () => {
 		const result = await discoverAdvisorConfigs(tmp, agentDir);
 		expect(result.advisors).toEqual([]);
 		expect(result.sharedInstructions).toBeUndefined();
+		expect(result.warnings).toHaveLength(1);
+		expect(result.warnings[0]).toContain("failed to parse YAML");
+		// Editor reports the same problem class instead of blanking silently.
+		const doc = await loadWatchdogConfigFile(path.join(tmp, "WATCHDOG.yml"));
+		expect(doc.advisors).toEqual([]);
+		expect(doc.warnings).toHaveLength(1);
+		expect(doc.warnings?.[0]).toContain("failed to parse YAML");
 	});
 
 	it("skips a file whose shape fails the schema (advisors must be a list)", async () => {
 		await Bun.write(path.join(tmp, "WATCHDOG.yml"), "advisors: not-an-array");
 		const result = await discoverAdvisorConfigs(tmp, agentDir);
 		expect(result.advisors).toEqual([]);
+		expect(result.warnings).toHaveLength(1);
+		expect(result.warnings[0]).toContain("advisors must be a list");
+		const doc = await loadWatchdogConfigFile(path.join(tmp, "WATCHDOG.yml"));
+		expect(doc.advisors).toEqual([]);
+		expect(doc.warnings).toHaveLength(1);
+		expect(doc.warnings?.[0]).toContain("advisors must be a list");
+	});
+
+	it("reports a non-mapping document in the editor just like discovery does", async () => {
+		const file = path.join(tmp, "WATCHDOG.yml");
+		await Bun.write(file, "- just\n- a\n- list\n");
+
+		const discovered = await discoverAdvisorConfigs(tmp, tmp);
+		expect(discovered.advisors).toEqual([]);
+		expect(discovered.warnings).toHaveLength(1);
+		expect(discovered.warnings[0]).toContain("expected a YAML mapping");
+
+		const doc = await loadWatchdogConfigFile(file);
+		expect(doc.advisors).toEqual([]);
+		expect(doc.warnings).toHaveLength(1);
+		expect(doc.warnings?.[0]).toContain("expected a YAML mapping");
+	});
+
+	it("drops only the malformed entry and reports one warning per problem", async () => {
+		await Bun.write(
+			path.join(tmp, "WATCHDOG.yml"),
+			[
+				"advisors:",
+				"  - name: Good",
+				"  - name: Bad",
+				"    enabled: not-a-boolean",
+				"  - name: Also Bad",
+				"    maxNotesPerUpdate: not-a-number",
+			].join("\n"),
+		);
+		const result = await discoverAdvisorConfigs(tmp, agentDir);
+		expect(result.advisors.map(a => a.name)).toEqual(["Good"]);
+		expect(result.warnings).toHaveLength(2);
+		expect(result.warnings[0]).toContain('"Bad"');
+		expect(result.warnings[1]).toContain('"Also Bad"');
+	});
+
+	it("editor load drops only the malformed entry, like discovery", async () => {
+		const file = path.join(tmp, "WATCHDOG.yml");
+		await Bun.write(file, "advisors:\n  - name: Good\n  - name: Bad\n    enabled: bogus\n");
+		const doc = await loadWatchdogConfigFile(file);
+		expect(doc.advisors.map(a => a.name)).toEqual(["Good"]);
+		expect(doc.warnings).toHaveLength(1);
+		expect(doc.warnings?.[0]).toContain('"Bad"');
 	});
 
 	it("returns an empty roster when no config file exists", async () => {

--- a/packages/coding-agent/test/modes/components/advisor-config.test.ts
+++ b/packages/coding-agent/test/modes/components/advisor-config.test.ts
@@ -1,4 +1,6 @@
 import { beforeAll, describe, expect, it } from "bun:test";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { TUI } from "@oh-my-pi/pi-tui";
 import type { WatchdogConfigDoc } from "../../../src/advisor/config";
 import type { ModelRegistry } from "../../../src/config/model-registry";
@@ -56,7 +58,9 @@ describe("advisor config editor warnings and synthetic default row", () => {
 				loadDoc: () => {
 					pendingLoad = Promise.resolve({
 						advisors: [],
-						warnings: ['/home/user/.omp/WATCHDOG.yml: advisor "Bad" dropped — boom'],
+						warnings: [
+							`${path.join(os.homedir(), ".omp", "WATCHDOG.yml")}: advisor "\x1b[31mBad\tName\x1b[0m" dropped — boom`,
+						],
 					});
 					return pendingLoad;
 				},
@@ -70,7 +74,6 @@ describe("advisor config editor warnings and synthetic default row", () => {
 
 		// Opening the project file shows nothing — the host owns initial warnings.
 		expect(warnings).toEqual([]);
-		expect(overlay.render(100).join("\n")).not.toContain("Config problems");
 
 		for (let i = 0; i < 3; i++) overlay.handleInput("\x1b[B");
 		overlay.handleInput("\r"); // Switch scope to user.
@@ -78,12 +81,13 @@ describe("advisor config editor warnings and synthetic default row", () => {
 		await pendingLoad;
 
 		expect(warnings).toHaveLength(1);
-		expect(warnings[0]).toContain('advisor "Bad" dropped');
+		expect(warnings[0]).toContain('advisor "Bad   Name" dropped');
+		expect(warnings[0]).toContain("~/.omp/WATCHDOG.yml");
+		expect(warnings[0]).not.toContain(path.join(os.homedir(), ".omp", "WATCHDOG.yml"));
 		// The toast is chat-mounted behind the fullscreen overlay, so the warning
 		// must also render inside the editor itself.
 		const frame = overlay.render(100).join("\n");
-		expect(frame).toContain("Config problems");
-		expect(frame).toContain('advisor "Bad" dropped');
+		expect(frame).toContain('advisor "Bad   Name" dropped');
 	});
 
 	it("renders the opening file's warnings inside the overlay without re-notifying", () => {
@@ -104,7 +108,6 @@ describe("advisor config editor warnings and synthetic default row", () => {
 		);
 
 		const frame = overlay.render(100).join("\n");
-		expect(frame).toContain("Config problems");
 		expect(frame).toContain('advisor "Bad" dropped');
 		expect(warnings).toEqual([]);
 	});

--- a/packages/coding-agent/test/modes/components/advisor-config.test.ts
+++ b/packages/coding-agent/test/modes/components/advisor-config.test.ts
@@ -1,0 +1,111 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { TUI } from "@oh-my-pi/pi-tui";
+import type { WatchdogConfigDoc } from "../../../src/advisor/config";
+import type { ModelRegistry } from "../../../src/config/model-registry";
+import { Settings } from "../../../src/config/settings";
+import { AdvisorConfigOverlayComponent } from "../../../src/modes/components/advisor-config";
+import { getThemeByName, setThemeInstance } from "../../../src/modes/theme/theme";
+
+describe("advisor config editor warnings and synthetic default row", () => {
+	let settings: Settings;
+
+	beforeAll(async () => {
+		settings = await Settings.init({ inMemory: true });
+		const theme = await getThemeByName("dark");
+		if (!theme) throw new Error("theme unavailable");
+		setThemeInstance(theme);
+	});
+
+	const buildOverlay = (doc: WatchdogConfigDoc, onSave: (doc: WatchdogConfigDoc) => void) =>
+		new AdvisorConfigOverlayComponent(
+			{} as TUI,
+			{ modelRegistry: {} as ModelRegistry, settings, scopedModels: [], availableToolNames: [] },
+			"project",
+			doc,
+			{
+				loadDoc: async () => ({ advisors: [] }),
+				save: async (_scope, doc) => onSave(doc),
+				close: () => {},
+				requestRender: () => {},
+				notify: () => {},
+			},
+		);
+
+	it("still drops the untouched seeded default row on save", async () => {
+		let saved: WatchdogConfigDoc | undefined;
+		const overlay = buildOverlay({ advisors: [] }, doc => {
+			saved = structuredClone(doc);
+		});
+
+		for (let i = 0; i < 4; i++) overlay.handleInput("\x1b[B");
+		overlay.handleInput("\r"); // Save & apply without touching the seeded row.
+		await Promise.resolve();
+
+		expect(saved?.advisors).toEqual([]);
+	});
+
+	it("surfaces the newly active file's warnings on scope switch, and only there", async () => {
+		const warnings: string[] = [];
+		let pendingLoad: Promise<WatchdogConfigDoc> | undefined;
+		const overlay = new AdvisorConfigOverlayComponent(
+			{} as TUI,
+			{ modelRegistry: {} as ModelRegistry, settings, scopedModels: [], availableToolNames: [] },
+			"project",
+			{ advisors: [{ name: "Reviewer" }] },
+			{
+				loadDoc: () => {
+					pendingLoad = Promise.resolve({
+						advisors: [],
+						warnings: ['/home/user/.omp/WATCHDOG.yml: advisor "Bad" dropped — boom'],
+					});
+					return pendingLoad;
+				},
+				save: async () => {},
+				close: () => {},
+				requestRender: () => {},
+				notify: () => {},
+				warn: message => warnings.push(message),
+			},
+		);
+
+		// Opening the project file shows nothing — the host owns initial warnings.
+		expect(warnings).toEqual([]);
+		expect(overlay.render(100).join("\n")).not.toContain("Config problems");
+
+		for (let i = 0; i < 3; i++) overlay.handleInput("\x1b[B");
+		overlay.handleInput("\r"); // Switch scope to user.
+		// The overlay awaits the same promise; awaiting it here runs after its continuation.
+		await pendingLoad;
+
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain('advisor "Bad" dropped');
+		// The toast is chat-mounted behind the fullscreen overlay, so the warning
+		// must also render inside the editor itself.
+		const frame = overlay.render(100).join("\n");
+		expect(frame).toContain("Config problems");
+		expect(frame).toContain('advisor "Bad" dropped');
+	});
+
+	it("renders the opening file's warnings inside the overlay without re-notifying", () => {
+		const warnings: string[] = [];
+		const overlay = new AdvisorConfigOverlayComponent(
+			{} as TUI,
+			{ modelRegistry: {} as ModelRegistry, settings, scopedModels: [], availableToolNames: [] },
+			"project",
+			{ advisors: [{ name: "Good" }], warnings: ['/repo/WATCHDOG.yml: advisor "Bad" dropped — boom'] },
+			{
+				loadDoc: async () => ({ advisors: [] }),
+				save: async () => {},
+				close: () => {},
+				requestRender: () => {},
+				notify: () => {},
+				warn: message => warnings.push(message),
+			},
+		);
+
+		const frame = overlay.render(100).join("\n");
+		expect(frame).toContain("Config problems");
+		expect(frame).toContain('advisor "Bad" dropped');
+		expect(warnings).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/tools/render-utils.test.ts
+++ b/packages/coding-agent/test/tools/render-utils.test.ts
@@ -15,6 +15,7 @@ import {
 	formatFeedModelBadge,
 	formatScreenshot,
 	sanitizeDisplayLines,
+	sanitizeDisplayWarning,
 	shortenPath,
 	truncateDiffByHunk,
 } from "@oh-my-pi/pi-coding-agent/tools/render-utils";
@@ -524,5 +525,19 @@ describe("sanitizeDisplayLines", () => {
 
 	it("collapses carriage-return progress overwrites to the final segment", () => {
 		expect(sanitizeDisplayLines("50%\r100%")).toEqual(["100%"]);
+	});
+});
+
+describe("sanitizeDisplayWarning", () => {
+	it("strips terminal controls, expands tabs, flattens lines, and shortens home paths", () => {
+		const filePath = path.join(os.homedir(), ".omp", "WATCHDOG.yml");
+		const warning = sanitizeDisplayWarning(`${filePath}: advisor "\x1b[31mBad\tName\x1b[0m\nfollow-up" dropped`);
+
+		expect(warning).toContain("~/.omp/WATCHDOG.yml");
+		expect(warning).toContain('advisor "Bad   Name follow-up" dropped');
+		expect(warning).not.toContain(filePath);
+		expect(warning).not.toContain("\x1b");
+		expect(warning).not.toContain("\t");
+		expect(warning).not.toContain("\n");
 	});
 });

--- a/packages/coding-agent/test/tools/render-utils.test.ts
+++ b/packages/coding-agent/test/tools/render-utils.test.ts
@@ -14,9 +14,13 @@ import {
 	formatParseErrors,
 	formatFeedModelBadge,
 	formatScreenshot,
+	PREVIEW_LIMITS,
 	sanitizeDisplayLines,
 	sanitizeDisplayWarning,
+	sanitizeDisplayWarnings,
+	shortenEmbeddedPaths,
 	shortenPath,
+	TRUNCATE_LENGTHS,
 	truncateDiffByHunk,
 } from "@oh-my-pi/pi-coding-agent/tools/render-utils";
 import {
@@ -539,5 +543,41 @@ describe("sanitizeDisplayWarning", () => {
 		expect(warning).not.toContain("\x1b");
 		expect(warning).not.toContain("\t");
 		expect(warning).not.toContain("\n");
+	});
+});
+
+describe("shortenEmbeddedPaths", () => {
+	it("shortens home paths containing spaces before tokenizing", () => {
+		expect(shortenEmbeddedPaths("/Users/Jane Smith/.omp/WATCHDOG.yml: failed", "/Users/Jane Smith")).toBe(
+			"~/.omp/WATCHDOG.yml: failed",
+		);
+	});
+
+	it("preserves sibling paths outside the home boundary", () => {
+		const home = "/Users/Jane";
+		const sibling = "/Users/Jane2/.omp/WATCHDOG.yml: failed";
+		expect(shortenEmbeddedPaths(sibling, home)).toBe(sibling);
+	});
+
+	it("normalizes shortened Windows paths", () => {
+		const home = String.raw`C:\Users\Jane`;
+		const filePath = String.raw`C:\Users\Jane\projects\demo: failed`;
+		expect(shortenEmbeddedPaths(filePath, home)).toBe("~/projects/demo: failed");
+	});
+});
+
+describe("sanitizeDisplayWarnings", () => {
+	it("caps warning count and reports omitted warnings", () => {
+		const warnings = Array.from({ length: PREVIEW_LIMITS.COLLAPSED_ITEMS + 2 }, (_, index) => `warning-${index}`);
+		const displayed = sanitizeDisplayWarnings(warnings);
+
+		expect(displayed).toHaveLength(PREVIEW_LIMITS.COLLAPSED_ITEMS + 1);
+		expect(displayed.at(-1)).toBe("… 2 more warnings");
+	});
+
+	it("truncates each warning before display", () => {
+		const displayed = sanitizeDisplayWarnings(["warning ".repeat(TRUNCATE_LENGTHS.LONG)]);
+
+		expect(Bun.stringWidth(displayed[0])).toBeLessThanOrEqual(TRUNCATE_LENGTHS.LONG);
 	});
 });


### PR DESCRIPTION
had malformed watchdog, it silently failed, proceed unment
came to idea to let it:
1) fail least possible amount of advisors for unnatended jobs
2) give clear warnings

## what

keep valid advisors available when another entry in `WATCHDOG.yml` is malformed, and show configuration problems where users can see them

- validate advisor entries independently during both discovery and `/advisor configure` loading; identify rejected entries by name or list position
- retain valid entries and valid shared instructions instead of rejecting the entire document because one entry has the wrong type
- report invalid YAML, non-mapping documents, invalid shared instructions, and a non-list `advisors` field
- retain startup warnings until the interactive UI is ready, then display them together
- show the active file's warnings inside the fullscreen editor, including after switching between project and user configuration
- clear load warnings after a successful save; saving writes only valid entries, so skipped malformed entries are not preserved in the saved file

## why

with one valid advisor and another containing `enabled: not-a-boolean`, whole-document validation discarded the entire file. the valid advisor disappeared too, and opening the editor could look like an empty configuration

per-entry validation keeps unaffected advisors usable and explains which entry needs repair. warnings also need to appear inside the editor: a warning attached to the chat UI is hidden while the fullscreen editor is open

unparseable YAML still cannot be recovered entry by entry; those files produce a file-level warning and are skipped

## testing

- included regression cases cover mixed valid/invalid entries, discovery/editor warning parity, invalid YAML and document shape, warnings after scope changes, warnings rendered inside the editor, and saving the untouched synthetic default row
- checks were not rerun during draft preparation; exact earlier commands/results and a contributor-observed behavior scenario remain to be recorded


---

- [x] contributor-written explanation added
- [x] `bun check` passes
- [x] tested locally; exact scenario and result recorded
- [x] CHANGELOG updated with PR link and contributor credit
