### PR TITLE
feat(extensions): add transient context injection for tools and subagents

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -189,6 +189,8 @@ Also exposed:
 - `pi.zod` (Zod-compatible builder backed by omptype)
 - `pi.typebox` (legacy TypeBox-compatible shim)
 - `pi.pi` (package exports)
+- `pi.contextInjectionVersion` (currently `1`; feature-detect before registering context-injection handlers)
+- `pi.pi.resolveToCwd(path, cwd)` (the host's path expansion and working-directory resolution semantics)
 
 ### Message delivery semantics
 
@@ -302,6 +304,8 @@ Cancelable pre-events:
 - `input`
 - `before_agent_start`
 - `before_provider_request` (may replace provider request payload — the replacement is applied by every provider that fires the hook, which is all of them except `devin-agent`, which does not fire it)
+- `before_agent_context` (may return transient model context before each real provider call)
+- `before_subagent_start` (runs in the parent before each child provider call and receives child identity, tools, working directory, and prompt)
 - `after_provider_response`
 - `context`
 - `agent_start` / `agent_end` — agent loop lifecycle notification; `agent_end` remains notification-only
@@ -311,12 +315,25 @@ Cancelable pre-events:
 
 ### Tool lifecycle
 
+- `before_tool_execution` (runs immediately before native execution with an isolated input snapshot; may return informational model context but cannot revise arguments)
 - `tool_call` (pre-exec, may block, or revise the tool's execution `input`; for model-issued calls it fires at arg-prep time in the agent loop, so a revision is revalidated and seen by concurrency scheduling, execution events, the persisted assistant message, and the approval gate alike)
-- `tool_result` (post-exec, may patch content/details/isError)
+- `tool_result` (post-exec, may patch content/details/isError and return informational model context)
 - `tool_execution_start` / `tool_execution_update` / `tool_execution_end` (observability)
 - `tool_approval_requested` / `tool_approval_resolved` (observability; emitted by `wrapper.ts` only when a tool requires approval and an approval handler is registered)
 
 `tool_result` is middleware-style: handlers run in extension order and each sees prior modifications.
+
+### Context injection
+
+`before_tool_execution`, `before_agent_context`, and `before_subagent_start` handlers may return:
+
+```ts
+{ additionalContext: "Current repository policy...", requiredTools: ["read"] }
+```
+
+`tool_result` may return the same fields alongside its existing result edits. `additionalContext` is model-only guidance; `requiredTools` names every enabled tool needed for that guidance to be valid. The host validates tool names when the handler settles and again when context is delivered, so a concurrent tool-set change drops stale guidance.
+
+Context is ordered by extension registration, limited to 64 KiB per collection boundary, and never persisted into the base system prompt. Tool-associated context is stored as an invisible passive message, so it joins the current conversation without starting an extra provider turn. Agent/subagent context is recomputed for each provider call, deduplicated against the current prompt, and discarded after that request. Dedicated context handlers have a five-second timeout and fail open with an extension error.
 
 ### Reliability/runtime signals
 
@@ -802,6 +819,7 @@ Provide `renderCall` / `renderResult` on `registerTool` definitions for custom t
 
 - Runtime actions are unavailable during extension load.
 - `tool_call` errors block execution (fail-closed).
+- Context-injection failures, timeouts, stale session results, and unmet `requiredTools` drop only the proposed context; they do not block the tool or provider call.
 - Command name conflicts with built-ins are skipped with diagnostics.
 - Reserved shortcuts are ignored (`ctrl+c`, `ctrl+d`, `ctrl+z`, `ctrl+k`, `ctrl+p`, `ctrl+l`, `ctrl+o`, `ctrl+t`, `ctrl+g`, `ctrl+q`, `alt+m`, `shift+tab`, `shift+ctrl+p`, `alt+enter`, `escape`, `enter`).
 - Treat `ctx.reload()` as terminal for the current command handler frame.

--- a/docs/skills/authoring-extensions.md
+++ b/docs/skills/authoring-extensions.md
@@ -216,6 +216,19 @@ pi.on("session_stop", async (event) => {
 });
 ```
 
+Use context-injection events when an extension needs to give the model transient guidance without rewriting a tool result or waking an idle session:
+
+```ts
+if (pi.contextInjectionVersion === 1) {
+  pi.on("before_tool_execution", async (event) => ({
+    additionalContext: `Review ${event.toolName} output using the repository policy.`,
+    requiredTools: ["read"],
+  }));
+}
+```
+
+The host caps and validates injected context, rechecks `requiredTools` at delivery, and drops failed or stale injections without blocking execution. `before_agent_context` runs before each provider call; `before_subagent_start` lets a parent supply context for each child provider call.
+
 Full event catalog: see [extension authoring guide](../extensions.md).
 
 ## Extension vs hook — when to use which

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -90,6 +90,7 @@ import type {
 import {
 	ASIDE_MESSAGE_COMMIT,
 	ASIDE_MESSAGE_DISCARD,
+	ASIDE_MESSAGE_WAKE,
 	isSoftToolRequirement,
 	SPECULATIVE_STREAM_SESSION,
 } from "./types";
@@ -1576,10 +1577,21 @@ async function runLoopBody(
 			const lateSteering = signal?.aborted ? [] : (await config.getSteeringMessages?.(signal)) || [];
 			const asideMessages = signal?.aborted ? [] : resolveAsides(await config.getAsideMessages?.());
 			const followUpMessages = signal?.aborted ? [] : (await config.getFollowUpMessages?.(signal)) || [];
-			if (lateSteering.length > 0 || asideMessages.length > 0 || followUpMessages.length > 0) {
-				// Set as pending so the inner loop processes them before stopping.
+			const wakingAsides = asideMessages.filter(
+				message => (message as CommittableAsideMessage)[ASIDE_MESSAGE_WAKE] !== false,
+			);
+			if (lateSteering.length > 0 || wakingAsides.length > 0 || followUpMessages.length > 0) {
+				// Waking work carries every aside into the next turn in arrival order.
 				pendingMessages = [...lateSteering, ...asideMessages, ...followUpMessages];
 				continue;
+			}
+			if (asideMessages.length > 0) {
+				currentContext.messages.push(...asideMessages);
+				newMessages.push(...asideMessages);
+				for (const message of asideMessages) {
+					(message as CommittableAsideMessage)[ASIDE_MESSAGE_COMMIT]?.();
+				}
+				emitInputMessages(stream, asideMessages);
 			}
 
 			// No more messages, exit

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -37,10 +37,13 @@ export const ASIDE_MESSAGE_COMMIT = Symbol("aside-message-commit");
 export const SPECULATIVE_STREAM_SESSION = Symbol("speculative-stream-session");
 /** Called when an aside was drained but the agent loop ended before inserting it. */
 export const ASIDE_MESSAGE_DISCARD = Symbol("aside-message-discard");
+/** False marks an aside as informational context that must not start another model turn. */
+export const ASIDE_MESSAGE_WAKE = Symbol("aside-message-wake");
 
 export type CommittableAsideMessage = AgentMessage & {
 	[ASIDE_MESSAGE_COMMIT]?: () => void;
 	[ASIDE_MESSAGE_DISCARD]?: (error: Error) => void;
+	[ASIDE_MESSAGE_WAKE]?: boolean;
 };
 
 /**

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -18,7 +18,12 @@ import type {
 	SpeculativePhysicalOutcome,
 	ToolCallContext,
 } from "@oh-my-pi/pi-agent-core/types";
-import { ASIDE_MESSAGE_COMMIT, ASIDE_MESSAGE_DISCARD, SPECULATIVE_STREAM_SESSION } from "@oh-my-pi/pi-agent-core/types";
+import {
+	ASIDE_MESSAGE_COMMIT,
+	ASIDE_MESSAGE_DISCARD,
+	ASIDE_MESSAGE_WAKE,
+	SPECULATIVE_STREAM_SESSION,
+} from "@oh-my-pi/pi-agent-core/types";
 import type { AssistantMessage, AssistantMessageEvent, Context, Message, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { createMockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
 import { kCursorExecResolved, setStreamingPartialJson } from "@oh-my-pi/pi-ai/utils/block-symbols";
@@ -2810,6 +2815,45 @@ describe("agentLoop with AgentMessage", () => {
 		for await (const _event of stream) {
 			// Drain the loop.
 		}
+	});
+
+	it("commits passive yield context without starting another provider turn", async () => {
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [] };
+		const mock = createMockModel({ responses: [{ content: ["done"] }] });
+		const passive = createUserMessage("informational context");
+		let committed = 0;
+		Object.defineProperties(passive, {
+			[ASIDE_MESSAGE_WAKE]: { value: false },
+			[ASIDE_MESSAGE_COMMIT]: { value: () => committed++ },
+		});
+		let delivered = false;
+		const events: AgentEvent[] = [];
+		const stream = agentLoop(
+			[createUserMessage("work")],
+			context,
+			{
+				model: mock.model,
+				convertToLlm: identityConverter,
+				onBeforeYield: () => {
+					delivered = true;
+				},
+				getAsideMessages: async () => (delivered ? [() => passive] : []),
+			},
+			undefined,
+			mock.stream,
+		);
+		for await (const event of stream) events.push(event);
+
+		expect(mock.calls).toHaveLength(1);
+		expect(committed).toBe(1);
+		expect(await stream.result()).toEqual(expect.arrayContaining([passive]));
+		expect(events.filter(event => event.type === "turn_start")).toHaveLength(1);
+		const passiveStart = events.findIndex(event => event.type === "message_start" && event.message === passive);
+		const passiveEnd = events.findIndex(event => event.type === "message_end" && event.message === passive);
+		const agentEnd = events.findIndex(event => event.type === "agent_end");
+		expect(passiveStart).toBeGreaterThan(-1);
+		expect(passiveEnd).toBeGreaterThan(passiveStart);
+		expect(agentEnd).toBeGreaterThan(passiveEnd);
 	});
 
 	it("discards a drained aside when the deadline expires before insertion", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -51,6 +51,8 @@
 
 - Enable `tui.mouse` to focus live subagent cards and jump-list rows by clicking them, with a hover highlight on the target; native selection becomes Shift+drag while on ([#11737](https://github.com/can1357/oh-my-pi/pull/11737) by [@H4vC](https://github.com/H4vC)).
 - The pinned `Subagents` block now lists every live agent, collapsed to a few rows with a click expander by default; `display.pinnedAgents` switches it to `full` or `off` ([#11737](https://github.com/can1357/oh-my-pi/pull/11737) by [@H4vC](https://github.com/H4vC)).
+- Extensions can now inject bounded, tool-gated model context around tool execution and at agent/subagent provider boundaries without persisting transient guidance or triggering extra model turns.
+
 - The `remote` compaction method now covers Claude: Anthropic server-side compaction (`compact-2026-01-12` beta) runs behind the existing `compaction.methodOrder` / `compaction.remoteEnabled` gates for first-party Anthropic models, persists its plain-text summary with a native replay payload that later Anthropic turns send back as a `compaction` block, and falls through to the next configured method on failure like OpenAI server compaction.
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Enable `tui.mouse` to focus live subagent cards and jump-list rows by clicking them, with a hover highlight on the target; native selection becomes Shift+drag while on ([#11737](https://github.com/can1357/oh-my-pi/pull/11737) by [@H4vC](https://github.com/H4vC)).
 - The pinned `Subagents` block now lists every live agent, collapsed to a few rows with a click expander by default; `display.pinnedAgents` switches it to `full` or `off` ([#11737](https://github.com/can1357/oh-my-pi/pull/11737) by [@H4vC](https://github.com/H4vC)).
 - Extensions can now inject bounded, tool-gated model context around tool execution and at agent/subagent provider boundaries without persisting transient guidance or triggering extra model turns.
+- Extensions can now inject bounded, tool-gated model context around tool execution and at agent/subagent provider boundaries without persisting transient guidance or triggering extra model turns ([#11887](https://github.com/can1357/oh-my-pi/pull/11887) by [@kirisame-meguru](https://github.com/kirisame-meguru)).
 
 - The `remote` compaction method now covers Claude: Anthropic server-side compaction (`compact-2026-01-12` beta) runs behind the existing `compaction.methodOrder` / `compaction.remoteEnabled` gates for first-party Anthropic models, persists its plain-text summary with a native replay payload that later Anthropic turns send back as a `compaction` block, and falls through to the next configured method on failure like OpenAI server compaction.
 

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -156,6 +156,7 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 	readonly typebox = TypeBox;
 	readonly arktype = type;
 	readonly zod = zod;
+	readonly contextInjectionVersion = 1 as const;
 	readonly flagValues = new Map<string, boolean | string>();
 	readonly pendingProviderRegistrations: Array<{
 		name: string;

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -28,12 +28,16 @@ import type {
 	AssistantThinkingRenderer,
 	BeforeAgentStartEvent,
 	BeforeAgentStartEventResult,
+	BeforeAgentContextEvent,
 	BeforeProviderRequestEvent,
 	BeforeProviderRequestEventResult,
+	BeforeSubagentStartEvent,
+	BeforeToolExecutionEvent,
 	CompactOptions,
 	ComposerShapeDefinition,
 	ContextEvent,
 	ContextEventResult,
+	ContextInjectionResult,
 	ContextUsage,
 	Extension,
 	ExtensionActions,
@@ -75,6 +79,16 @@ import type {
 	UserPythonEventResult,
 } from "./types";
 
+export type ToolContextSinkFactory = (
+	toolCallId: string,
+	toolName: string,
+	signal?: AbortSignal,
+) => (injections: readonly ContextInjectionResult[]) => void;
+
+export interface ToolResultCombinedResult extends ToolResultEventResult {
+	contextInjections?: ContextInjectionResult[];
+}
+
 /** Combined result from all before_agent_start handlers */
 interface BeforeAgentStartCombinedResult {
 	messages?: NonNullable<BeforeAgentStartEventResult["message"]>[];
@@ -85,6 +99,8 @@ export type ExtensionErrorListener = (error: ExtensionError) => void;
 
 export const EXTENSION_HANDLER_TIMEOUT_MS = 30_000;
 let extensionHandlerTimeoutMs = EXTENSION_HANDLER_TIMEOUT_MS;
+const CONTEXT_HANDLER_TIMEOUT_MS = 5_000;
+const MAX_CONTEXT_BYTES = 64 * 1024;
 
 function throwUnsupportedServiceTierAction(): never {
 	throw new Error("This extension host does not support service-tier actions");
@@ -339,6 +355,9 @@ type RunnerEmitEvent = Exclude<
 	| BeforeProviderRequestEvent
 	| AfterProviderResponseEvent
 	| BeforeAgentStartEvent
+	| BeforeToolExecutionEvent
+	| BeforeSubagentStartEvent
+	| BeforeAgentContextEvent
 	| ResourcesDiscoverEvent
 	| InputEvent
 >;
@@ -457,6 +476,7 @@ export class ExtensionRunner {
 	#commandDiagnostics: Array<{ type: string; message: string; path: string }> = [];
 	#toolRegistrationScope = new AsyncLocalStorage<ToolRegistrationScope>();
 	#toolRegistrationBarrier: Promise<void> | undefined;
+	#toolContextSinkFactory: ToolContextSinkFactory = () => () => {};
 	#initialized = false;
 	/**
 	 * Buffer for `credential_disabled` events received via {@link emitCredentialDisabled}
@@ -533,6 +553,18 @@ export class ExtensionRunner {
 	/** Consumes a {@link markToolCallEmitted} marker; true when the loop already emitted. */
 	consumeToolCallEmitted(toolCallId: string, toolName: string): boolean {
 		return this.#emittedToolCalls.delete(`${toolCallId}:${toolName}`);
+	}
+
+	setToolContextSinkFactory(factory: ToolContextSinkFactory): void {
+		this.#toolContextSinkFactory = factory;
+	}
+
+	createToolContextSink(
+		toolCallId: string,
+		toolName: string,
+		signal?: AbortSignal,
+	): (injections: readonly ContextInjectionResult[]) => void {
+		return this.#toolContextSinkFactory(toolCallId, toolName, signal);
 	}
 
 	/**
@@ -1268,10 +1300,6 @@ export class ExtensionRunner {
 		onFailure?: (kind: "timeout" | "error", message: string) => R,
 		outerSignal?: AbortSignal,
 	): Promise<R | undefined> {
-		// `session_stop` carries its own signal on the event; `tool_call` receives
-		// the outer dispatch signal (loop request or wrapper execute) so an abort
-		// while a handler awaits a human dialog cancels the dialog and settles the
-		// gate without executing the underlying tool. Compose whichever apply.
 		const sessionStopSignal =
 			event.type === "session_stop" && "signal" in event && event.signal instanceof AbortSignal
 				? event.signal
@@ -1288,10 +1316,27 @@ export class ExtensionRunner {
 					async (handlerSignal, budget) => {
 						registrationScope.signal = handlerSignal;
 						let result: R | undefined;
+						let handlerEvent = event;
+						if (event.type === "before_tool_execution") {
+							handlerEvent = {
+								...event,
+								input: structuredClone(Reflect.get(event, "input")),
+								signal: handlerSignal,
+							};
+						} else if (event.type === "before_subagent_start" || event.type === "before_agent_context") {
+							handlerEvent = {
+								...event,
+								tools: [...(Reflect.get(event, "tools") as readonly string[])],
+								systemPrompt: [...(Reflect.get(event, "systemPrompt") as readonly string[])],
+								signal: handlerSignal,
+							};
+						} else if (event.type === "tool_result") {
+							handlerEvent = { ...event, signal: handlerSignal };
+						}
 						try {
 							result = await this.#toolRegistrationScope.run(registrationScope, () =>
 								handler(
-									event,
+									handlerEvent,
 									createHandlerContext(ctx, handlerSignal, event.type === "tool_call" ? budget : undefined),
 								),
 							);
@@ -1409,15 +1454,105 @@ export class ExtensionRunner {
 		return result as RunnerEmitResult<TEvent>;
 	}
 
-	async emitToolResult(event: ToolResultEvent): Promise<ToolResultEventResult | undefined> {
+	#validatedContextInjection(
+		value: unknown,
+		ext: Extension,
+		eventType: string,
+		usedBytes: number,
+	): ContextInjectionResult | undefined {
+		if (value === undefined || value === null) return undefined;
+		if (typeof value !== "object" || Array.isArray(value)) {
+			this.emitError({ extensionPath: ext.path, event: eventType, error: "handler returned invalid context" });
+			return undefined;
+		}
+		const additionalContext = Reflect.get(value, "additionalContext");
+		if (additionalContext === undefined) return undefined;
+		if (typeof additionalContext !== "string") {
+			this.emitError({ extensionPath: ext.path, event: eventType, error: "additionalContext must be a string" });
+			return undefined;
+		}
+		if (additionalContext.trim().length === 0) return undefined;
+		const rawRequiredTools = Reflect.get(value, "requiredTools");
+		if (
+			rawRequiredTools !== undefined &&
+			(!Array.isArray(rawRequiredTools) ||
+				rawRequiredTools.some(tool => typeof tool !== "string" || tool.length === 0 || tool.trim() !== tool))
+		) {
+			this.emitError({
+				extensionPath: ext.path,
+				event: eventType,
+				error: "requiredTools must contain canonical names",
+			});
+			return undefined;
+		}
+		if (!this.#initialized) return undefined;
+		const requiredTools = rawRequiredTools as string[] | undefined;
+		const enabledTools = new Set(this.runtime.getActiveTools());
+		if (requiredTools?.some(tool => !enabledTools.has(tool))) return undefined;
+		const contextBytes = Buffer.byteLength(additionalContext, "utf8");
+		if (contextBytes > MAX_CONTEXT_BYTES || usedBytes + contextBytes > MAX_CONTEXT_BYTES) {
+			this.emitError({ extensionPath: ext.path, event: eventType, error: "additionalContext exceeds 64 KiB limit" });
+			return undefined;
+		}
+		return {
+			additionalContext,
+			...(requiredTools ? { requiredTools: [...requiredTools] } : {}),
+		};
+	}
+
+	async #emitContextInjections(
+		event: BeforeToolExecutionEvent | BeforeAgentContextEvent | BeforeSubagentStartEvent,
+	): Promise<ContextInjectionResult[]> {
+		if (!this.hasHandlers(event.type)) return [];
+		const ctx = this.createContext();
+		const injections: ContextInjectionResult[] = [];
+		let usedBytes = 0;
+		for (const ext of this.extensions) {
+			const handlers = ext.handlers.get(event.type);
+			if (!handlers) continue;
+			for (const handler of handlers) {
+				const result = await this.#runHandlerWithTimeout(
+					handler,
+					event,
+					ctx,
+					ext,
+					CONTEXT_HANDLER_TIMEOUT_MS,
+					undefined,
+					event.signal,
+				);
+				const injection = this.#validatedContextInjection(result, ext, event.type, usedBytes);
+				if (!injection) continue;
+				usedBytes += Buffer.byteLength(injection.additionalContext!, "utf8");
+				injections.push(injection);
+			}
+		}
+		return injections;
+	}
+
+	emitBeforeToolExecution(event: BeforeToolExecutionEvent): Promise<ContextInjectionResult[]> {
+		return this.#emitContextInjections(event);
+	}
+
+	emitBeforeAgentContext(event: BeforeAgentContextEvent): Promise<ContextInjectionResult[]> {
+		return this.#emitContextInjections(event);
+	}
+
+	async emitBeforeSubagentStart(event: BeforeSubagentStartEvent): Promise<string[]> {
+		const injections = await this.#emitContextInjections(event);
+		return injections.flatMap(injection => injection.additionalContext ?? []);
+	}
+
+	async emitToolResult(event: ToolResultEvent, signal?: AbortSignal): Promise<ToolResultCombinedResult | undefined> {
+		if (!this.hasHandlers("tool_result")) return undefined;
 		const ctx = this.createContext();
 		const currentEvent: ToolResultEvent = { ...event };
+		const contextInjections: ContextInjectionResult[] = [];
+		let contextBytes = 0;
 		let modified = false;
 
 		for (const ext of this.extensions) {
 			const handlers = ext.handlers.get("tool_result");
-			if (!handlers || handlers.length === 0) continue;
-
+			if (!handlers) continue;
 			for (const handler of handlers) {
 				const handlerResult = (await this.#runHandlerWithTimeout(
 					handler,
@@ -1425,9 +1560,16 @@ export class ExtensionRunner {
 					ctx,
 					ext,
 					extensionHandlerTimeoutMs,
+					undefined,
+					signal,
 				)) as ToolResultEventResult | undefined;
 				if (!handlerResult) continue;
 
+				const injection = this.#validatedContextInjection(handlerResult, ext, "tool_result", contextBytes);
+				if (injection) {
+					contextBytes += Buffer.byteLength(injection.additionalContext!, "utf8");
+					contextInjections.push(injection);
+				}
 				if (handlerResult.content !== undefined) {
 					currentEvent.content = handlerResult.content;
 					modified = true;
@@ -1443,12 +1585,16 @@ export class ExtensionRunner {
 			}
 		}
 
-		if (!modified) return undefined;
-
+		if (!modified && contextInjections.length === 0) return undefined;
 		return {
-			content: currentEvent.content,
-			details: currentEvent.details,
-			isError: currentEvent.isError,
+			...(modified
+				? {
+						content: currentEvent.content,
+						details: currentEvent.details,
+						isError: currentEvent.isError,
+					}
+				: {}),
+			...(contextInjections.length > 0 ? { contextInjections } : {}),
 		};
 	}
 

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -768,6 +768,48 @@ export interface BeforeAgentStartEvent {
 	systemPrompt: string[];
 }
 
+export interface ContextInjectionResult {
+	additionalContext?: string;
+	requiredTools?: readonly string[];
+}
+
+export interface BeforeToolExecutionEvent {
+	type: "before_tool_execution";
+	toolName: string;
+	toolCallId: string;
+	input: Readonly<Record<string, unknown>>;
+	signal?: AbortSignal;
+}
+
+export interface BeforeSubagentStartEvent {
+	type: "before_subagent_start";
+	agentId: string;
+	agent: string;
+	parentAgentId?: string;
+	sessionId: string;
+	cwd: string;
+	tools: readonly string[];
+	restricted: boolean;
+	systemPrompt: readonly string[];
+	signal?: AbortSignal;
+}
+
+export interface BeforeAgentContextEvent {
+	type: "before_agent_context";
+	agentId: string;
+	agent: string;
+	parentAgentId?: string;
+	isSubagent: boolean;
+	sessionId: string;
+	cwd: string;
+	tools: readonly string[];
+	restricted: boolean;
+	systemPrompt: readonly string[];
+	signal?: AbortSignal;
+}
+
+export type SubagentContextProvider = (event: BeforeSubagentStartEvent) => Promise<string[]>;
+
 export type {
 	AgentEndEvent,
 	AgentStartEvent,
@@ -991,6 +1033,7 @@ interface ToolResultEventBase {
 	input: Record<string, unknown>;
 	content: (TextContent | ImageContent)[];
 	isError: boolean;
+	signal?: AbortSignal;
 }
 
 export interface BashToolResultEvent extends ToolResultEventBase {
@@ -1080,6 +1123,9 @@ export type ExtensionEvent =
 	| BeforeProviderRequestEvent
 	| AfterProviderResponseEvent
 	| BeforeAgentStartEvent
+	| BeforeToolExecutionEvent
+	| BeforeSubagentStartEvent
+	| BeforeAgentContextEvent
 	| AgentStartEvent
 	| AgentEndEvent
 	| SessionStopEvent
@@ -1236,6 +1282,7 @@ export interface ExtensionAPI {
 
 	/** Injected pi-coding-agent exports for accessing SDK utilities */
 	pi: typeof PiCodingAgent;
+	readonly contextInjectionVersion: 1;
 
 	// =========================================================================
 	// Event Subscription
@@ -1269,6 +1316,15 @@ export interface ExtensionAPI {
 	): void;
 	on(event: "after_provider_response", handler: ExtensionHandler<AfterProviderResponseEvent>): void;
 	on(event: "before_agent_start", handler: ExtensionHandler<BeforeAgentStartEvent, BeforeAgentStartEventResult>): void;
+	on(
+		event: "before_tool_execution",
+		handler: ExtensionHandler<BeforeToolExecutionEvent, ContextInjectionResult>,
+	): void;
+	on(
+		event: "before_subagent_start",
+		handler: ExtensionHandler<BeforeSubagentStartEvent, ContextInjectionResult>,
+	): void;
+	on(event: "before_agent_context", handler: ExtensionHandler<BeforeAgentContextEvent, ContextInjectionResult>): void;
 	on(event: "agent_start", handler: ExtensionHandler<AgentStartEvent>): void;
 	on(event: "agent_end", handler: ExtensionHandler<AgentEndEvent>): void;
 	on(event: "session_stop", handler: ExtensionHandler<SessionStopEvent, SessionStopEventResult>): void;

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -182,6 +182,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		onUpdate?: AgentToolUpdateCallback<TDetails, TParameters>,
 		context?: AgentToolContext,
 	): Promise<AgentToolResult<TDetails, TParameters>> {
+		const commitContext = this.runner.createToolContextSink(toolCallId, this.tool.name, signal);
 		// The agent loop emits `tool_call` at arg-prep time (session
 		// `beforeToolCall` wiring) so a handler revision lands before concurrency
 		// scheduling and `tool_execution_start`. Consume the marker
@@ -346,6 +347,20 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			}
 		}
 
+		const contextInjections = this.runner.hasHandlers("before_tool_execution")
+			? await this.runner.emitBeforeToolExecution({
+					type: "before_tool_execution",
+					toolName: this.tool.name,
+					toolCallId,
+					input: normalizeToolEventInput(
+						this.tool.name,
+						resolveToolEventInput(this.tool, toolEventArgs(effectiveParams, context)),
+					),
+					signal,
+				})
+			: [];
+		signal?.throwIfAborted();
+
 		// Execute the actual tool
 		let result: AgentToolResult<TDetails, TParameters>;
 		let executionError: Error | undefined;
@@ -368,50 +383,46 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			};
 		}
 
-		// Emit tool_result event - extensions can modify the result and error status
+		const nativeError = !!executionError || result.isError === true;
+		let resultResult;
 		if (this.runner.hasHandlers("tool_result")) {
-			const resultResult = await this.runner.emitToolResult({
-				type: "tool_result",
-				toolName: this.tool.name,
-				toolCallId,
-				input: normalizeToolEventInput(
-					this.tool.name,
-					resolveToolEventInput(this.tool, toolEventArgs(effectiveParams, context)),
-				),
-				content: result.content,
-				details: result.details,
-				isError: !!executionError,
-			});
+			resultResult = await this.runner.emitToolResult(
+				{
+					type: "tool_result",
+					toolName: this.tool.name,
+					toolCallId,
+					input: normalizeToolEventInput(
+						this.tool.name,
+						resolveToolEventInput(this.tool, toolEventArgs(effectiveParams, context)),
+					),
+					content: result.content,
+					details: result.details,
+					isError: nativeError,
+					signal,
+				},
+				signal,
+			);
+			if (resultResult?.contextInjections) contextInjections.push(...resultResult.contextInjections);
+		}
+		commitContext(contextInjections);
 
-			if (resultResult) {
-				const modifiedContent: (TextContent | ImageContent)[] = resultResult.content ?? result.content;
-				const modifiedDetails = (resultResult.details ?? result.details) as TDetails;
-
-				// Effective error state: an explicit handler override wins; otherwise the
-				// original execution outcome stands. This lets a handler rewrite a failed
-				// call's model-visible content/details while keeping it an error, flip a
-				// failure to success, or flag a success as an error.
-				const effectiveError = resultResult.isError ?? !!executionError;
-
-				// Return the (possibly modified) result carrying the error flag rather than
-				// rethrowing the original exception. The agent loop honors
-				// `AgentToolResult.isError` and surfaces it as a tool error on the wire (see
-				// `coerceToolResult` in agent-loop), so replacement failure content reaches
-				// the model while the call remains an error — the original exception text is
-				// no longer forced through, which previously discarded the replacement.
-				return {
-					content: modifiedContent,
-					details: modifiedDetails,
-					providerMetadata: result.providerMetadata,
-					...(effectiveError ? { isError: true } : {}),
-				};
-			}
+		const hasResultEdits =
+			resultResult?.content !== undefined ||
+			resultResult?.details !== undefined ||
+			resultResult?.isError !== undefined;
+		if (resultResult && hasResultEdits) {
+			const modifiedContent: (TextContent | ImageContent)[] = resultResult.content ?? result.content;
+			const modifiedDetails = (resultResult.details ?? result.details) as TDetails;
+			const effectiveError = resultResult.isError ?? nativeError;
+			return {
+				...result,
+				content: modifiedContent,
+				details: modifiedDetails,
+				isError: effectiveError || undefined,
+			};
 		}
 
-		// No extension modification
-		if (executionError) {
-			throw executionError;
-		}
+		if (executionError) throw executionError;
 		return result;
 	}
 }

--- a/packages/coding-agent/src/extensibility/shared-events.ts
+++ b/packages/coding-agent/src/extensibility/shared-events.ts
@@ -342,6 +342,10 @@ export interface ToolResultEventResult {
 	details?: unknown;
 	/** Override isError flag */
 	isError?: boolean;
+	/** Optional model context contributed without changing the tool result. */
+	additionalContext?: string;
+	/** Canonical enabled tool names required for delivering additionalContext. */
+	requiredTools?: readonly string[];
 }
 
 /** Return type for `session_before_switch` handlers */

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -57,6 +57,7 @@ export * from "./task/executor";
 export type * from "./task/types";
 // Tools (detail types and utilities)
 export * from "./tools";
+export { resolveToCwd } from "./tools/path-utils";
 export * from "./utils/github";
 // UI components for extensions
 export {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -115,6 +115,7 @@ import {
 	loadExtensionFromFactory,
 	loadExtensions,
 	type PreparedExtension,
+	type SubagentContextProvider,
 	type RegisteredTool,
 	type ToolDefinition,
 	wrapRegisteredTools,
@@ -594,6 +595,8 @@ export interface CreateAgentSessionOptions {
 	 * "main" for a top-level session / "sub" for a subagent.
 	 */
 	agentName?: string;
+	/** Parent-side lifecycle context provider inherited by this session. */
+	beforeSubagentStart?: SubagentContextProvider;
 	/** Optional shared agent registry for IRC routing. Default: AgentRegistry.global(). */
 	agentRegistry?: AgentRegistry;
 	/**
@@ -1847,6 +1850,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			getHindsightSessionState: () => session?.getHindsightSessionState(),
 			getMnemopiSessionState: () => session?.getMnemopiSessionState(),
 			getAgentId: () => resolvedAgentId,
+			getSubagentContextProvider: () => session.getSubagentContextProvider(),
 			getToolByName: name => session?.getToolByName(name),
 			getToolForEvalBridge: name => session?.getToolForEvalBridge(name),
 			getEvalBridgeToolNames: () => session?.getEvalBridgeToolNames() ?? [],
@@ -3845,6 +3849,10 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			obfuscator,
 			agentId: resolvedAgentId,
 			agentKind,
+			beforeSubagentStart: options.beforeSubagentStart,
+			agentName: resolvedAgentName,
+			parentAgentId: options.parentAgentId,
+			restrictToolNames,
 			providerSessionId: options.providerSessionId,
 			providerPromptCacheKeySource,
 			parentEvalSessionId: options.parentEvalSessionId,

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -33,6 +33,7 @@ import type { LoadedCustomCommand } from "../extensibility/custom-commands";
 import type { CustomTool } from "../extensibility/custom-tools/types";
 import type { ExtensionRunner, PreparedExtension } from "../extensibility/extensions";
 import type { ContextUsage } from "../extensibility/extensions/types";
+import type { SubagentContextProvider } from "../extensibility/extensions/types";
 import type { Skill, SkillWarning } from "../extensibility/skills";
 import type { FileSlashCommand } from "../extensibility/slash-commands";
 import type { SecretObfuscator } from "../secrets/obfuscator";
@@ -272,6 +273,14 @@ export interface AgentSessionConfig {
 	agentId?: string;
 	/** Whether this is a top-level or subagent session. */
 	agentKind?: "main" | "sub";
+	/** Extension context inherited from the owning parent session. */
+	beforeSubagentStart?: SubagentContextProvider;
+	/** Agent definition name used for lifecycle context. */
+	agentName?: string;
+	/** Parent registry identity used for lifecycle context. */
+	parentAgentId?: string;
+	/** Whether the session tool slate is explicitly restricted. */
+	restrictToolNames?: boolean;
 	/** Provider-facing session ID override. */
 	providerSessionId?: string;
 	/** Whether the provider prompt-cache key was explicit or fork-inherited. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -33,7 +33,9 @@ import {
 	type AgentToolResult,
 	type AgentTurnEndContext,
 	AppendOnlyContextManager,
+	ASIDE_MESSAGE_WAKE,
 	type AsideMessage,
+	type CommittableAsideMessage,
 	type BeforeToolCallContext,
 	type BeforeToolCallResult,
 	EventLoopKeepalive,
@@ -54,6 +56,7 @@ import {
 import type {
 	AssistantMessage,
 	CodexCompactionContext,
+	Context,
 	ImageContent,
 	Message,
 	Model,
@@ -145,7 +148,12 @@ import type {
 import { emitSessionShutdownEvent } from "../extensibility/extensions";
 import { ManagedTimers } from "../extensibility/extensions/managed-timers";
 import { createExtensionModelQuery } from "../extensibility/extensions/model-api";
-import type { CompactOptions, ContextUsage } from "../extensibility/extensions/types";
+import type {
+	CompactOptions,
+	ContextInjectionResult,
+	ContextUsage,
+	SubagentContextProvider,
+} from "../extensibility/extensions/types";
 import type { HookCommandContext } from "../extensibility/hooks/types";
 import type { Skill, SkillWarning } from "../extensibility/skills";
 import { expandSlashCommand, type FileSlashCommand } from "../extensibility/slash-commands";
@@ -319,6 +327,7 @@ import {
 	type FileMentionMessage,
 	type HookMessage,
 	INTERRUPTED_THINKING_MESSAGE_TYPE,
+	EXTENSION_TOOL_CONTEXT_MESSAGE_TYPE,
 	type InterruptedThinkingDetails,
 	isEmptyErrorTurn,
 	isUserInterruptAbort,
@@ -388,6 +397,7 @@ import { LoopGuards, type StreamGuardsHost, StreamingEditGuard } from "./stream-
 import { TodoTracker, type TodoTrackerHost } from "./todo-tracker";
 import { TtsrCoordinator, type TtsrCoordinatorHost } from "./ttsr-coordinator";
 
+const EXTENSION_CONTEXT_MAX_BYTES = 64 * 1024;
 const PLAN_MODE_REMINDER_MAX = 3;
 const POST_PROMPT_DRAIN_TIMEOUT_MS = 5_000;
 const EXPERIMENTAL_CONTEXT_REQUIRED_TOOLS: Record<string, true> = {
@@ -697,6 +707,10 @@ export class AgentSession {
 	// Agent identity (registry id) used for IRC routing and job ownership.
 	#agentId: string | undefined;
 	#agentKind: "main" | "sub" = "main";
+	#agentName = "main";
+	#parentAgentId: string | undefined;
+	#restrictToolNames = false;
+	#inheritedSubagentContextProvider: SubagentContextProvider | undefined;
 	#scoutAllowedBySpawnPolicy = true;
 	#providerSessionId: string | undefined;
 	#freshProviderSessionId: string | undefined;
@@ -737,6 +751,11 @@ export class AgentSession {
 	#usagePreflightReadyModel: Model | undefined;
 	#detachUsageBeforeQueueDequeue: (() => void) | undefined;
 	#detachUsageBeforeModelCall: (() => void) | undefined;
+	#detachExtensionBeforeModelCall: (() => void) | undefined;
+	#contextInjectionRuns = new WeakMap<
+		AbortSignal,
+		{ sessionGeneration: number; promise: Promise<ContextInjectionResult[]> }
+	>();
 
 	#transformContext: (messages: AgentMessage[], signal?: AbortSignal) => AgentMessage[] | Promise<AgentMessage[]>;
 	#onPayload: SimpleStreamOptions["onPayload"] | undefined;
@@ -931,38 +950,26 @@ export class AgentSession {
 		if (this.#modeExitDrainSuppressionDepth > 0 || this.#isDisposed || this.isStreaming || !this.#irc.hasPending()) {
 			return;
 		}
-		// A pooled yield contract means a pool turn owns this worker (installed,
-		// dispatching, or dispatch-imminent). Waking here would either emit keyed
-		// yields against its items or re-queue into the deferral path forever, so
-		// leave the records pending until the contract clears.
-		if (this.#workPoolYieldItems.length > 0) {
-			return;
-		}
-		// Session transitions call #disconnectFromAgent() BEFORE `await abort()`, and only bump
-		// #sessionGeneration/clear the IRC queue several awaits later once they reach agent.reset().
-		// A normalization await that resolves in that gap sees an unchanged generation and an idle,
-		// non-streaming session, so without this guard it would wake/fold into the still-old context
-		// and race the transition's own reset — same rationale as #drainStrandedQueuedMessages.
-		if (this.#unsubscribeAgent === undefined) return;
+		if (this.#workPoolYieldItems.length > 0 || this.#unsubscribeAgent === undefined) return;
 		if (this.#canAutoContinueForFollowUp() && this.agent.hasQueuedMessages()) return;
-		// Parked wake records resume alongside ordinary stranded asides; they were
-		// already decided wake-intended at deferral time.
+
 		const records = [...this.#irc.drainDeferredWakes(), ...this.#irc.drainPending()];
+		const passive: AgentMessage[] = [];
+		const waking: AgentMessage[] = [];
+		for (const record of records) {
+			if ((record as CommittableAsideMessage)[ASIDE_MESSAGE_WAKE] === false) passive.push(record);
+			else waking.push(record);
+		}
+		this.#foldStrandedIrcAsidesIntoContext(passive);
+		if (waking.length === 0) return;
 		if (this.#planModeState?.enabled) {
-			// Plan mode: fold stranded IRC asides into context without waking an
-			// autonomous turn. Convergence to ask/resolve stays user-driven.
-			this.#foldStrandedIrcAsidesIntoContext(records);
+			this.#foldStrandedIrcAsidesIntoContext(waking);
 			return;
 		}
 		if (this.#advisors.autoResumeSuppressed) {
-			// A user interrupt is still in effect (clearQueue({ forInterrupt: true }) already
-			// dropped these same records from the agent-core queues to keep the run the user
-			// stopped from auto-resuming). Only a real peer IRC message justifies waking a fresh
-			// turn here; extension/user asides fold into context like the plan-mode branch above,
-			// staying user-driven until the next deliberate prompt.
 			const wake: AgentMessage[] = [];
 			const fold: AgentMessage[] = [];
-			for (const record of records) {
+			for (const record of waking) {
 				if (record.role === "custom" && record.customType === "irc:incoming") wake.push(record);
 				else fold.push(record);
 			}
@@ -970,21 +977,82 @@ export class AgentSession {
 			if (wake.length > 0) this.#wakeForIrc(wake);
 			return;
 		}
-		this.#wakeForIrc(records);
+		this.#wakeForIrc(waking);
 	}
 
-	/** Persist stranded IRC/extension asides into context without starting a turn — shared by the
-	 *  plan-mode branch and the post-interrupt fold branch of #resumeStrandedIrcAsides. All records
-	 *  (custom and non-custom alike) route through emitExternalEvent so message_end both appends to
-	 *  context and notifies event listeners — #persistMessageEnd handles custom-role persistence
-	 *  (sessionManager.appendCustomMessageEntry) from that event, and a displayable custom aside that
-	 *  went stranded mid-stream gets the message_end its sender's rebuild-skip decision expects
-	 *  (extension-ui-controller's #applyCustomMessageDisplay), matching IrcBridge.flushPending(). */
+	/** Persist stranded IRC/extension asides into context without starting a turn. */
 	#foldStrandedIrcAsidesIntoContext(records: AgentMessage[]): void {
 		for (const record of records) {
 			this.agent.emitExternalEvent({ type: "message_start", message: record });
 			this.agent.emitExternalEvent({ type: "message_end", message: record });
 		}
+	}
+
+	#createToolContextSink(
+		toolCallId: string,
+		toolName: string,
+		signal?: AbortSignal,
+	): (injections: readonly ContextInjectionResult[]) => void {
+		const promptGeneration = this.#promptGeneration;
+		const sessionGeneration = this.#sessionGeneration;
+		const sessionId = this.sessionId;
+		const cwd = this.sessionManager.getCwd();
+		let used = false;
+		return injections => {
+			if (used) return;
+			used = true;
+			if (
+				injections.length === 0 ||
+				signal?.aborted ||
+				this.#isDisposed ||
+				this.#abortInProgress ||
+				this.#unsubscribeAgent === undefined ||
+				this.#promptGeneration !== promptGeneration ||
+				this.#sessionGeneration !== sessionGeneration ||
+				this.sessionId !== sessionId ||
+				this.sessionManager.getCwd() !== cwd
+			) {
+				return;
+			}
+			try {
+				const enabledTools = new Set(this.getEnabledToolNames());
+				const parts: string[] = [];
+				let bytes = 0;
+				for (const injection of injections) {
+					const text = injection.additionalContext;
+					if (
+						typeof text !== "string" ||
+						text.trim().length === 0 ||
+						injection.requiredTools?.some(tool => !enabledTools.has(tool))
+					) {
+						continue;
+					}
+					const nextBytes = Buffer.byteLength(text, "utf8");
+					if (bytes + nextBytes > EXTENSION_CONTEXT_MAX_BYTES) continue;
+					bytes += nextBytes;
+					parts.push(text);
+				}
+				if (parts.length === 0) return;
+				const record: CustomMessage = {
+					role: "custom",
+					customType: EXTENSION_TOOL_CONTEXT_MESSAGE_TYPE,
+					content: parts.join("\n\n"),
+					display: false,
+					details: { toolCallId, toolName },
+					attribution: "agent",
+					timestamp: Date.now(),
+				};
+				Object.defineProperty(record, ASIDE_MESSAGE_WAKE, { value: false });
+				if (this.isStreaming) this.#irc.queueAside([record]);
+				else this.#foldStrandedIrcAsidesIntoContext([record]);
+			} catch (error) {
+				this.#extensionRunner?.emitError({
+					extensionPath: "<host>",
+					event: "tool_context",
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		};
 	}
 
 	/** Re-validates a #sessionGeneration snapshot captured before an aside-queueing call's
@@ -1168,12 +1236,6 @@ export class AgentSession {
 			this.#emit(pending);
 			return;
 		}
-
-		// `agent_end` is deferred until the prompt count reaches zero, but it is
-		// emitted immediately before the settle drain schedules work that arrived
-		// after the loop's final queue/aside poll. Such a tail arrival is a real
-		// continuation, not a terminal stop: mark this end non-terminal so
-		// subscribers wait through the queued steer/follow-up or stranded IRC wake.
 		const canDrain =
 			!this.#abortInProgress && this.#unsubscribeAgent !== undefined && this.#modeExitDrainSuppressionDepth === 0;
 		const queuedContinuation =
@@ -1181,7 +1243,8 @@ export class AgentSession {
 			!this.#queuedMessageDrainBlocked &&
 			this.#canAutoContinueForFollowUp() &&
 			this.agent.hasQueuedMessages();
-		const ircContinuation = canDrain && !this.#isDisposed && !this.#planModeState?.enabled && this.#irc.hasPending();
+		const ircContinuation =
+			canDrain && !this.#isDisposed && !this.#planModeState?.enabled && this.#irc.hasPendingWake();
 		this.#emit(queuedContinuation || ircContinuation ? { ...pending, isTerminal: false } : pending);
 	}
 
@@ -1672,6 +1735,16 @@ export class AgentSession {
 		this.#loopGuards = new LoopGuards(streamGuardsHost);
 		this.#agentId = config.agentId;
 		this.#agentKind = config.agentKind ?? "main";
+		this.#extensionRunner?.setToolContextSinkFactory?.((toolCallId, toolName, signal) =>
+			this.#createToolContextSink(toolCallId, toolName, signal),
+		);
+		this.#agentName = config.agentName ?? this.#agentKind;
+		this.#parentAgentId = config.parentAgentId;
+		this.#restrictToolNames = config.restrictToolNames ?? false;
+		this.#inheritedSubagentContextProvider = config.beforeSubagentStart;
+		this.#detachExtensionBeforeModelCall = this.agent.addBeforeModelCall((context, signal) =>
+			this.#injectExtensionModelContext(context, signal),
+		);
 		this.#scoutAllowedBySpawnPolicy = config.scoutAllowedBySpawnPolicy ?? true;
 		this.#providerSessionId = config.providerSessionId;
 		this.#inheritedProviderPromptCacheKey =
@@ -2005,6 +2078,163 @@ export class AgentSession {
 
 	getAgentId(): string | undefined {
 		return this.#agentId;
+	}
+	getSubagentContextProvider(): SubagentContextProvider {
+		if (this.#inheritedSubagentContextProvider) return this.#inheritedSubagentContextProvider;
+		const owner = new WeakRef(this);
+		const sessionId = this.sessionId;
+		const sessionGeneration = this.#sessionGeneration;
+		return async event => {
+			const session = owner.deref();
+			if (
+				!session ||
+				session.#isDisposed ||
+				session.#unsubscribeAgent === undefined ||
+				session.sessionId !== sessionId ||
+				session.#sessionGeneration !== sessionGeneration ||
+				event.signal?.aborted
+			) {
+				return [];
+			}
+			const runner = session.#extensionRunner;
+			if (!runner?.hasHandlers("before_subagent_start")) return [];
+			return runner.emitBeforeSubagentStart({
+				...event,
+				tools: [...event.tools],
+				systemPrompt: [...event.systemPrompt],
+			});
+		};
+	}
+
+	async #injectExtensionModelContext(context: Context, signal?: AbortSignal): Promise<void> {
+		const originalPrompt = [...(context.systemPrompt ?? [])];
+		const sessionGeneration = this.#sessionGeneration;
+		const sessionId = this.sessionId;
+		const cwd = this.sessionManager.getCwd();
+		const runner = this.#extensionRunner;
+		const collectLocal = async (): Promise<ContextInjectionResult[]> => {
+			if (!runner?.hasHandlers("before_agent_context")) return [];
+			return runner.emitBeforeAgentContext({
+				type: "before_agent_context",
+				agentId: this.#agentId ?? (this.#agentKind === "main" ? "Main" : "sub"),
+				agent: this.#agentName,
+				parentAgentId: this.#parentAgentId,
+				isSubagent: this.#agentKind === "sub",
+				sessionId,
+				cwd,
+				tools: [...this.getEnabledToolNames()],
+				restricted: this.#restrictToolNames,
+				systemPrompt: [...originalPrompt],
+				signal,
+			});
+		};
+
+		let localPromise: Promise<ContextInjectionResult[]>;
+		if (signal) {
+			const cached = this.#contextInjectionRuns.get(signal);
+			if (cached?.sessionGeneration === sessionGeneration) {
+				localPromise = cached.promise;
+			} else {
+				localPromise = collectLocal();
+				this.#contextInjectionRuns.set(signal, { sessionGeneration, promise: localPromise });
+			}
+		} else {
+			localPromise = collectLocal();
+		}
+
+		let local: ContextInjectionResult[] = [];
+		try {
+			local = await localPromise;
+		} catch (error) {
+			runner?.emitError({
+				extensionPath: "<host>",
+				event: "before_agent_context",
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+		signal?.throwIfAborted();
+		if (
+			this.#isDisposed ||
+			this.#unsubscribeAgent === undefined ||
+			this.#sessionGeneration !== sessionGeneration ||
+			this.sessionId !== sessionId ||
+			this.sessionManager.getCwd() !== cwd
+		) {
+			return;
+		}
+
+		const eligibleLocal = (): string[] => {
+			const enabled = new Set(this.getEnabledToolNames());
+			return local.flatMap(injection => {
+				const text = injection.additionalContext;
+				return typeof text === "string" &&
+					text.trim().length > 0 &&
+					!injection.requiredTools?.some(tool => !enabled.has(tool))
+					? [text]
+					: [];
+			});
+		};
+		const localForParent = eligibleLocal();
+		let parent: string[] = [];
+		if (this.#inheritedSubagentContextProvider) {
+			const controller = new AbortController();
+			const parentSignal = signal ? AbortSignal.any([signal, controller.signal]) : controller.signal;
+			const parentPromise = Promise.resolve().then(() =>
+				this.#inheritedSubagentContextProvider!({
+					type: "before_subagent_start",
+					agentId: this.#agentId ?? "sub",
+					agent: this.#agentName,
+					parentAgentId: this.#parentAgentId,
+					sessionId,
+					cwd,
+					tools: [...this.getEnabledToolNames()],
+					restricted: this.#restrictToolNames,
+					systemPrompt: [...originalPrompt, ...localForParent],
+					signal: parentSignal,
+				}),
+			);
+			void parentPromise.catch(() => undefined);
+			try {
+				parent = await withTimeout(
+					parentPromise,
+					5_000,
+					"Timed out collecting parent subagent context",
+					parentSignal,
+				);
+			} catch (error) {
+				if (signal?.aborted) signal.throwIfAborted();
+				runner?.emitError({
+					extensionPath: "<parent>",
+					event: "before_subagent_start",
+					error: error instanceof Error ? error.message : String(error),
+				});
+			} finally {
+				controller.abort();
+			}
+		}
+		signal?.throwIfAborted();
+		if (
+			this.#isDisposed ||
+			this.#unsubscribeAgent === undefined ||
+			this.#sessionGeneration !== sessionGeneration ||
+			this.sessionId !== sessionId ||
+			this.sessionManager.getCwd() !== cwd
+		) {
+			return;
+		}
+
+		const injected: string[] = [];
+		const seen = new Set(originalPrompt);
+		let bytes = 0;
+		for (const text of [...eligibleLocal(), ...parent]) {
+			if (typeof text !== "string" || text.trim().length === 0 || seen.has(text)) continue;
+			const nextBytes = Buffer.byteLength(text, "utf8");
+			if (bytes + nextBytes > EXTENSION_CONTEXT_MAX_BYTES) continue;
+			bytes += nextBytes;
+			seen.add(text);
+			injected.push(text);
+		}
+		if (injected.length > 0) context.systemPrompt = [...originalPrompt, ...injected];
 	}
 
 	/** Dequeue the next HARD forced tool choice for the upcoming LLM call, dropping
@@ -4529,6 +4759,8 @@ export class AgentSession {
 		this.#detachUsageBeforeQueueDequeue = undefined;
 		this.#detachUsageBeforeModelCall?.();
 		this.#detachUsageBeforeModelCall = undefined;
+		this.#detachExtensionBeforeModelCall?.();
+		this.#detachExtensionBeforeModelCall = undefined;
 		this.#memory.cancelLocalMemoryStartup();
 		this.#titleGenerationAbortController.abort();
 		this.#abortAutolearnCapture();

--- a/packages/coding-agent/src/session/irc-bridge.ts
+++ b/packages/coding-agent/src/session/irc-bridge.ts
@@ -1,4 +1,9 @@
-import type { Agent, AgentMessage } from "@oh-my-pi/pi-agent-core";
+import {
+	ASIDE_MESSAGE_WAKE,
+	type Agent,
+	type AgentMessage,
+	type CommittableAsideMessage,
+} from "@oh-my-pi/pi-agent-core";
 import { logger, prompt } from "@oh-my-pi/pi-utils";
 import type { Settings } from "../config/settings";
 import { IrcBus, type IrcMessage } from "../irc/bus";
@@ -47,6 +52,13 @@ export class IrcBridge {
 	/** Whether any undelivered IRC record remains queued. */
 	hasPending(): boolean {
 		return this.#interrupts.length > 0 || this.#asides.length > 0 || this.#deferredWakes.length > 0;
+	}
+
+	/** Whether queued records include anything that should start or extend a model turn. */
+	hasPendingWake(): boolean {
+		return [...this.#interrupts, ...this.#asides, ...this.#deferredWakes].some(
+			record => (record as CommittableAsideMessage)[ASIDE_MESSAGE_WAKE] !== false,
+		);
 	}
 
 	/**

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -44,6 +44,7 @@ export const SKILL_PROMPT_MESSAGE_TYPE = "skill-prompt";
 export const LSP_LATE_DIAGNOSTIC_MESSAGE_TYPE = "lsp-late-diagnostic";
 export const BACKGROUND_TAN_DISPATCH_MESSAGE_TYPE = "background-tan-dispatch";
 export const PREWALK_PLAN_MESSAGE_TYPE = "prewalk-plan";
+export const EXTENSION_TOOL_CONTEXT_MESSAGE_TYPE = "extension-tool-context";
 
 /** Custom message type for the transient Vibe mode directive. */
 export const VIBE_MODE_CONTEXT_MESSAGE_TYPE = "vibe-mode-context";

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -558,6 +558,8 @@ export interface ExecutorOptions {
 	 * passes its own `getAgentId()`).
 	 */
 	parentAgentId?: string;
+	/** Parent-bound extension guidance evaluated at each child provider boundary. */
+	beforeSubagentStart?: CreateAgentSessionOptions["beforeSubagentStart"];
 	/**
 	 * Keep the finished subagent addressable in the registry for IRC/revival.
 	 * Defaults to true. Eval bridge agents are programmatic one-shot helpers and
@@ -3542,6 +3544,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				parentMnemopiSessionState: options.parentMnemopiSessionState,
 				parentTaskPrefix: id,
 				parentAgentId: options.parentAgentId,
+				beforeSubagentStart: options.beforeSubagentStart,
 				agentId: id,
 				agentDisplayName: agent.name,
 				agentName: agent.name,

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -163,6 +163,7 @@ export function createPersistedSubagentReviverFactory(
 						: ref.displayName,
 				parentTaskPrefix: ref.id,
 				parentAgentId: ref.parentId,
+				beforeSubagentStart: ctx.session.getSubagentContextProvider?.(),
 				expectedAgentRef: expectedRef,
 				taskDepth,
 				toolNames: revivedToolNames,

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -487,6 +487,7 @@ function buildExecutorOptions(
 		parentTelemetry: session.getTelemetry?.(),
 		parentEvalSessionId: request.shareEvalSession === false ? undefined : (session.getEvalSessionId?.() ?? undefined),
 		parentAgentId: session.getAgentId?.() ?? MAIN_AGENT_ID,
+		beforeSubagentStart: session.getSubagentContextProvider?.(),
 		parentServiceTier: session.getServiceTierByFamily ? (session.getServiceTierByFamily() ?? null) : undefined,
 	};
 }

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -12,6 +12,7 @@ import { EditTool } from "../edit";
 import { checkPythonKernelAvailability } from "../eval/py/kernel";
 import type { ToolPathWithSource } from "../extensibility/custom-tools";
 import type { PreparedExtension } from "../extensibility/extensions/types";
+import type { SubagentContextProvider } from "../extensibility/extensions/types";
 import type { Skill } from "../extensibility/skills";
 import type { GoalModeState, GoalRuntime } from "../goals";
 import { GoalTool } from "../goals/tools/goal-tool";
@@ -284,6 +285,8 @@ export interface ToolSession {
 	getMnemopiSessionState?: () => MnemopiSessionState | undefined;
 	/** Agent identity used for IRC routing. Returns the registry id (e.g. "Main", "AuthLoader"). */
 	getAgentId?: () => string | null;
+	/** Parent-bound extension guidance provider forwarded to spawned child sessions. */
+	getSubagentContextProvider?: () => SubagentContextProvider;
 	/** Look up a registered tool by name (used by the eval js backend's tool bridge). */
 	getToolByName?: (name: string) => AgentTool | undefined;
 	/** Look up an enabled tool through the eval bridge's normal permission pipeline. */

--- a/packages/coding-agent/src/vibe/runtime.ts
+++ b/packages/coding-agent/src/vibe/runtime.ts
@@ -1365,6 +1365,7 @@ export class VibeSessionRegistry {
 			parentTelemetry: session.getTelemetry?.(),
 			parentEvalSessionId: session.getEvalSessionId?.() ?? undefined,
 			parentAgentId: session.getAgentId?.() ?? MAIN_AGENT_ID,
+			beforeSubagentStart: session.getSubagentContextProvider?.(),
 			parentServiceTier: session.getServiceTierByFamily ? (session.getServiceTierByFamily() ?? null) : undefined,
 			keepAlive: true,
 		};

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -1810,4 +1810,77 @@ describe("AgentSession message pipeline", () => {
 		expect(result.assistantMessage.content.some(block => block.type === "toolCall")).toBe(false);
 		expect(result.assistantMessage.content.every(block => block.type !== "toolCall")).toBe(true);
 	});
+	it("consumes inherited subagent context at each real provider boundary without persisting it", async () => {
+		const api = "test-inherited-subagent-context";
+		const contexts: Context[] = [];
+		registerCustomApi(api, (_model, context) => {
+			contexts.push(context);
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				const message = createAssistantMessage("ok");
+				stream.push({ type: "text_delta", contentIndex: 0, delta: "ok", partial: message });
+				stream.push({ type: "done", reason: "stop", message });
+			});
+			return stream;
+		});
+		const model = buildModel({
+			id: "inherited-context-model",
+			name: "Inherited context model",
+			api,
+			provider: "test-provider",
+			baseUrl: "",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 4096,
+			maxTokens: 1024,
+		} as ModelSpec<Api>) as Model<Api>;
+		const providerEvents: Array<Record<string, unknown>> = [];
+		let providerCall = 0;
+		const session = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model,
+					systemPrompt: ["system prompt"],
+					messages: [],
+					tools: [],
+				},
+			}),
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry: createModelRegistryStub() as never,
+			agentKind: "sub",
+			agentName: "ordinary-child",
+			agentId: "Child-1",
+			parentAgentId: "Main",
+			beforeSubagentStart: event => {
+				providerEvents.push(event as unknown as Record<string, unknown>);
+				providerCall++;
+				if (providerCall === 1) return Promise.resolve(["parent fallback"]);
+				if (providerCall === 2) return Promise.resolve([]);
+				throw new Error("parent disposed");
+			},
+		});
+		sessions.push(session);
+
+		await session.sendUserMessage("first");
+		await session.sendUserMessage("second");
+		await session.sendUserMessage("third");
+
+		expect(contexts).toHaveLength(3);
+		expect(contexts[0]?.systemPrompt).toEqual(["system prompt", "parent fallback"]);
+		expect(contexts[1]?.systemPrompt).toEqual(["system prompt"]);
+		expect(contexts[2]?.systemPrompt).toEqual(["system prompt"]);
+		expect(session.agent.state.systemPrompt).toEqual(["system prompt"]);
+		expect(providerEvents).toHaveLength(3);
+		expect(providerEvents[0]).toEqual(
+			expect.objectContaining({
+				agentId: "Child-1",
+				agent: "ordinary-child",
+				parentAgentId: "Main",
+				restricted: false,
+				tools: [],
+			}),
+		);
+	});
 });

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -66,6 +66,7 @@ describe("ExtensionRunner", () => {
 	afterEach(() => {
 		testSetExtensionHandlerTimeoutMs(EXTENSION_HANDLER_TIMEOUT_MS);
 		testSetSessionShutdownHandlerTimeoutMs(SESSION_SHUTDOWN_HANDLER_TIMEOUT_MS);
+		delete (globalThis as Record<string, unknown>).__ompContextGate;
 		tempDir.removeSync();
 	});
 
@@ -1305,6 +1306,152 @@ describe("ExtensionRunner", () => {
 				details: { source: "ext1" },
 				isError: true,
 			});
+		});
+	});
+	describe("informational tool context", () => {
+		function initializeRunner(runner: ExtensionRunner, getActiveTools: () => string[]): void {
+			runner.initialize(
+				{
+					sendMessage: () => {},
+					sendUserMessage: () => {},
+					appendEntry: () => {},
+					setLabel: () => {},
+					getActiveTools,
+					getAllTools: () => [],
+					setActiveTools: async () => {},
+					getCommands: () => [],
+					setModel: async () => false,
+					getThinkingLevel: () => undefined,
+					setThinkingLevel: () => {},
+					getSessionName: () => undefined,
+					setSessionName: async () => {},
+				},
+				{
+					getModel: () => undefined,
+					isIdle: () => true,
+					abort: () => {},
+					hasPendingMessages: () => false,
+					shutdown: () => {},
+					getContextUsage: () => undefined,
+					compact: async () => {},
+					getSystemPrompt: () => [],
+				},
+			);
+		}
+
+		it("commits ordered context while preserving native arguments and error state", async () => {
+			fs.writeFileSync(
+				path.join(extensionsDir, "context-before.ts"),
+				`export default function(pi) {
+					pi.on("before_tool_execution", event => {
+						event.input.value = "attempted mutation";
+						return { additionalContext: "before", requiredTools: ["native"] };
+					});
+				}`,
+			);
+			fs.writeFileSync(
+				path.join(extensionsDir, "context-after.ts"),
+				`export default function(pi) {
+					pi.on("tool_result", event => ({
+						additionalContext: "after",
+						requiredTools: ["native"],
+						content: [...event.content, { type: "text", text: "edited" }],
+					}));
+				}`,
+			);
+			const loaded = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				loaded.extensions,
+				loaded.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			initializeRunner(runner, () => ["native"]);
+			const committed: string[] = [];
+			let sinkFactories = 0;
+			runner.setToolContextSinkFactory(() => {
+				sinkFactories++;
+				let used = false;
+				return injections => {
+					if (used) throw new Error("context sink reused");
+					used = true;
+					committed.push(...injections.map(injection => injection.additionalContext ?? ""));
+				};
+			});
+			const executed: Array<Record<string, unknown>> = [];
+			const tool: AgentTool = {
+				name: "native",
+				label: "Native",
+				description: "native test tool",
+				parameters: Type.Object({ value: Type.String() }),
+				execute: async (_id, params) => {
+					executed.push(params as Record<string, unknown>);
+					return {
+						content: [{ type: "text" as const, text: "native" }],
+						isError: true,
+					};
+				},
+			};
+			const result = await new ExtensionToolWrapper(tool, runner).execute("context-call", {
+				value: "original",
+			} as never);
+
+			expect(executed).toEqual([{ value: "original" }]);
+			expect(committed).toEqual(["before", "after"]);
+			expect(sinkFactories).toBe(1);
+			expect(result.content).toEqual([
+				{ type: "text", text: "native" },
+				{ type: "text", text: "edited" },
+			]);
+			expect(result.isError).toBe(true);
+		});
+
+		it("drops context when a required tool is disabled while the handler is pending", async () => {
+			const gate = Promise.withResolvers<void>();
+			const entered = Promise.withResolvers<void>();
+			(globalThis as Record<string, unknown>).__ompContextGate = {
+				promise: gate.promise,
+				entered: entered.resolve,
+			};
+			fs.writeFileSync(
+				path.join(extensionsDir, "context-gated.ts"),
+				`export default function(pi) {
+					pi.on("before_tool_execution", async () => {
+						const gate = globalThis.__ompContextGate;
+						gate.entered();
+						await gate.promise;
+						return { additionalContext: "stale", requiredTools: ["native"] };
+					});
+				}`,
+			);
+			const loaded = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				loaded.extensions,
+				loaded.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			let active = ["native"];
+			initializeRunner(runner, () => active);
+			const committed: string[] = [];
+			runner.setToolContextSinkFactory(() => injections => {
+				committed.push(...injections.map(injection => injection.additionalContext ?? ""));
+			});
+			const tool: AgentTool = {
+				name: "native",
+				label: "Native",
+				description: "native test tool",
+				parameters: Type.Object({}),
+				execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+			};
+			const execution = new ExtensionToolWrapper(tool, runner).execute("gated-call", {} as never);
+			await entered.promise;
+			active = [];
+			gate.resolve();
+			await execution;
+			expect(committed).toEqual([]);
 		});
 	});
 


### PR DESCRIPTION
## What

Adds a versioned extension context-injection pipeline for tool execution, provider boundaries, and parent-to-subagent guidance. Extensions can return bounded `additionalContext` with `requiredTools`; tool-associated context is delivered as a passive invisible message, while agent/subagent context is applied only to the current provider request.

The runtime isolates handler inputs, preserves native tool results and error state, propagates parent providers through every child creation/revival path, and exposes the host path resolver through the package API for extensions that interpret working-directory-relative inputs.

<!-- Before marking ready, add at least one sentence here in your own words explaining what changed and why, as required by CONTRIBUTING.md. -->

## Why

Previously extension handlers could block or rewrite tool calls/results, but they had no safe side channel for transient model guidance. Reusing ordinary messages would either persist one-shot facts into later prompts or wake an idle session into an unexpected provider call, adding cost and latency. Subagents also had no per-provider-call seam for current parent policy, identity, working directory, or tool availability.

The new delivery path recomputes transient context at the boundary where it is valid, rechecks tool requirements after asynchronous handlers settle, and drops stale session results. Five-second handler budgets and 64 KiB caps prevent a context provider from indefinitely delaying or bloating a model request.

This advances the non-waking model-context delivery primitive requested in #11436; the custom-message activation UI described there remains out of scope.

## Testing

- `bun run check` — passed (TypeScript formatting/lint/typecheck and Rust check).
- `bun test packages/coding-agent/test/extensions-runner.test.ts packages/coding-agent/test/agent-session-message-pipeline.test.ts packages/agent/test/agent-loop.test.ts` — 219 passed, 0 failed.
- Manual smoke: loaded a real extension that registered `before_tool_execution` and `tool_result`, executed a wrapped native tool, and observed ordered `before`/`after` context while the tool result remained unchanged.
- `bun run test` and `bun run ci:test:full` are not green on this Windows host: both report the same 11 failures in untouched `packages/utils` tests covering Bun stdout truncation, cross-platform browser path/mode goldens, process-tree timeout/signal behavior, and logger temp paths.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)