### PR TITLE
fix(spec): exact-code reconcile, transform coercion gates, lexical cl…

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added opt-in host authorization and exact-once streamed child execution for discard-safe local reads.
 ### Fixed
 
-- Speculative stream sessions are now discarded when a hook or argument transform replaces a call's arguments while keeping its ID, instead of releasing deferred work planned from the original code (by [@h4vc](https://github.com/h4vc)).
+- Speculative stream sessions are now discarded when a hook or argument transform replaces a call's arguments while keeping its ID, instead of releasing deferred work planned from the original code ([#11889](https://github.com/can1357/oh-my-pi/pull/11889) by [@h4vc](https://github.com/h4vc)).
 ## [18.1.18] - 2026-09-11
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Speculative eval sessions are now discarded at reconciliation when a hook or transform appends source the stream never verified, instead of releasing reads planned from the original code ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
 - Speculative reads now classify format and rendering by the requested path while opening the resolved target, so symlinks with a different extension read exactly like ordinary reads ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
 - JavaScript speculation now validates coercion intrinsics used by `String()` and `.join()` inputs, not just template and `+` operands ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
+- Speculative reads now infer the summary language from the requested path while reading the resolved target, so cross-language symlinks summarize exactly like ordinary reads (by [@h4vc](https://github.com/h4vc)).
 ### Added
 
 - Added session-local `/btw` history with persistent answers and follow-ups; bare `/btw` reopens history, Escape cancels running answers before closing, and new questions no longer replace an in-progress answer.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,11 +29,11 @@
 - `/move` now checks BTW migration availability before confirming or creating a missing target directory, preventing leftover directories after a refused move.
 - BTW errors now shorten embedded home paths and sanitize control characters and oversized text before display, while retaining original diagnostic errors.
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
-- Speculative reads now open the authorized resolved target while rendering the requested path, so enabling speculation no longer changes read output for symlinks; video targets are declined at authorization (by [@h4vc](https://github.com/h4vc)).
-- JavaScript speculation now verifies the retained tool-bridge dispatcher and string-coercion intrinsic identities before projecting reads (by [@h4vc](https://github.com/h4vc)).
-- Speculative eval sessions are now discarded at reconciliation when a hook or transform appends source the stream never verified, instead of releasing reads planned from the original code (by [@h4vc](https://github.com/h4vc)).
-- Speculative reads now classify format and rendering by the requested path while opening the resolved target, so symlinks with a different extension read exactly like ordinary reads (by [@h4vc](https://github.com/h4vc)).
-- JavaScript speculation now validates coercion intrinsics used by `String()` and `.join()` inputs, not just template and `+` operands (by [@h4vc](https://github.com/h4vc)).
+- Speculative reads now open the authorized resolved target while rendering the requested path, so enabling speculation no longer changes read output for symlinks; video targets are declined at authorization ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
+- JavaScript speculation now verifies the retained tool-bridge dispatcher and string-coercion intrinsic identities before projecting reads ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
+- Speculative eval sessions are now discarded at reconciliation when a hook or transform appends source the stream never verified, instead of releasing reads planned from the original code ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
+- Speculative reads now classify format and rendering by the requested path while opening the resolved target, so symlinks with a different extension read exactly like ordinary reads ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
+- JavaScript speculation now validates coercion intrinsics used by `String()` and `.join()` inputs, not just template and `+` operands ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
 ### Added
 
 - Added session-local `/btw` history with persistent answers and follow-ups; bare `/btw` reopens history, Escape cancels running answers before closing, and new questions no longer replace an in-progress answer.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,9 @@
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
 - Speculative reads now open the authorized resolved target while rendering the requested path, so enabling speculation no longer changes read output for symlinks; video targets are declined at authorization (by [@h4vc](https://github.com/h4vc)).
 - JavaScript speculation now verifies the retained tool-bridge dispatcher and string-coercion intrinsic identities before projecting reads (by [@h4vc](https://github.com/h4vc)).
+- Speculative eval sessions are now discarded at reconciliation when a hook or transform appends source the stream never verified, instead of releasing reads planned from the original code (by [@h4vc](https://github.com/h4vc)).
+- Speculative reads now classify format and rendering by the requested path while opening the resolved target, so symlinks with a different extension read exactly like ordinary reads (by [@h4vc](https://github.com/h4vc)).
+- JavaScript speculation now validates coercion intrinsics used by `String()` and `.join()` inputs, not just template and `+` operands (by [@h4vc](https://github.com/h4vc)).
 ### Added
 
 - Added session-local `/btw` history with persistent answers and follow-ups; bare `/btw` reopens history, Escape cancels running answers before closing, and new questions no longer replace an in-progress answer.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Speculative reads now classify format and rendering by the requested path while opening the resolved target, so symlinks with a different extension read exactly like ordinary reads ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
 - JavaScript speculation now validates coercion intrinsics used by `String()` and `.join()` inputs, not just template and `+` operands ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
 - Speculative reads now infer the summary language from the requested path while reading the resolved target, so cross-language symlinks summarize exactly like ordinary reads (by [@h4vc](https://github.com/h4vc)).
+- The structural summary cache now keys on the parser language path, so one file read through different extensions no longer reuses a stale summary (by [@h4vc](https://github.com/h4vc)).
 ### Added
 
 - Added session-local `/btw` history with persistent answers and follow-ups; bare `/btw` reopens history, Escape cancels running answers before closing, and new questions no longer replace an in-progress answer.

--- a/packages/coding-agent/src/eval/js/speculation.ts
+++ b/packages/coding-agent/src/eval/js/speculation.ts
@@ -342,7 +342,15 @@ function projectExpression(expression: Expression, state: ProjectionState): Shad
 			args.length === 1
 		) {
 			const input = projectExpression(args[0] as Expression, state);
-			return input ? { kind: "transform", name: "String", input } : undefined;
+			if (!input) return undefined;
+			// String() coerces its input: arrays dispatch join, objects toString.
+			if (
+				coercionNeedsIntrinsics(input) &&
+				(!intrinsicIntact(state, "Array.prototype.join") || !intrinsicIntact(state, "Object.prototype.toString"))
+			) {
+				return undefined;
+			}
+			return { kind: "transform", name: "String", input };
 		}
 		if (
 			isMemberExpression(expression.callee) &&
@@ -367,9 +375,15 @@ function projectExpression(expression: Expression, state: ProjectionState): Shad
 		) {
 			const input = projectExpression(expression.callee.object, state);
 			const argument = args[0] ? projectExpression(args[0], state) : undefined;
-			return input && (!args[0] || argument)
-				? { kind: "transform", name: "Array.join", input, ...(argument ? { argument } : {}) }
-				: undefined;
+			if (!input || (args[0] && !argument)) return undefined;
+			// Elements and the separator stringify: objects reach toString
+			// (nested arrays stay under the join gate above).
+			const elements = input.kind === "array" ? input.items : [input];
+			const coerced = argument === undefined ? elements : [...elements, argument];
+			if (coerced.some(coercionNeedsIntrinsics) && !intrinsicIntact(state, "Object.prototype.toString")) {
+				return undefined;
+			}
+			return { kind: "transform", name: "Array.join", input, ...(argument ? { argument } : {}) };
 		}
 	}
 	return undefined;

--- a/packages/coding-agent/src/eval/speculation/cell-session.ts
+++ b/packages/coding-agent/src/eval/speculation/cell-session.ts
@@ -80,6 +80,8 @@ export class EvalShadowCellSession implements ToolSpeculationStreamSession {
 	#occurrenceAssignment = Promise.resolve();
 	#snapshot: Readonly<Record<string, ShadowValue | unknown>> | undefined;
 	#lastPlan: { code: string; language: string; plan: ShadowPlan | null } | undefined;
+	/** Exact source the stream finalize verified; reconcile must see the same bytes. */
+	#finalizedCode: string | undefined;
 	#snapshotToken: { language: string; revision: number; digest: string } | undefined;
 	#closed = false;
 	#updates = Promise.resolve();
@@ -131,13 +133,13 @@ export class EvalShadowCellSession implements ToolSpeculationStreamSession {
 			this.#planning = false;
 		}
 	}
-
 	async finalize(context: { args: Readonly<Record<string, unknown>> }): Promise<void> {
 		if (this.#closed) return;
 		if (!this.#decoder.matchesFinal(context.args)) {
 			await this.discard("final eval arguments do not match streamed shadow plan");
 			return;
 		}
+		if (typeof context.args.code === "string") this.#finalizedCode = context.args.code;
 		await this.#updates;
 		// Re-project the final arguments: streamed prefixes may have admitted
 		// operations that later source invalidates (e.g. a hoisted `tool` shadow
@@ -153,11 +155,14 @@ export class EvalShadowCellSession implements ToolSpeculationStreamSession {
 	/**
 	 * Whether the streamed plan still authorizes these final arguments. The
 	 * coordinator re-checks after hook/transform reconciliation and discards
-	 * the session on mismatch, so deferred work planned from replaced code
-	 * never releases. Pure: safe to call any number of times.
+	 * the session on mismatch. The decoder check alone accepts any extension
+	 * of the streamed prefix, so additionally require the exact source the
+	 * stream finalize verified: appended source (e.g. a hoisted `tool` shadow
+	 * after the read) invalidates previously projected operations. Pure: safe
+	 * to call any number of times.
 	 */
 	matchesFinalArgs(args: Readonly<Record<string, unknown>>): boolean {
-		return this.#decoder.matchesFinal(args);
+		return this.#finalizedCode !== undefined && this.#decoder.matchesFinal(args) && args.code === this.#finalizedCode;
 	}
 
 	async #verifyFinalPlan(args: Readonly<Record<string, unknown>>): Promise<boolean> {

--- a/packages/coding-agent/src/speculation/host.ts
+++ b/packages/coding-agent/src/speculation/host.ts
@@ -158,7 +158,11 @@ export class CodingAgentSpeculativeExecutionHost implements SpeculativeExecution
 			// Video reads render viewer UI through a separate frame pipeline
 			// that has no lexical render path; a symlink could otherwise route
 			// a text file there with target-named output.
-			isVideoPath(resolved)
+			isVideoPath(resolved) ||
+			// The requested path itself may carry a video extension while the
+			// target does not (or vice versa): classification follows the
+			// lexical path exactly like an ordinary read, so decline either.
+			isVideoPath(resource.path)
 		) {
 			return { allowed: false, reason: "local read target is unsafe" };
 		}

--- a/packages/coding-agent/src/tools/read-summary.ts
+++ b/packages/coding-agent/src/tools/read-summary.ts
@@ -61,7 +61,10 @@ export function routeReadThroughBridge(
  * Structural summary of `absolutePath`, or `null` when the file is too large,
  * too short, or unparseable. `diskText` lets a caller that already read the file
  * hand those bytes over instead of forcing a second read; an ACP bridge still
- * wins, since the editor's buffer is the source of truth.
+ * wins, since the editor's buffer is the source of truth. `languagePath`
+ * overrides only parser-language inference (speculative reads pass the
+ * requested lexical path while reading the resolved target); bytes and cache
+ * identity stay on `absolutePath`.
  */
 export async function trySummarize(
 	session: ToolSession,
@@ -69,6 +72,7 @@ export async function trySummarize(
 	fileSize: number,
 	signal?: AbortSignal,
 	diskText?: string,
+	languagePath?: string,
 ): Promise<SummaryResult | null> {
 	if (fileSize > MAX_SUMMARY_BYTES) return null;
 
@@ -92,7 +96,7 @@ export async function trySummarize(
 		if (memoized !== undefined) return memoized || null;
 		const result = summarizeCode({
 			code,
-			path: absolutePath,
+			path: languagePath ?? absolutePath,
 			minBodyLines,
 			minCommentLines,
 			unfoldUntilLines,

--- a/packages/coding-agent/src/tools/read-summary.ts
+++ b/packages/coding-agent/src/tools/read-summary.ts
@@ -91,7 +91,7 @@ export async function trySummarize(
 		const unfoldUntilLines = session.settings.get("read.summarize.unfoldUntil");
 		const unfoldLimitLines = session.settings.get("read.summarize.unfoldLimit");
 		const cache = getSummaryParseCache(session);
-		const cacheKey = `${absolutePath}\0${Bun.hash(code)}\0${minBodyLines},${minCommentLines},${unfoldUntilLines},${unfoldLimitLines}`;
+		const cacheKey = `${absolutePath}\0${languagePath ?? ""}\0${Bun.hash(code)}\0${minBodyLines},${minCommentLines},${unfoldUntilLines},${unfoldLimitLines}`;
 		const memoized = cache.get(cacheKey);
 		if (memoized !== undefined) return memoized || null;
 		const result = summarizeCode({

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1920,7 +1920,14 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				this.session.settings.get("read.summarize.enabled") &&
 				(this.session.settings.get("read.summarize.prose") || !isProseSummaryPath(renderAbsolutePath))
 			) {
-				const summary = await trySummarize(this.session, absolutePath, fileSize, signal, buffered?.strippedText);
+				const summary = await trySummarize(
+					this.session,
+					absolutePath,
+					fileSize,
+					signal,
+					buffered?.strippedText,
+					renderAbsolutePath,
+				);
 				if (summary?.parsed && summary.elided) {
 					const renderedSummary = renderSummary(this.session, summary);
 					const footer = formatSummaryElisionFooter(

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1742,10 +1742,11 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			}
 		}
 		// Speculative reads open the authorized resolved target (absolutePath)
-		// but must render the requested lexical path exactly like an ordinary
-		// read. All display derivations below use this; filesystem access keeps
-		// using absolutePath. Ordinary callers pass no lexical path, so this
-		// is identical to absolutePath for them.
+		// but must behave exactly like an ordinary read of the requested
+		// lexical path. All display derivations AND format/classification
+		// decisions (extension, prose/markdown detection) below use this;
+		// filesystem access keeps using absolutePath. Ordinary callers pass no
+		// lexical path, so this is identical to absolutePath for them.
 		const renderAbsolutePath = lexicalAbsolutePath ?? absolutePath;
 
 		if (isDirectory) {
@@ -1781,7 +1782,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 
 		const imageMetadata = await readImageMetadata(absolutePath);
 		const mimeType = imageMetadata?.mimeType;
-		const ext = path.extname(absolutePath).toLowerCase();
+		const ext = path.extname(renderAbsolutePath).toLowerCase();
 		const resolvedDisplayPath = formatPathRelativeToCwd(renderAbsolutePath, this.session.cwd);
 		const shouldConvertWithMarkit = CONVERTIBLE_EXTENSIONS.has(ext);
 
@@ -1791,12 +1792,14 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		// the extension falls through to the plain-text path.
 		if (!mimeType && !isRawSelector(parsed) && fileSize <= MAX_PROFILE_SUMMARY_BYTES) {
 			let rendered: string | null = null;
-			if (isSampleProfilePath(absolutePath)) rendered = renderSampleProfile(await Bun.file(absolutePath).text());
-			else if (isCpuProfilePath(absolutePath)) rendered = renderCpuProfile(await Bun.file(absolutePath).text());
+			if (isSampleProfilePath(renderAbsolutePath))
+				rendered = renderSampleProfile(await Bun.file(absolutePath).text());
+			else if (isCpuProfilePath(renderAbsolutePath))
+				rendered = renderCpuProfile(await Bun.file(absolutePath).text());
 			if (rendered) {
 				return buildInMemorySelectorResult(this.session, rendered, parsed, {
-					details: { resolvedPath: absolutePath },
-					sourcePath: absolutePath,
+					details: { resolvedPath: renderAbsolutePath },
+					sourcePath: renderAbsolutePath,
 					entityLabel: "profile summary",
 				});
 			}
@@ -1841,7 +1844,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			}));
 		} else if (question !== undefined) {
 			throw new ToolError(IMAGE_QUESTION_SELECTOR_ERROR);
-		} else if (absolutePath.toLowerCase().endsWith(".ipynb") && !isRawSelector(parsed)) {
+		} else if (renderAbsolutePath.toLowerCase().endsWith(".ipynb") && !isRawSelector(parsed)) {
 			let notebookJson: string;
 			try {
 				notebookJson = await Bun.file(absolutePath).text();
@@ -1851,8 +1854,8 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			}
 			const notebookText = notebookToEditableText(notebookJson, resolvedDisplayPath);
 			return buildInMemorySelectorResult(this.session, notebookText, parsed, {
-				details: { resolvedPath: absolutePath },
-				sourcePath: absolutePath,
+				details: { resolvedPath: renderAbsolutePath },
+				sourcePath: renderAbsolutePath,
 				entityLabel: "notebook",
 			});
 		} else if (shouldConvertWithMarkit) {
@@ -1867,10 +1870,10 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				// because only `truncateHead` was being applied.
 				return buildInMemorySelectorResult(this.session, renderedContent, parsed, {
 					details: {
-						resolvedPath: absolutePath,
+						resolvedPath: renderAbsolutePath,
 						contentType: this.session.settings.get("read.renderMarkdown") ? "text/markdown" : undefined,
 					},
-					sourcePath: absolutePath,
+					sourcePath: renderAbsolutePath,
 					entityLabel: "document",
 				});
 			} else if (result.error) {
@@ -1915,7 +1918,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			if (
 				parsed.kind === "none" &&
 				this.session.settings.get("read.summarize.enabled") &&
-				(this.session.settings.get("read.summarize.prose") || !isProseSummaryPath(absolutePath))
+				(this.session.settings.get("read.summarize.prose") || !isProseSummaryPath(renderAbsolutePath))
 			) {
 				const summary = await trySummarize(this.session, absolutePath, fileSize, signal, buffered?.strippedText);
 				if (summary?.parsed && summary.elided) {
@@ -2335,7 +2338,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		}
 
 		details.fileSize = fileSize;
-		markMarkdownContentType(this.session, details, absolutePath);
+		markMarkdownContentType(this.session, details, renderAbsolutePath);
 		if (suffixResolution) {
 			details.suffixResolution = suffixResolution;
 			// Inline resolution notice into first text block so the model sees the actual path

--- a/packages/coding-agent/test/eval/js-shadow-projection.test.ts
+++ b/packages/coding-agent/test/eval/js-shadow-projection.test.ts
@@ -446,4 +446,36 @@ tool.read({ path: selected });
 		expect(spoofed.operations).toEqual([]);
 		expect(spoofed.barrier).toBeDefined();
 	});
+	it("rejects transform inputs that coerce through replaced intrinsics", async () => {
+		const intact = {
+			String: true,
+			JSON: true,
+			"JSON.stringify": true,
+			"Array.prototype.join": true,
+			"Object.prototype.toString": true,
+			__omp_call_tool__: true,
+		};
+		// Pristine realm: explicit transforms over any input project.
+		for (const code of [
+			'await tool.read({ path: String(["secret.txt"]) })',
+			"await tool.read({ path: [{ x: 1 }].join() })",
+		]) {
+			const plan = await projectJavaScriptShadowPlan(code, { snapshot: {}, initialGlobals: intact });
+			expect(plan.barrier).toBeUndefined();
+			expect(plan.operations).toHaveLength(1);
+		}
+		// `String(array)` dispatches join; object elements and separators
+		// reach toString.
+		for (const [code, overridden] of [
+			['await tool.read({ path: String(["secret.txt"]) })', "Array.prototype.join"],
+			["await tool.read({ path: [{ x: 1 }].join() })", "Object.prototype.toString"],
+		] as Array<[string, keyof typeof intact]>) {
+			const plan = await projectJavaScriptShadowPlan(code, {
+				snapshot: {},
+				initialGlobals: { ...intact, [overridden]: false },
+			});
+			expect(plan.operations).toEqual([]);
+			expect(plan.barrier).toBeDefined();
+		}
+	});
 });

--- a/packages/coding-agent/test/read-speculation.test.ts
+++ b/packages/coding-agent/test/read-speculation.test.ts
@@ -285,6 +285,45 @@ describe("read speculation assessment", () => {
 		expect(textOf(ordinary)).toContain("summary.md");
 		expect(textOf(committed)).toBe(textOf(ordinary));
 	});
+	it("summarizes speculative symlink reads by the requested language", async () => {
+		const bodies = Array.from({ length: 25 }, (_, index) => {
+			const work = Array.from({ length: 5 }, (_, line) => `    step${line} = ${index} * ${line}`).join("\n");
+			return `def run${index}():\n${work}\n    return step0`;
+		});
+		const raw = `${bodies.join("\n\n")}\n`;
+		fs.writeFileSync(path.join(testDir, "api.py"), raw);
+		try {
+			fs.symlinkSync(path.join(testDir, "api.py"), path.join(testDir, "api.ts"), "file");
+		} catch {
+			// Windows without symlink privilege: nothing to verify.
+			return;
+		}
+		const session = createSession(testDir);
+		const tool = new ReadTool(session);
+		const policy = tool.speculation.finalized;
+		if (!policy) throw new Error("read tool has no finalized speculation policy");
+		const args = { path: "api.ts" };
+		const assessment = await policy.assess({ args });
+		if (!assessment?.eligible) throw new Error("expected speculative read admission");
+		const context = {
+			toolCall: { type: "toolCall" as const, id: "lang-link-read", name: "read", arguments: args },
+			args,
+			effect: assessment.effect,
+		};
+		const outcome = await policy.execute(context, new AbortController().signal);
+		if (!outcome) throw new Error("expected speculative read outcome");
+		const committed = await policy.commit?.({ ...context, physicalOutcome: outcome }, outcome);
+		// Requested TypeScript cannot parse `def` bodies, so the ordinary
+		// read returns them verbatim; classifying by the resolved Python
+		// target would summarize instead.
+		const ordinary = await new ReadTool(createSession(testDir)).execute("ordinary-lang-link-read", args);
+		const textOf = (result: unknown) =>
+			(result as { content?: Array<{ type: string; text?: string }> } | undefined)?.content?.find(
+				(entry): entry is { type: "text"; text: string } => entry.type === "text",
+			)?.text ?? "";
+		expect(textOf(ordinary)).toContain("step4 = 24 * 4");
+		expect(textOf(committed)).toBe(textOf(ordinary));
+	});
 
 	it("defers conflict-aware reads without mutating live conflict history", async () => {
 		const conflictPath = path.join(testDir, "conflict.txt");

--- a/packages/coding-agent/test/read-speculation.test.ts
+++ b/packages/coding-agent/test/read-speculation.test.ts
@@ -208,6 +208,83 @@ describe("read speculation assessment", () => {
 		expect(String(metaOf(committed)?.source?.value ?? "")).toContain("link.txt");
 		expect(metaOf(committed)?.source).toEqual(metaOf(ordinary)?.source);
 	});
+	it("classifies speculative symlink reads by the requested extension", async () => {
+		fs.writeFileSync(path.join(testDir, "prose-target.txt"), "plain prose");
+		try {
+			fs.symlinkSync(path.join(testDir, "prose-target.txt"), path.join(testDir, "guide.md"), "file");
+		} catch {
+			// Windows without symlink privilege: nothing to verify.
+			return;
+		}
+		const settings = Settings.isolated({ "images.autoResize": false, "read.renderMarkdown": true });
+		const session = { ...createSession(testDir), settings } as ToolSession;
+		const tool = new ReadTool(session);
+		const policy = tool.speculation.finalized;
+		if (!policy) throw new Error("read tool has no finalized speculation policy");
+		const args = { path: "guide.md" };
+		const assessment = await policy.assess({ args });
+		if (!assessment?.eligible) throw new Error("expected speculative read admission");
+		const context = {
+			toolCall: { type: "toolCall" as const, id: "md-link-read", name: "read", arguments: args },
+			args,
+			effect: assessment.effect,
+		};
+		const outcome = await policy.execute(context, new AbortController().signal);
+		if (!outcome) throw new Error("expected speculative read outcome");
+		const committed = await policy.commit?.({ ...context, physicalOutcome: outcome }, outcome);
+		const ordinary = await new ReadTool({ ...createSession(testDir), settings } as ToolSession).execute(
+			"ordinary-md-link-read",
+			args,
+		);
+		const textOf = (result: unknown) =>
+			(result as { content?: Array<{ type: string; text?: string }> } | undefined)?.content?.find(
+				(entry): entry is { type: "text"; text: string } => entry.type === "text",
+			)?.text ?? "";
+		expect(textOf(committed)).toBe(textOf(ordinary));
+		const typeOf = (result: unknown) =>
+			(result as { details?: { contentType?: unknown } } | undefined)?.details?.contentType;
+		// Markdown rendering follows the requested extension in both paths.
+		expect(typeOf(ordinary)).toBe("text/markdown");
+		expect(typeOf(committed)).toBe(typeOf(ordinary));
+	});
+
+	it("skips summaries for speculative symlink reads by the requested extension", async () => {
+		const bodies = Array.from({ length: 25 }, (_, index) => {
+			const work = Array.from({ length: 5 }, (_, line) => `	const step${line} = ${index} * ${line};`).join("\n");
+			return `function run${index}() {\n${work}\n	return step0;\n}`;
+		});
+		fs.writeFileSync(path.join(testDir, "long.ts"), `${bodies.join("\n\n")}\n`);
+		try {
+			fs.symlinkSync(path.join(testDir, "long.ts"), path.join(testDir, "summary.md"), "file");
+		} catch {
+			// Windows without symlink privilege: nothing to verify.
+			return;
+		}
+		const session = createSession(testDir);
+		const tool = new ReadTool(session);
+		const policy = tool.speculation.finalized;
+		if (!policy) throw new Error("read tool has no finalized speculation policy");
+		const args = { path: "summary.md" };
+		const assessment = await policy.assess({ args });
+		if (!assessment?.eligible) throw new Error("expected speculative read admission");
+		const context = {
+			toolCall: { type: "toolCall" as const, id: "summary-link-read", name: "read", arguments: args },
+			args,
+			effect: assessment.effect,
+		};
+		const outcome = await policy.execute(context, new AbortController().signal);
+		if (!outcome) throw new Error("expected speculative read outcome");
+		const committed = await policy.commit?.({ ...context, physicalOutcome: outcome }, outcome);
+		const ordinary = await new ReadTool(createSession(testDir)).execute("ordinary-summary-link-read", args);
+		const textOf = (result: unknown) =>
+			(result as { content?: Array<{ type: string; text?: string }> } | undefined)?.content?.find(
+				(entry): entry is { type: "text"; text: string } => entry.type === "text",
+			)?.text ?? "";
+		// Prose requests skip structural summaries in both paths; classifying
+		// by the resolved TypeScript target would summarize here instead.
+		expect(textOf(ordinary)).toContain("summary.md");
+		expect(textOf(committed)).toBe(textOf(ordinary));
+	});
 
 	it("defers conflict-aware reads without mutating live conflict history", async () => {
 		const conflictPath = path.join(testDir, "conflict.txt");
@@ -370,5 +447,41 @@ describe("read speculation assessment", () => {
 		const plainContext = authorizeContext("content-plain", "plain.txt", plain.effect);
 		await expect(host.authorize(plainContext)).resolves.toEqual({ allowed: true, deferBeforeToolCall: true });
 		await expect(host.captureEvidence(plainContext)).resolves.toBe(true);
+	});
+	it("denies video extensions on either side of a symlink at authorization", async () => {
+		fs.writeFileSync(path.join(testDir, "clip.txt"), "not actually video");
+		try {
+			fs.symlinkSync(path.join(testDir, "clip.txt"), path.join(testDir, "clip.mp4"), "file");
+		} catch {
+			// Windows without symlink privilege: nothing to verify.
+			return;
+		}
+		const session = {
+			...createSession(testDir),
+			settings: Settings.isolated({
+				"images.autoResize": false,
+				"tools.approvalMode": "yolo",
+				"tools.speculativeExecution.enabled": true,
+			}),
+		} as ToolSession;
+		const tool = new ReadTool(session);
+		const policy = tool.speculation.finalized;
+		if (!policy) throw new Error("read tool has no finalized speculation policy");
+		const host = new CodingAgentSpeculativeExecutionHost(session.settings, session, { hasHandlers: () => false });
+		// The resolved target is plain text, but the requested path routes
+		// through the viewer pipeline, which has no lexical render path.
+		const assessment = await policy.assess({ args: { path: "clip.mp4" } });
+		if (!assessment.eligible) throw new Error("expected provisional admission for clip.mp4");
+		await expect(
+			host.authorize({
+				candidateId: "video-link",
+				source: "direct",
+				dependencies: [],
+				tool,
+				toolCall: { type: "toolCall", id: "video-link", name: "read", arguments: { path: "clip.mp4" } },
+				args: { path: "clip.mp4" },
+				effect: assessment.effect,
+			}),
+		).resolves.toEqual({ allowed: false, reason: "local read target is unsafe" });
 	});
 });

--- a/packages/coding-agent/test/read-summary.test.ts
+++ b/packages/coding-agent/test/read-summary.test.ts
@@ -8,6 +8,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import type { ReadToolDetails } from "@oh-my-pi/pi-coding-agent/tools/read";
 import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
+import { trySummarize } from "@oh-my-pi/pi-coding-agent/tools/read-summary";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 let artifactCounter = 0;
@@ -354,5 +355,20 @@ describe("read summary", () => {
 		expect(text).not.toContain("elided regions");
 		expect(text).not.toContain(":raw");
 		expect(result.details?.summary).toBeUndefined();
+	});
+	it("keys the summary cache by parser language path", async () => {
+		const fixture = path.join(tmpDir, "mod.ts");
+		const code =
+			"export function alpha(value: string): string {\n\tconst clean = value.trim();\n\tconst label = clean || 'alpha';\n\treturn label.toUpperCase();\n}\n\nexport function beta(): number {\n\tconst one = 1;\n\tconst two = 2;\n\treturn one + two;\n}\n";
+		await fs.writeFile(fixture, code);
+		const session = createSession(tmpDir);
+		const size = Buffer.byteLength(code);
+		// Same bytes requested as TypeScript, then as Python (e.g. a symlink
+		// read through a `.py` lexical path): the second call must not reuse
+		// the cached TypeScript summary.
+		const first = await trySummarize(session, fixture, size, undefined, code, fixture);
+		expect(first?.parsed && first?.elided).toBe(true);
+		const second = await trySummarize(session, fixture, size, undefined, code, path.join(tmpDir, "mod.py"));
+		expect(second).not.toBe(first);
 	});
 });

--- a/packages/coding-agent/test/speculative-eval-integration.test.ts
+++ b/packages/coding-agent/test/speculative-eval-integration.test.ts
@@ -435,6 +435,49 @@ describe("streamed eval speculation", () => {
 		expect(admitted[1]?.args).toMatchObject({ path: "COMMITTED.txt" });
 		await shadow.discard("test complete");
 	});
+	it("rejects appended source at reconcile even when the prefix matches", async () => {
+		const directory = await fs.mkdtemp(path.join(os.tmpdir(), "speculative-eval-appended-"));
+		temporaryDirectories.push(directory);
+		const settings = Settings.isolated({ "eval.autoBackground.enabled": false, "images.autoResize": false });
+		const session: ToolSession = {
+			cwd: directory,
+			hasUI: false,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			getEvalSessionId: () => "speculative-eval-appended-test",
+			getToolForEvalBridge: name => (name === "read" ? eraseToolSchema(read) : undefined),
+			getEvalBridgeToolNames: () => ["read"],
+			settings,
+		};
+		const read = new ReadTool(session);
+		const evalTool = new EvalTool(session);
+		await evalTool.execute("warm-appended", { language: "js", code: "globalThis.shadowWarm = true" });
+		const coordinator: SpeculativeOperationSink = {
+			maxInFlight: 2,
+			async admit() {
+				return undefined;
+			},
+			close() {},
+		};
+		const code = 'await tool.read({ path: "a.txt" });';
+		const args = { language: "js", code };
+		const shadow = new EvalShadowCellSession({
+			coordinator,
+			parentToolCallId: "eval-appended",
+			session,
+			cwd: directory,
+			sessionId: "speculative-eval-appended-test",
+		});
+		const toolCall = { type: "toolCall" as const, id: "eval-appended", name: "eval", arguments: args };
+		shadow.update(toolCall, JSON.stringify(args));
+		await shadow.finalize({ args });
+		// Identical arguments still match the verified plan.
+		expect(shadow.matchesFinalArgs(args)).toBe(true);
+		// Appended source keeps the streamed prefix but was never verified:
+		// a hoisted shadow here would invalidate the projected read.
+		expect(shadow.matchesFinalArgs({ language: "js", code: `${code}\nvar tool = {};` })).toBe(false);
+		await shadow.discard("test complete");
+	});
 
 	it("namespaces child tool-call IDs across outer eval calls", async () => {
 		const directory = await fs.mkdtemp(path.join(os.tmpdir(), "speculative-eval-child-ids-"));


### PR DESCRIPTION
…assification

Reconcile now requires the exact source the stream finalize verified, not just a matching prefix, so appended bindings discard the session. String() and .join() transform inputs refuse when their coercion intrinsics report replaced. Speculative reads classify format and rendering by the requested path while opening the resolved target, and authorization declines video extensions on either side of a symlink.

## What

<!-- Brief description of the change. Include at least one sentence in your own words explaining what changed and why, as required by CONTRIBUTING.md. -->

## Why

<!-- Motivation, context, or link to issue (fixes #N) -->

## Testing

<!-- How was this tested? -->

---

- [x ] `bun check` passes
- [x ] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)
