### PR TITLE
fix(yield): reset cumulative schema-retry budget on valid yield, recover JSON primitives

### DIFF
--- a/packages/coding-agent/src/tools/yield.ts
+++ b/packages/coding-agent/src/tools/yield.ts
@@ -104,14 +104,16 @@ function parseYieldType(value: unknown): string | string[] | undefined {
 	if (isYieldType(value)) return value;
 	throw new Error("type must be a string or non-empty array of strings");
 }
-/** Parse a `{`/`[`-leading JSON string; undefined on non-container or parse failure. */
-function parseJsonContainerString(value: string): unknown {
-	const trimmed = value.trim();
-	if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) return undefined;
+/** Parse any JSON-encoded string value (`"correct"`, `42`, `{"n":4}` …).
+ * Returns a `{parsed:true,value}` sentinel — never `undefined`-as-failure —
+ * so decoded `null`/`false` stay distinguishable from a parse error.
+ * Runs only after raw validation already failed, and the caller adopts the
+ * value only if it revalidates. */
+function parseJsonEncodedValue(value: string): { parsed: true; value: unknown } | { parsed: false } {
 	try {
-		return JSON.parse(trimmed);
+		return { parsed: true, value: JSON.parse(value) };
 	} catch {
-		return undefined;
+		return { parsed: false };
 	}
 }
 
@@ -429,6 +431,7 @@ export class YieldTool implements AgentTool<TSchema, YieldDetails> {
 
 		const status = errorMessage !== undefined ? "aborted" : "success";
 		let schemaValidationOverridden = false;
+		let schemaValidationFailureCount = 0;
 		// Unknown incremental labels are a hard contract mismatch with the closed caller
 		// schema. Reject before the last-turn short-circuit too: `type: ["findings"], result: {}`
 		// would otherwise be accepted as a typed last-turn incremental yield, then a sibling
@@ -469,12 +472,13 @@ export class YieldTool implements AgentTool<TSchema, YieldDetails> {
 				// Lossless recovery: a JSON-encoded payload string parses to exactly
 				// the intended value (executor finalization already parses terminal
 				// yields the same way). Never the reverse — stringifying objects to
-				// fit string-typed fields is silent corruption.
-				const parsed = parseJsonContainerString(data);
-				if (parsed !== undefined) {
-					const revalidated = validateData(parsed);
+				// fit string-typed fields is silent corruption. The sentinel keeps
+				// decoded `null`/`false` distinct from a parse error.
+				const decoded = parseJsonEncodedValue(data);
+				if (decoded.parsed) {
+					const revalidated = validateData(decoded.value);
 					if (revalidated === undefined || revalidated.success) {
-						data = parsed;
+						data = decoded.value;
 						sectionFailure = revalidated;
 					}
 				}
@@ -492,7 +496,15 @@ export class YieldTool implements AgentTool<TSchema, YieldDetails> {
 						`${scope} does not match schema: ${formatAllValidationIssues(sectionFailure.issues)}.${retryHint}`,
 					);
 				}
+				// Budget exhausted: capture the count for the message, accept, and
+				// reset so the next independent submission starts fresh.
+				schemaValidationFailureCount = this.#schemaValidationFailures;
+				this.#schemaValidationFailures = 0;
 				schemaValidationOverridden = true;
+			} else {
+				// Schema-valid submission: the documented budget is consecutive,
+				// so a success resets it for the next independent section.
+				this.#schemaValidationFailures = 0;
 			}
 		}
 
@@ -515,7 +527,7 @@ export class YieldTool implements AgentTool<TSchema, YieldDetails> {
 						? `Item ${completedWorkPoolItem.index} submitted. All workpool items are complete; ending this turn.`
 						: `Item ${completedWorkPoolItem.index} submitted. Remaining item(s): ${remainingWorkPoolItems.map(item => item.index).join(", ")}.`
 					: schemaValidationOverridden
-						? `Result submitted (schema validation overridden after ${this.#schemaValidationFailures} failed attempt(s)).`
+						? `Result submitted (schema validation overridden after ${schemaValidationFailureCount} failed attempt(s)).`
 						: "Result submitted.";
 		return {
 			content: [{ type: "text", text: responseText }],

--- a/packages/coding-agent/test/tools/yield.test.ts
+++ b/packages/coding-agent/test/tools/yield.test.ts
@@ -1423,6 +1423,112 @@ describe("YieldTool", () => {
 		});
 	});
 
+	it("resets the schema-retry budget after a schema-valid incremental section", async () => {
+		// Reproduces the RolesFallbacksReview incident: two malformed findings
+		// must not exhaust the verdict section's budget when a valid section
+		// lands in between. Incremental sections stay nonterminal, so the
+		// counter reset is observable across submissions on one tool instance.
+		const tool = new YieldTool(
+			createSession({
+				outputSchema: {
+					properties: {
+						overall_correctness: { enum: ["correct", "incorrect"] },
+						explanation: { type: "string" },
+						confidence: { type: "number" },
+					},
+					optionalProperties: {
+						findings: {
+							elements: { properties: { title: { type: "string" }, body: { type: "string" } } },
+						},
+					},
+				},
+			}),
+		);
+		const finding = { title: "bug", body: "details" };
+		// Two malformed findings: bare string, then double-encoded wrapper.
+		await expect(
+			tool.execute("call-reset-bad-1", { type: ["findings"], data: "just text" } as never),
+		).rejects.toThrow(/Section "findings" does not match schema.*2 retry attempt\(s\) remain/);
+		await expect(
+			tool.execute("call-reset-bad-2", {
+				type: ["findings"],
+				data: JSON.stringify({ findings: [finding] }),
+			} as never),
+		).rejects.toThrow(/Section "findings" does not match schema.*1 retry attempt\(s\) remain/);
+		// One valid finding: budget resets to full.
+		const ok = await tool.execute("call-reset-good", { type: ["findings"], data: finding } as never);
+		expect(ok.details?.data).toEqual(finding);
+		// Three invalid verdicts must ALL reject again — the earlier two
+		// failures no longer count against this independent section.
+		await expect(
+			tool.execute("call-reset-v1", { type: ["overall_correctness"], data: "Correct" } as never),
+		).rejects.toThrow(/2 retry attempt\(s\) remain/);
+		await expect(
+			tool.execute("call-reset-v2", { type: ["overall_correctness"], data: "correct." } as never),
+		).rejects.toThrow(/1 retry attempt\(s\) remain/);
+		await expect(
+			tool.execute("call-reset-v3", { type: ["overall_correctness"], data: "approved" } as never),
+		).rejects.toThrow(/final retry/);
+		const override = await tool.execute("call-reset-v4", {
+			type: ["overall_correctness"],
+			data: "still-wrong",
+		} as never);
+		expect(override.details?.schemaOverridden).toBe(true);
+		expect(override.content).toEqual([
+			{ type: "text", text: "Result submitted (schema validation overridden after 4 failed attempt(s))." },
+		]);
+	});
+
+	it("recovers double-encoded JSON primitives only when raw validation fails", async () => {
+		const tool = new YieldTool(
+			createSession({
+				outputSchema: {
+					properties: {
+						overall_correctness: { enum: ["correct", "incorrect"] },
+						verdict_count: { type: "number" },
+					},
+				},
+			}),
+		);
+		// Double-encoded enum: raw `"correct"` (with quotes) fails the enum,
+		// decoded `correct` validates — adopted without spending retries twice.
+		const recovered = await tool.execute("call-prim-enum", {
+			type: ["overall_correctness"],
+			data: '"correct"',
+		} as never);
+		expect(recovered.details?.data).toBe("correct");
+		expect(recovered.content).toEqual([{ type: "text", text: "Result submitted." }]);
+		// Double-encoded number on its own label.
+		const recoveredNum = await tool.execute("call-prim-num", {
+			type: ["verdict_count"],
+			data: "42",
+		} as never);
+		expect(recoveredNum.details?.data).toBe(42);
+		// Decoded-but-still-invalid stays rejected: `"still-wrong"` parses to
+		// a string that still misses the enum.
+		await expect(
+			tool.execute("call-prim-bad", { type: ["overall_correctness"], data: '"still-wrong"' } as never),
+		).rejects.toThrow(/Section "overall_correctness" does not match schema/);
+	});
+
+	it("leaves raw-valid strings untouched by JSON recovery", async () => {
+		const tool = new YieldTool(
+			createSession({
+				outputSchema: {
+					properties: { explanation: { type: "string" } },
+				},
+			}),
+		);
+		// `correct` without quotes is already a valid string — recovery must
+		// not parse or alter it (no reverse stringify-into-typed-fields).
+		const result = await tool.execute("call-raw-str", {
+			type: ["explanation"],
+			data: "correct",
+		} as never);
+		expect(result.details?.data).toBe("correct");
+		expect(result.content).toEqual([{ type: "text", text: "Result submitted." }]);
+	});
+
 	it("does not treat literal $ref fields inside enum values as unresolved schema references", async () => {
 		const tool = new YieldTool(
 			createSession({


### PR DESCRIPTION
## Problem

`YieldTool.#schemaValidationFailures` is documented as consecutive (`MAX_SCHEMA_RETRIES` comment) but never resets — only `#emptyResultFailures` is cleared on success. Two malformed `findings` sections permanently spend the budget, so a later independent section (verdict) hits force-override after non-consecutive mistakes. Observed in production: 4 counted failures across sections → `Result submitted (schema validation overridden after 4 failed attempt(s))` on a quoted `correct` that never got recovery.

Second defect: `parseJsonContainerString` only recovers `{`/`[`-leading strings. A double-encoded enum (`data: "\\"correct\\""`) skips recovery straight to failure.

## Fix

- Reset `#schemaValidationFailures` on each schema-valid submission and after an override fires (captured count preserved for the message).
- `parseJsonEncodedValue` replaces container-only recovery: any JSON string parses after raw failure, adopted only if revalidation passes; sentinel keeps decoded `null`/`false` distinct from parse errors.

## Scope

Narrow: cumulative reset + primitive recovery only. Related/out of scope: #7171 (batched-findings arrays — broader contract enhancement), open #11154 (touches yield.ts — rebased past it).

## Tests

`bun test packages/coding-agent/test/tools/yield.test.ts` — 52/52 (49 existing + 3 new):
- budget reset across sections (2 bad findings → valid → 3 bad verdicts all reject → 4th overrides with count 4)
- quoted enum/number recovery + decoded-invalid stays rejected
- raw-valid strings untouched