### PR TITLE
Wnmitch/spec followup nits

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 
 - Added opt-in host authorization and exact-once streamed child execution for discard-safe local reads.
+### Fixed
+
+- Speculative stream sessions are now discarded when a hook or argument transform replaces a call's arguments while keeping its ID, instead of releasing deferred work planned from the original code.
 ## [18.1.18] - 2026-09-11
 
 ### Added

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added opt-in host authorization and exact-once streamed child execution for discard-safe local reads.
 ### Fixed
 
-- Speculative stream sessions are now discarded when a hook or argument transform replaces a call's arguments while keeping its ID, instead of releasing deferred work planned from the original code.
+- Speculative stream sessions are now discarded when a hook or argument transform replaces a call's arguments while keeping its ID, instead of releasing deferred work planned from the original code (by [@h4vc](https://github.com/h4vc)).
 ## [18.1.18] - 2026-09-11
 
 ### Added

--- a/packages/agent/src/speculative-execution.ts
+++ b/packages/agent/src/speculative-execution.ts
@@ -222,6 +222,10 @@ class TrackedStreamSession implements ToolSpeculationStreamSession {
 		this.#closed = true;
 		await this.inner.discard(reason);
 	}
+
+	matchesFinalArgs(args: Readonly<Record<string, unknown>>): boolean {
+		return this.inner.matchesFinalArgs?.(args) ?? true;
+	}
 }
 
 /** One streamed assistant response's invisible speculative-operation lifecycle. */
@@ -498,8 +502,20 @@ export class SpeculativeOperationCoordinator {
 				await this.#discardCandidate(candidate, "fingerprint_mismatch", "final tool call changed");
 			}
 		}
-		for (const toolCallId of this.#streamSessions.keys()) {
-			if (!calls.has(toolCallId)) await this.discardStreamSession(toolCallId, "final outer tool call changed");
+		for (const toolCallId of [...this.#streamSessions.keys()]) {
+			const finalCall = calls.get(toolCallId);
+			if (!finalCall) {
+				await this.discardStreamSession(toolCallId, "final outer tool call changed");
+				continue;
+			}
+			// A hook or argument transform may replace arguments while keeping the
+			// ID: the session planned from the original code, so releasing its
+			// deferred work would execute a stale plan.
+			const session = this.#streamSessions.get(toolCallId);
+			const args = finalCall.arguments;
+			if (session && args !== undefined && !session.matchesFinalArgs(args as Record<string, unknown>)) {
+				await this.discardStreamSession(toolCallId, "final outer tool call arguments changed");
+			}
 		}
 	}
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -698,6 +698,14 @@ export interface ToolSpeculationStreamSession {
 	finalize(context: ToolSpeculationAssessmentContext): void | Promise<void>;
 	commit(): void | Promise<void>;
 	discard(reason: string): void | Promise<void>;
+	/**
+	 * Whether the session's streamed plan still authorizes these final
+	 * arguments. The coordinator discards the session when the finalized call
+	 * kept its ID but a hook or argument transform replaced its arguments:
+	 * deferred work planned from the original code must never release.
+	 * Sessions without this predicate are always retained.
+	 */
+	matchesFinalArgs?(args: Readonly<Record<string, unknown>>): boolean;
 }
 
 export interface SpeculativeOperationSink {

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -6304,6 +6304,30 @@ describe("speculative tool execution", () => {
 		expect(SpeculativeOperationCoordinator.take(message)).toBeUndefined();
 		await coordinator.close("test complete");
 	});
+	it("discards stream sessions whose final arguments changed", async () => {
+		const coordinator = new SpeculativeOperationCoordinator({ enabled: true });
+		const discarded: string[] = [];
+		expect(
+			coordinator.registerStreamSession("stream-1", {
+				update() {},
+				finalize() {},
+				commit() {},
+				async discard(reason: string) {
+					discarded.push(reason);
+				},
+				matchesFinalArgs: args => args.code === "original",
+			}),
+		).toBe(true);
+		const callFor = (code: string) =>
+			new Map([["stream-1", { type: "toolCall" as const, id: "stream-1", name: "eval", arguments: { code } }]]);
+		// Unchanged arguments retain the session.
+		await coordinator.reconcileFinalCalls(callFor("original"));
+		expect(discarded).toEqual([]);
+		// A hook rewrite that keeps the ID discards the stale plan.
+		await coordinator.reconcileFinalCalls(callFor("replaced"));
+		expect(discarded).toEqual(["final outer tool call arguments changed"]);
+		await coordinator.close("test complete");
+	});
 
 	it("does not attach a coordinator after its close begins", async () => {
 		const cleanup = Promise.withResolvers<void>();

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,8 +29,8 @@
 - `/move` now checks BTW migration availability before confirming or creating a missing target directory, preventing leftover directories after a refused move.
 - BTW errors now shorten embedded home paths and sanitize control characters and oversized text before display, while retaining original diagnostic errors.
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
-- Speculative reads now open the authorized resolved target while rendering the requested path, so enabling speculation no longer changes read output for symlinks; video targets are declined at authorization.
-- JavaScript speculation now verifies the retained tool-bridge dispatcher and string-coercion intrinsic identities before projecting reads.
+- Speculative reads now open the authorized resolved target while rendering the requested path, so enabling speculation no longer changes read output for symlinks; video targets are declined at authorization (by [@h4vc](https://github.com/h4vc)).
+- JavaScript speculation now verifies the retained tool-bridge dispatcher and string-coercion intrinsic identities before projecting reads (by [@h4vc](https://github.com/h4vc)).
 ### Added
 
 - Added session-local `/btw` history with persistent answers and follow-ups; bare `/btw` reopens history, Escape cancels running answers before closing, and new questions no longer replace an in-progress answer.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,8 @@
 - `/move` now checks BTW migration availability before confirming or creating a missing target directory, preventing leftover directories after a refused move.
 - BTW errors now shorten embedded home paths and sanitize control characters and oversized text before display, while retaining original diagnostic errors.
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+- Speculative reads now open the authorized resolved target while rendering the requested path, so enabling speculation no longer changes read output for symlinks; video targets are declined at authorization.
+- JavaScript speculation now verifies the retained tool-bridge dispatcher and string-coercion intrinsic identities before projecting reads.
 ### Added
 
 - Added session-local `/btw` history with persistent answers and follow-ups; bare `/btw` reopens history, Escape cancels running answers before closing, and new questions no longer replace an in-progress answer.

--- a/packages/coding-agent/src/eval/js/shared/runtime.ts
+++ b/packages/coding-agent/src/eval/js/shared/runtime.ts
@@ -122,6 +122,22 @@ export type ShadowInitialGlobals = Readonly<{
 	JSON: boolean;
 	"JSON.stringify": boolean;
 	"Array.prototype.join": boolean;
+	/**
+	 * Whether `Object.prototype.toString` still has its original identity.
+	 * Implicit string coercion (templates, `+`) dispatches it for objects
+	 * (including arrays containing objects); a retained replacement changes
+	 * authoritative paths while leaving no snapshot trace. Absent only for
+	 * hand-built snapshots, where the intrinsic is assumed intact.
+	 */
+	"Object.prototype.toString"?: boolean;
+	/**
+	 * Whether the prelude tool bridge dispatcher still has its installed
+	 * identity. The proxy resolves `__omp_call_tool__` per call, so the flag
+	 * must track this binding; it also joins the snapshot digest, invalidating
+	 * plans if the installation ever changes under them. Absent only for
+	 * hand-built snapshots, where the bridge is assumed intact.
+	 */
+	__omp_call_tool__?: boolean;
 }>;
 
 export type ShadowSnapshot = Readonly<{
@@ -297,7 +313,9 @@ export class JsRuntime {
 		JSON: globalThis.JSON,
 		stringify: globalThis.JSON.stringify,
 		arrayJoin: Array.prototype.join,
+		objectToString: Object.prototype.toString,
 	};
+	#installedCallTool: unknown;
 
 	snapshotUserGlobals(): ShadowSnapshot {
 		this.#activateGlobals("snapshot user globals");
@@ -324,6 +342,8 @@ export class JsRuntime {
 				currentJSON === this.#initialIntrinsics.JSON &&
 				currentJSON.stringify === this.#initialIntrinsics.stringify,
 			"Array.prototype.join": Array.prototype.join === this.#initialIntrinsics.arrayJoin,
+			"Object.prototype.toString": Object.prototype.toString === this.#initialIntrinsics.objectToString,
+			__omp_call_tool__: (globalThis as Record<string, unknown>).__omp_call_tool__ === this.#installedCallTool,
 		};
 		return Object.freeze({
 			revision: this.#namespaceRevision,
@@ -676,6 +696,14 @@ export class JsRuntime {
 		// onto globalThis. Must run after helpers are in place.
 		indirectEval(JAVASCRIPT_PRELUDE_SOURCE);
 		for (const key of allGlobalKeys) recordGlobalValue(key, this.#globalOwner);
+		// Capture the installed bridge dispatcher for the snapshot identity
+		// flag below. The prelude tool proxy resolves `__omp_call_tool__` per
+		// call, so the flag must track this binding. (Steady-state retained
+		// replacements self-heal: owned-global activation restores the recorded
+		// value before any observation. The `tool` binding itself needs no
+		// flag: the prelude declares it as a lexical const, which shadows any
+		// `globalThis.tool` replacement for bare references.)
+		this.#installedCallTool = (globalThis as Record<string, unknown>).__omp_call_tool__;
 		RUN_HOOK_RESOLVERS.add(this.#runHookResolver);
 		patchStdioOnce();
 	}

--- a/packages/coding-agent/src/eval/js/speculation.ts
+++ b/packages/coding-agent/src/eval/js/speculation.ts
@@ -164,6 +164,21 @@ function isDefinitelyString(expression: ShadowExpression): boolean {
 	);
 }
 
+/**
+ * Whether string-coercing this value may invoke a mutable intrinsic. Literals
+ * of primitive type and intrinsics-gated transform outputs have fixed
+ * conversions; arrays dispatch `Array.prototype.join` and every other opaque
+ * value (snapshots, prior results, property reads, objects) may reach either
+ * `join` or `Object.prototype.toString`. Callers refuse the projection unless
+ * both flags report intact.
+ */
+function coercionNeedsIntrinsics(expression: ShadowExpression): boolean {
+	if (expression.kind === "literal") return false;
+	if (expression.kind === "concat") return expression.items.some(coercionNeedsIntrinsics);
+	if (expression.kind === "transform") return false;
+	return true;
+}
+
 type ProjectionState = {
 	readonly snapshot: Readonly<Record<string, unknown>>;
 	readonly initialGlobals: Readonly<Record<string, boolean>>;
@@ -289,6 +304,15 @@ function projectExpression(expression: Expression, state: ProjectionState): Shad
 				items.push(projected);
 			}
 		}
+		// Implicit template coercion dispatches `Array.prototype.join` for
+		// arrays and `Object.prototype.toString` for other objects; refuse the
+		// projection unless both intrinsics report intact.
+		if (
+			items.some(coercionNeedsIntrinsics) &&
+			(!intrinsicIntact(state, "Array.prototype.join") || !intrinsicIntact(state, "Object.prototype.toString"))
+		) {
+			return undefined;
+		}
 		return { kind: "concat", items };
 	}
 	if (
@@ -298,9 +322,16 @@ function projectExpression(expression: Expression, state: ProjectionState): Shad
 	) {
 		const left = projectExpression(expression.left, state);
 		const right = projectExpression(expression.right, state);
-		return left && right && (isDefinitelyString(left) || isDefinitelyString(right))
-			? { kind: "concat", items: [left, right] }
-			: undefined;
+		if (!(left && right && (isDefinitelyString(left) || isDefinitelyString(right)))) return undefined;
+		// Same implicit coercion as templates: either side may dispatch `join`
+		// or `toString` when it is not a statically fixed primitive.
+		if (
+			(coercionNeedsIntrinsics(left) || coercionNeedsIntrinsics(right)) &&
+			(!intrinsicIntact(state, "Array.prototype.join") || !intrinsicIntact(state, "Object.prototype.toString"))
+		) {
+			return undefined;
+		}
+		return { kind: "concat", items: [left, right] };
 	}
 	if (isCallExpression(expression) && expression.arguments.every(argument => isExpression(argument))) {
 		const args = expression.arguments as Expression[];
@@ -372,6 +403,11 @@ function addOperation(
 	if (!isCallExpression(call)) return undefined;
 	const name = callKind(call);
 	if (name !== "read" || call.arguments.length !== 1) return undefined;
+	// The prelude tool proxy resolves the bridge dispatcher per call, so admit
+	// reads only while the runtime reports its installed identity: a poisoned
+	// installation must degrade to unadmitted dependents, never to speculative
+	// I/O against a bridge the authoritative cell cannot reach.
+	if (!intrinsicIntact(state, "__omp_call_tool__")) return undefined;
 	const argument = call.arguments[0];
 	if (!argument || !isExpression(argument)) return undefined;
 	const projectedArgs = projectExpression(argument, state);

--- a/packages/coding-agent/src/eval/speculation/cell-session.ts
+++ b/packages/coding-agent/src/eval/speculation/cell-session.ts
@@ -150,6 +150,15 @@ export class EvalShadowCellSession implements ToolSpeculationStreamSession {
 			await this.discard("final eval arguments invalidate an admitted speculative operation");
 		}
 	}
+	/**
+	 * Whether the streamed plan still authorizes these final arguments. The
+	 * coordinator re-checks after hook/transform reconciliation and discards
+	 * the session on mismatch, so deferred work planned from replaced code
+	 * never releases. Pure: safe to call any number of times.
+	 */
+	matchesFinalArgs(args: Readonly<Record<string, unknown>>): boolean {
+		return this.#decoder.matchesFinal(args);
+	}
 
 	async #verifyFinalPlan(args: Readonly<Record<string, unknown>>): Promise<boolean> {
 		const { code, language } = args as { code?: unknown; language?: unknown };

--- a/packages/coding-agent/src/speculation/host.ts
+++ b/packages/coding-agent/src/speculation/host.ts
@@ -20,6 +20,7 @@ import { CONVERTIBLE_EXTENSIONS } from "../utils/markit";
 import { type LocalReadSpeculationEvidence, resolveSpeculativeReadTarget, SNAPSHOT_MAX_BYTES } from "../tools/read";
 import { isCpuProfilePath } from "../utils/cpuprofile";
 import { isSampleProfilePath } from "../utils/sample-profile";
+import { isVideoPath } from "../utils/video";
 
 type LocalReadEvidence = {
 	path: string;
@@ -153,7 +154,11 @@ export class CodingAgentSpeculativeExecutionHost implements SpeculativeExecution
 			isCpuProfilePath(resolved) ||
 			CONVERTIBLE_EXTENSIONS.has(path.extname(resolved).toLowerCase()) ||
 			resolved.endsWith(".svg") ||
-			resolved.endsWith(".svgz")
+			resolved.endsWith(".svgz") ||
+			// Video reads render viewer UI through a separate frame pipeline
+			// that has no lexical render path; a symlink could otherwise route
+			// a text file there with target-named output.
+			isVideoPath(resolved)
 		) {
 			return { allowed: false, reason: "local read target is unsafe" };
 		}

--- a/packages/coding-agent/src/tools/read-format.ts
+++ b/packages/coding-agent/src/tools/read-format.ts
@@ -72,8 +72,9 @@ export async function readHashlineHeaderContext(
 	session: ToolSession,
 	absolutePath: string,
 	cwd: string,
+	displayPath?: string,
 ): Promise<HashlineHeaderContext> {
-	return hashlineHeaderContextForText(session, absolutePath, cwd, await Bun.file(absolutePath).text());
+	return hashlineHeaderContextForText(session, absolutePath, cwd, await Bun.file(absolutePath).text(), displayPath);
 }
 
 /**
@@ -86,13 +87,9 @@ export function hashlineHeaderContextForText(
 	absolutePath: string,
 	cwd: string,
 	fullText: string,
+	displayPath: string = formatPathRelativeToCwd(absolutePath, cwd),
 ): HashlineHeaderContext {
-	const context = recordFullHashlineContext(
-		session,
-		absolutePath,
-		formatPathRelativeToCwd(absolutePath, cwd),
-		fullText,
-	);
+	const context = recordFullHashlineContext(session, absolutePath, displayPath, fullText);
 	if (!context) throw new ToolError(`Cannot record hashline snapshot for non-absolute path: ${absolutePath}`);
 	return context;
 }

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -908,15 +908,16 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			});
 			const store = getEditStore(speculativeSession);
 			const speculativeTool = new ReadTool(speculativeSession);
-			// Execute against the requested lexical path so the committed result
-			// renders exactly like an ordinary read (hashline headers, source
-			// metadata). The resolved target above stays a validation gate and
-			// still binds content addressing below; containment and agreement are
-			// enforced by this revalidation plus the capture/execute/commit digest
-			// triple-check, never by the rendered path.
+			// Open the authorized resolved target: between validation above and
+			// the open below the lexical symlink could be retargeted (including
+			// outside the workspace), and later validation can reject the result
+			// but cannot undo that filesystem access. Render the requested
+			// lexical path instead, so the committed result matches an ordinary
+			// read exactly (hashline headers, source metadata).
+			const requestedPath = (context.args as ReadParams).path;
 			const result = await speculativeTool.#executeInner(
 				context.toolCall.id,
-				{ ...(context.args as ReadParams) },
+				{ ...(context.args as ReadParams), path: absolutePath },
 				signal,
 				undefined,
 				undefined,
@@ -926,6 +927,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				() => {
 					throw new Error("Conflict-aware reads require authoritative execution");
 				},
+				path.resolve(this.session.cwd, requestedPath),
 			);
 			const snapshotHash = store.headHash(absolutePath);
 			if (!signal.aborted && !execution.discarded && snapshotHash) {
@@ -1513,6 +1515,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		_toolContext?: AgentToolContext,
 		onBufferedFile?: (normalizedText: string) => void,
 		onConflictMarkers?: () => void,
+		lexicalAbsolutePath?: string,
 	): Promise<AgentToolResult<ReadToolDetails>> {
 		let { path: readPath } = params;
 		if (readPath.startsWith("file://")) {
@@ -1738,6 +1741,12 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				throw error;
 			}
 		}
+		// Speculative reads open the authorized resolved target (absolutePath)
+		// but must render the requested lexical path exactly like an ordinary
+		// read. All display derivations below use this; filesystem access keeps
+		// using absolutePath. Ordinary callers pass no lexical path, so this
+		// is identical to absolutePath for them.
+		const renderAbsolutePath = lexicalAbsolutePath ?? absolutePath;
 
 		if (isDirectory) {
 			if (question !== undefined) throw new ToolError(IMAGE_QUESTION_SELECTOR_ERROR);
@@ -1773,7 +1782,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		const imageMetadata = await readImageMetadata(absolutePath);
 		const mimeType = imageMetadata?.mimeType;
 		const ext = path.extname(absolutePath).toLowerCase();
-		const resolvedDisplayPath = formatPathRelativeToCwd(absolutePath, this.session.cwd);
+		const resolvedDisplayPath = formatPathRelativeToCwd(renderAbsolutePath, this.session.cwd);
 		const shouldConvertWithMarkit = CONVERTIBLE_EXTENSIONS.has(ext);
 
 		// Profiler reports (macOS `sample` call trees, V8 `.cpuprofile` JSON):
@@ -1889,14 +1898,14 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 					? isProbablyBinaryHeader(wholeFileBytes.subarray(0, BINARY_SNIFF_BYTES))
 					: await isProbablyBinary(absolutePath));
 			if (looksBinary) {
-				return toolResult<ReadToolDetails>({ resolvedPath: absolutePath, suffixResolution })
+				return toolResult<ReadToolDetails>({ resolvedPath: renderAbsolutePath, suffixResolution })
 					.text(
 						prependSuffixResolutionNotice(
 							`[Cannot read binary file '${resolvedDisplayPath}' (${formatBytes(fileSize)}); not valid UTF-8 text. Use ':raw' to read bytes verbatim.]`,
 							suffixResolution,
 						),
 					)
-					.sourcePath(absolutePath)
+					.sourcePath(renderAbsolutePath)
 					.done();
 			}
 			// Decode only what survived the sniff.
@@ -1916,6 +1925,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 						renderedSummary.elidedRanges,
 						renderedSummary.elidedLines,
 					);
+					const summaryDisplayPath = formatPathRelativeToCwd(renderAbsolutePath, this.session.cwd);
 					const summaryHashContext = displayMode.hashLines
 						? buffered
 							? hashlineHeaderContextForText(
@@ -1923,8 +1933,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 									absolutePath,
 									this.session.cwd,
 									buffered.normalizedText,
+									summaryDisplayPath,
 								)
-							: await readHashlineHeaderContext(this.session, absolutePath, this.session.cwd)
+							: await readHashlineHeaderContext(this.session, absolutePath, this.session.cwd, summaryDisplayPath)
 						: undefined;
 					const bodyText = footer ? `${renderedSummary.text}\n\n${footer}` : renderedSummary.text;
 					const modelText = prependHashlineHeader(bodyText, summaryHashContext);
@@ -1944,7 +1955,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 						},
 					};
 
-					sourcePath = absolutePath;
+					sourcePath = renderAbsolutePath;
 					content = [{ type: "text", text: modelText }];
 				}
 			}
@@ -2059,7 +2070,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 							totalFileLines === 0
 								? "The file is empty."
 								: `Use :1 to read from the start, or :${totalFileLines} to read the last line.`;
-						return toolResult<ReadToolDetails>({ resolvedPath: absolutePath, suffixResolution })
+						return toolResult<ReadToolDetails>({ resolvedPath: renderAbsolutePath, suffixResolution })
 							.text(
 								`Line ${requestedStart + 1} is beyond end of file (${totalFileLines} lines total). ${suggestion}`,
 							)
@@ -2147,7 +2158,10 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 									)
 								: getEditStore(this.session).recordSnapshotFile(absolutePath);
 						if (tag) {
-							hashContext = hashlineHeaderContext(formatPathRelativeToCwd(absolutePath, this.session.cwd), tag);
+							hashContext = hashlineHeaderContext(
+								formatPathRelativeToCwd(renderAbsolutePath, this.session.cwd),
+								tag,
+							);
 						}
 					}
 
@@ -2217,7 +2231,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 							)}, exceeds ${formatBytes(maxBytesForRead)} limit. Unable to display a valid UTF-8 snippet.]`;
 						}
 						details = { truncation };
-						sourcePath = absolutePath;
+						sourcePath = renderAbsolutePath;
 						truncationInfo = {
 							result: truncation,
 							options: {
@@ -2237,7 +2251,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 							)}`;
 						}
 						details = { truncation };
-						sourcePath = absolutePath;
+						sourcePath = renderAbsolutePath;
 						truncationInfo = {
 							result: truncation,
 							options: {
@@ -2255,12 +2269,12 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 							? `\n\n[${totalFileLines - (startLine + userLimitedLines)} more lines in file. Use :${nextOffset} to continue]`
 							: `\n\n[More lines in file (${formatBytes(fileSize)} total; not scanned to EOF). Use :${nextOffset} to continue]`;
 						details = {};
-						sourcePath = absolutePath;
+						sourcePath = renderAbsolutePath;
 					} else {
 						// No truncation, no user limit exceeded
 						outputText = formatBracketAwareText() ?? formatText(truncation.content, startLineDisplay);
 						details = {};
-						sourcePath = absolutePath;
+						sourcePath = renderAbsolutePath;
 					}
 					if (reachedEof) details.totalLines = totalFileLines;
 

--- a/packages/coding-agent/test/eval/js-shadow-projection.test.ts
+++ b/packages/coding-agent/test/eval/js-shadow-projection.test.ts
@@ -377,4 +377,73 @@ tool.read({ path: selected });
 		expect(control.barrier).toBeUndefined();
 		expect(control.operations).toHaveLength(1);
 	});
+	it("rejects tool reads when a retained cell replaced the bridge dispatcher", async () => {
+		const intact = {
+			String: true,
+			JSON: true,
+			"JSON.stringify": true,
+			"Array.prototype.join": true,
+			"Object.prototype.toString": true,
+			__omp_call_tool__: true,
+		};
+		const control = await projectJavaScriptShadowPlan('await tool.read({ path: "note.txt" })', {
+			snapshot: {},
+			initialGlobals: intact,
+		});
+		expect(control.barrier).toBeUndefined();
+		expect(control.operations).toHaveLength(1);
+		// The prelude tool proxy resolves `__omp_call_tool__` per call, so a
+		// poisoned installation must refuse admission even though the
+		// syntactic `tool.read` match still looks intact.
+		const spoofed = await projectJavaScriptShadowPlan('await tool.read({ path: "note.txt" })', {
+			snapshot: {},
+			initialGlobals: { ...intact, __omp_call_tool__: false },
+		});
+		expect(spoofed.operations).toEqual([]);
+		expect(spoofed.barrier).toBeDefined();
+	});
+	it("rejects implicit coercion when retained cells replaced join or toString", async () => {
+		const intact = {
+			String: true,
+			JSON: true,
+			"JSON.stringify": true,
+			"Array.prototype.join": true,
+			"Object.prototype.toString": true,
+			__omp_call_tool__: true,
+		};
+		// Pristine realm: array templates, snapshot templates, and plus-concat
+		// all project from identical host/authoritative conversions.
+		for (const code of [
+			'await tool.read({ path: `${["secret.txt"]}` })',
+			"await tool.read({ path: `${name}.txt` })",
+			'await tool.read({ path: ["secret"] + ".txt" })',
+		]) {
+			const plan = await projectJavaScriptShadowPlan(code, {
+				snapshot: { name: "secret" },
+				initialGlobals: intact,
+			});
+			expect(plan.barrier).toBeUndefined();
+			expect(plan.operations).toHaveLength(1);
+		}
+		// A replaced join changes what array coercions produce.
+		for (const code of [
+			'await tool.read({ path: `${["secret.txt"]}` })',
+			'await tool.read({ path: ["secret"] + ".txt" })',
+		]) {
+			const plan = await projectJavaScriptShadowPlan(code, {
+				snapshot: {},
+				initialGlobals: { ...intact, "Array.prototype.join": false },
+			});
+			expect(plan.operations).toEqual([]);
+			expect(plan.barrier).toBeDefined();
+		}
+		// Opaque snapshot values may reach `toString` (directly, or through
+		// array elements), so they refuse without its flag too.
+		const spoofed = await projectJavaScriptShadowPlan("await tool.read({ path: `${name}.txt` })", {
+			snapshot: { name: "secret" },
+			initialGlobals: { ...intact, "Object.prototype.toString": false },
+		});
+		expect(spoofed.operations).toEqual([]);
+		expect(spoofed.barrier).toBeDefined();
+	});
 });

--- a/packages/coding-agent/test/eval/runtime-global-dispose.test.ts
+++ b/packages/coding-agent/test/eval/runtime-global-dispose.test.ts
@@ -93,6 +93,8 @@ describe("JsRuntime global disposal", () => {
 					JSON: true,
 					"JSON.stringify": true,
 					"Array.prototype.join": true,
+					"Object.prototype.toString": true,
+					__omp_call_tool__: true,
 				},
 			});
 
@@ -147,6 +149,33 @@ describe("JsRuntime global disposal", () => {
 			expect(shadowSnapshotDigest(after)).not.toBe(before);
 		} finally {
 			globals.String = genuineString;
+			runtime.dispose();
+		}
+	});
+	it("reports the installed bridge dispatcher identity in snapshots", async () => {
+		const runtime = new JsRuntime({ initialCwd: process.cwd(), sessionId: "shadow-call-tool" });
+		try {
+			// The dispatcher is an owned global installed by every runtime, so
+			// the identity flag is always present; the exact-shape assertion
+			// above pins the full key set.
+			expect(runtime.snapshotUserGlobals().initialGlobals).toMatchObject({ __omp_call_tool__: true });
+		} finally {
+			runtime.dispose();
+		}
+	});
+	it("changes the snapshot digest when Object.prototype.toString is replaced", async () => {
+		const runtime = new JsRuntime({ initialCwd: process.cwd(), sessionId: "shadow-tostring" });
+		const genuineToString = Object.prototype.toString;
+		try {
+			const before = shadowSnapshotDigest(runtime.snapshotUserGlobals());
+			Object.prototype.toString = function toString() {
+				return "spoofed";
+			};
+			const after = runtime.snapshotUserGlobals();
+			expect(after.initialGlobals).toMatchObject({ "Object.prototype.toString": false });
+			expect(shadowSnapshotDigest(after)).not.toBe(before);
+		} finally {
+			Object.prototype.toString = genuineToString;
 			runtime.dispose();
 		}
 	});

--- a/packages/coding-agent/test/read-speculation.test.ts
+++ b/packages/coding-agent/test/read-speculation.test.ts
@@ -196,6 +196,17 @@ describe("read speculation assessment", () => {
 			"";
 		expect(text).toContain("link.txt");
 		expect(text).not.toContain("real.txt");
+		// The committed result must be byte-identical to an ordinary read of
+		// the same path: any missed render site breaks this equality.
+		const ordinary = await new ReadTool(createSession(testDir)).execute("ordinary-link-read", args);
+		const ordinaryText =
+			ordinary?.content?.find((entry): entry is { type: "text"; text: string } => entry.type === "text")?.text ?? "";
+		expect(text).toBe(ordinaryText);
+		const metaOf = (result: unknown) =>
+			(result as { details?: { meta?: { source?: { type?: string; value?: unknown } } } } | undefined)?.details
+				?.meta;
+		expect(String(metaOf(committed)?.source?.value ?? "")).toContain("link.txt");
+		expect(metaOf(committed)?.source).toEqual(metaOf(ordinary)?.source);
 	});
 
 	it("defers conflict-aware reads without mutating live conflict history", async () => {


### PR DESCRIPTION
What

Follow-up to #9732 addressing the four post-merge Codex review nits: the coordinator now discards stream sessions when a
hook or argument transform replaces a call's arguments while keeping its ID (new matchesFinalArgs predicate, implemented
by the eval shadow cell); speculative reads open the authorized resolved target again but render the requested lexical
path, so committed output is byte-identical to an ordinary read (plus video targets are now declined at authorization);
and JS speculation verifies the retained tool-bridge dispatcher identity and string-coercion intrinsic identities
(__omp_call_tool__, Object.prototype.toString) before projecting reads.

Why

Post-merge review (review 5187686857) on #9732 found four real gaps: stale-plan release on args rewrite, a symlink
resolve→open TOCTOU my own lexical-path fix had opened, an ungated bridge dispatcher, and implicit template/+ coercion
bypassing the join-identity flag.

Testing

Focused suites: 122 agent tests + 78 coding-agent speculation tests green; tsgo --noEmit clean on both packages; oxfmt
applied. Every new regression test fails pre-fix and passes post-fix (verified by revert-and-rerun for each).