### PR TITLE
test(utils,coding-agent): fix Windows-only suite failures

### DIFF
--- a/packages/coding-agent/test/eval/agent-bridge-policy.test.ts
+++ b/packages/coding-agent/test/eval/agent-bridge-policy.test.ts
@@ -1375,7 +1375,7 @@ describe("runEvalAgent isolation", () => {
 			caught = err as Error;
 		}
 		expect(caught).toBeDefined();
-		const match = caught?.message.match(/(\/[^\s,]+?\.nested-0-sub_nested\.patch)/);
+		const match = caught?.message.match(/([^\s,]+?\.nested-0-sub_nested\.patch)/);
 		expect(match).not.toBeNull();
 		const persistedPath = match?.[1];
 		expect(persistedPath).toBeDefined();

--- a/packages/coding-agent/test/eval/py/prelude.test.ts
+++ b/packages/coding-agent/test/eval/py/prelude.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "bun:test";
-import * as fs from "node:fs/promises";
 import { $which, TempDir } from "@oh-my-pi/pi-utils";
 import { PYTHON_PRELUDE } from "../../../src/eval/py/prelude";
 const pythonPath = Bun.env.PYTHON ?? ($which("python3") ? "python3" : "python");
@@ -18,7 +17,7 @@ async function runPrelude(
 	const dir = await TempDir.create("omp-py-prelude-");
 	try {
 		const scriptPath = dir.join("script.py");
-		await fs.writeFile(scriptPath, script, "utf-8");
+		await Bun.write(scriptPath, script);
 		const proc = Bun.spawn([pythonPath, scriptPath], {
 			stdout: "pipe",
 			stderr: "pipe",

--- a/packages/coding-agent/test/eval/py/prelude.test.ts
+++ b/packages/coding-agent/test/eval/py/prelude.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { $which } from "@oh-my-pi/pi-utils";
+import * as fs from "node:fs/promises";
+import { $which, TempDir } from "@oh-my-pi/pi-utils";
 import { PYTHON_PRELUDE } from "../../../src/eval/py/prelude";
 const pythonPath = Bun.env.PYTHON ?? ($which("python3") ? "python3" : "python");
 
@@ -12,18 +13,27 @@ async function runPrelude(
 		"from __future__ import annotations\n__omp_display = lambda *args, **kwargs: None",
 	);
 	const script = `${prelude}\n${code}`;
-	const proc = Bun.spawn([pythonPath, "-c", script], {
-		stdout: "pipe",
-		stderr: "pipe",
-		env: { ...process.env, ...env },
-	});
-	const [stdout, stderr, exitCode] = await Promise.all([
-		new Response(proc.stdout).text(),
-		new Response(proc.stderr).text(),
-		proc.exited,
-	]);
-	// Python's text-mode stdout emits \r\n on Windows.
-	return { stdout: stdout.replaceAll("\r\n", "\n"), stderr: stderr.replaceAll("\r\n", "\n"), exitCode };
+	// The full prelude exceeds Windows' ~32k `python -c` command-line limit
+	// (ENAMETOOLONG); a script file behaves identically on every platform.
+	const dir = await TempDir.create("omp-py-prelude-");
+	try {
+		const scriptPath = dir.join("script.py");
+		await fs.writeFile(scriptPath, script, "utf-8");
+		const proc = Bun.spawn([pythonPath, scriptPath], {
+			stdout: "pipe",
+			stderr: "pipe",
+			env: { ...process.env, ...env },
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+		// Python's text-mode stdout emits \r\n on Windows.
+		return { stdout: stdout.replaceAll("\r\n", "\n"), stderr: stderr.replaceAll("\r\n", "\n"), exitCode };
+	} finally {
+		await dir.remove();
+	}
 }
 
 describe("python prelude", () => {

--- a/packages/utils/test/browsers.test.ts
+++ b/packages/utils/test/browsers.test.ts
@@ -31,27 +31,45 @@ describe("Chrome-for-Testing layout goldens", () => {
 		{
 			platform: BrowserPlatform.LINUX,
 			url: `https://storage.googleapis.com/chrome-for-testing-public/${BUILD_ID}/linux64/chrome-linux64.zip`,
-			executable: `/cache/chrome/linux-${BUILD_ID}/chrome-linux64/chrome`,
+			executable: path.join("/cache", "chrome", `linux-${BUILD_ID}`, "chrome-linux64", "chrome"),
 		},
 		{
 			platform: BrowserPlatform.MAC,
 			url: `https://storage.googleapis.com/chrome-for-testing-public/${BUILD_ID}/mac-x64/chrome-mac-x64.zip`,
-			executable: `/cache/chrome/mac-${BUILD_ID}/chrome-mac-x64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`,
+			executable: path.join(
+				"/cache",
+				"chrome",
+				`mac-${BUILD_ID}`,
+				"chrome-mac-x64",
+				"Google Chrome for Testing.app",
+				"Contents",
+				"MacOS",
+				"Google Chrome for Testing",
+			),
 		},
 		{
 			platform: BrowserPlatform.MAC_ARM,
 			url: `https://storage.googleapis.com/chrome-for-testing-public/${BUILD_ID}/mac-arm64/chrome-mac-arm64.zip`,
-			executable: `/cache/chrome/mac_arm-${BUILD_ID}/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`,
+			executable: path.join(
+				"/cache",
+				"chrome",
+				`mac_arm-${BUILD_ID}`,
+				"chrome-mac-arm64",
+				"Google Chrome for Testing.app",
+				"Contents",
+				"MacOS",
+				"Google Chrome for Testing",
+			),
 		},
 		{
 			platform: BrowserPlatform.WIN32,
 			url: `https://storage.googleapis.com/chrome-for-testing-public/${BUILD_ID}/win32/chrome-win32.zip`,
-			executable: `/cache/chrome/win32-${BUILD_ID}/chrome-win32/chrome.exe`,
+			executable: path.join("/cache", "chrome", `win32-${BUILD_ID}`, "chrome-win32", "chrome.exe"),
 		},
 		{
 			platform: BrowserPlatform.WIN64,
 			url: `https://storage.googleapis.com/chrome-for-testing-public/${BUILD_ID}/win64/chrome-win64.zip`,
-			executable: `/cache/chrome/win64-${BUILD_ID}/chrome-win64/chrome.exe`,
+			executable: path.join("/cache", "chrome", `win64-${BUILD_ID}`, "chrome-win64", "chrome.exe"),
 		},
 	] as const;
 
@@ -137,11 +155,15 @@ test("install streams and extracts stored, deflated, nested, executable, and sym
 		});
 		const executable = await fs.readFile(installed.executablePath, "utf8");
 		expect(executable).toBe("#!/bin/sh\necho synthetic chrome\n");
-		expect((await fs.stat(installed.executablePath)).mode & 0o777).toBe(0o755);
+		if (process.platform !== "win32") {
+			expect((await fs.stat(installed.executablePath)).mode & 0o777).toBe(0o755);
+		}
 		expect(await fs.readFile(path.join(installed.path, "chrome-linux64/nested/data.txt"), "utf8")).toBe(
 			"nested fixture\n",
 		);
-		expect((await fs.stat(path.join(installed.path, "chrome-linux64/nested/data.txt"))).mode & 0o777).toBe(0o640);
+		if (process.platform !== "win32") {
+			expect((await fs.stat(path.join(installed.path, "chrome-linux64/nested/data.txt"))).mode & 0o777).toBe(0o640);
+		}
 		expect(await fs.readlink(path.join(installed.path, "chrome-linux64/chrome-link"))).toBe("chrome");
 		expect(progress.length).toBeGreaterThan(0);
 		expect(progress.at(-1)?.downloadedBytes).toBe(fixture.size);

--- a/packages/utils/test/fixtures/ptree-dead-root-probe.ts
+++ b/packages/utils/test/fixtures/ptree-dead-root-probe.ts
@@ -3,6 +3,9 @@ const child = Bun.spawn([process.execPath, "-e", "await Bun.sleep(30_000)"], {
 	stdout: "inherit",
 	stderr: "inherit",
 	windowsHide: true,
+	// Bun places Windows children in the parent job, which dies with the root;
+	// detached lets this descendant outlive the probe and hold the pipe.
+	detached: true,
 });
 
 await Bun.write(Bun.stdout, `${child.pid}\n`);

--- a/packages/utils/test/logger-contract.test.ts
+++ b/packages/utils/test/logger-contract.test.ts
@@ -48,12 +48,10 @@ async function runScenario(scenario: string): Promise<ScenarioResult> {
 			env: {
 				...process.env,
 				HOME: primaryDir,
+				// os.homedir() on Windows reads USERPROFILE, not HOME: without
+				// this the default-file scenario logs into the real profile.
+				USERPROFILE: primaryDir,
 				PI_CONFIG_DIR: ".omp",
-				OMP_PROFILE: "",
-				PI_PROFILE: "",
-				XDG_DATA_HOME: "",
-				XDG_STATE_HOME: "",
-				XDG_CACHE_HOME: "",
 				// Empty XDG_CACHE_HOME makes Bun's transpiler cache path relative,
 				// spewing bun/@t@/*.pile into the repo root (the child's cwd) — disable it.
 				BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0",

--- a/packages/utils/test/logger-contract.test.ts
+++ b/packages/utils/test/logger-contract.test.ts
@@ -52,6 +52,11 @@ async function runScenario(scenario: string): Promise<ScenarioResult> {
 				// this the default-file scenario logs into the real profile.
 				USERPROFILE: primaryDir,
 				PI_CONFIG_DIR: ".omp",
+				OMP_PROFILE: "",
+				PI_PROFILE: "",
+				XDG_DATA_HOME: "",
+				XDG_STATE_HOME: "",
+				XDG_CACHE_HOME: "",
 				// Empty XDG_CACHE_HOME makes Bun's transpiler cache path relative,
 				// spewing bun/@t@/*.pile into the repo root (the child's cwd) — disable it.
 				BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0",

--- a/packages/utils/test/postmortem-cleanup-error.test.ts
+++ b/packages/utils/test/postmortem-cleanup-error.test.ts
@@ -330,7 +330,7 @@ describe("postmortem expected cleanup errors", () => {
 		expect(result.stdout).toContain('["outer","late","settled"]');
 	});
 
-	it("finishes an async late registration before a SIGTERM exit", async () => {
+	it.skipIf(process.platform === "win32")("finishes an async late registration before a SIGTERM exit", async () => {
 		const result = await runPostmortemProbe(`
 			import { postmortem } from "${postmortemModuleUrl}";
 

--- a/packages/utils/test/ptree-stderr.test.ts
+++ b/packages/utils/test/ptree-stderr.test.ts
@@ -9,12 +9,14 @@ const FULL_CAPTURE_ERROR = "Full stderr capture must be requested when spawning 
 
 function stderrFixture(size: number, exitCode = 0, stdout = ""): string[] {
 	const fillLength = size - STDERR_HEAD.length - STDERR_TAIL.length;
+	// Writing "" to a piped stdout throws EINVAL on Windows Bun; skip the write.
+	const stdoutLine = stdout.length > 0 ? `await Bun.stdout.write(${JSON.stringify(stdout)});` : null;
 	const script = [
-		`await Bun.stdout.write(${JSON.stringify(stdout)});`,
+		stdoutLine,
 		`await Bun.stderr.write(${JSON.stringify(STDERR_HEAD)} + "x".repeat(${fillLength}) + ${JSON.stringify(STDERR_TAIL)});`,
 		`process.exitCode = ${exitCode};`,
-	].join("\n");
-	return ["bun", "-e", script];
+	].filter(line => line !== null);
+	return ["bun", "-e", script.join("\n")];
 }
 
 describe("ptree stderr capture", () => {


### PR DESCRIPTION
## What

CI FIX: the cis that are fixed:
- coding-agent eval isolation path regex now matches Windows paths (agent-bridge-policy)
- python prelude probe runs from a script file instead of `python -c` (ENAMETOOLONG on Windows)
- Chrome-for-Testing layout goldens built with `path.join` (separator-agnostic)
- POSIX mode-bit assertions guarded on win32 (no exec bits on Windows)
- logger contract probe sets USERPROFILE so the default-file scenario no longer logs into the real profile
- POSIX SIGTERM graceful-exit test skipped on win32 (TerminateProcess semantics)
- ptree stderr fixture skips empty stdout writes (EINVAL on Windows Bun)
- dead-root probe spawns detached so the descendant outlives the root under Bun job objects

## Why

`bun test` was red on Windows (15 failures across packages/utils and packages/coding-agent) while Linux CI stayed green. All 15 were test-harness platform assumptions, not product bugs; each fix is POSIX-identical.

## Testing

- packages/utils: 892 pass, 0 fail (was 882 pass, 11 fail)
- packages/coding-agent test/eval: 266 pass, 0 fail (was 4 fail)
- packages/agent: 580 pass, 0 fail (untouched, sanity)
- `bun run check:ts` green (oxlint + oxfmt + tsgo, all workspaces)
- `bun check` box unchecked: only the TS half was run; no Rust files are touched by this diff so check:rs is unaffected
- CHANGELOG box unchecked: test-only change, not user-facing

---

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)