### PR TITLE
fix(ai): preserve cache anchors across context hooks

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -3884,14 +3884,26 @@ function applyPromptCaching(params: MessageCreateParamsStreaming, cacheControl?:
 		params.messages[trailingIndex - 1]?.role === "assistant";
 	const messageEnd = hasTrailingAssistantPad ? trailingIndex - 1 : trailingIndex;
 
+	// A breakpoint caches every preceding byte, not only the decorated message.
+	// Once per-call or turn-scoped content appears, no later message can anchor a
+	// prefix reusable by the next request.
+	let stableMessageEnd = messageEnd;
+	for (let index = 0; index <= messageEnd; index++) {
+		const message = params.messages[index];
+		if (message && (message.clear_at === "next_user_message" || isPerCallContextMessage(message))) {
+			stableMessageEnd = index - 1;
+			break;
+		}
+	}
+
 	// Decimation counts conversational turns, so it reads the provenance marker
 	// `convertAnthropicMessages` records rather than the wire role. A wire `user`
 	// can also be a serialized `developer` message, a tool_result run, or an
 	// interior `Continue.` pad, none of which advance the user turn ordinal.
 	const userIndices: number[] = [];
-	for (let index = 0; index <= messageEnd; index++) {
+	for (let index = 0; index <= stableMessageEnd; index++) {
 		const message = params.messages[index];
-		if (message && message.clear_at !== "next_user_message" && isConversationalUser(message)) {
+		if (message && isConversationalUser(message)) {
 			userIndices.push(index);
 		}
 	}
@@ -3899,11 +3911,11 @@ function applyPromptCaching(params: MessageCreateParamsStreaming, cacheControl?:
 	// Stable historical decimation checkpoint every 15 user turns (15th, 30th, 45th...)
 	const decimationIndices = userIndices.filter((_, ordinal) => (ordinal + 1) % ANTHROPIC_DECIMATION_INTERVAL === 0);
 
-	// Collect eligible trailing candidates (up to 2 messages walking backward from messageEnd).
+	// Collect up to 2 trailing candidates from the reusable prefix.
 	const trailingCandidates: number[] = [];
-	for (let index = messageEnd; index >= 0 && trailingCandidates.length < 2; index--) {
+	for (let index = stableMessageEnd; index >= 0 && trailingCandidates.length < 2; index--) {
 		const message = params.messages[index];
-		if (!message || message.clear_at === "next_user_message" || isPerCallContextMessage(message)) continue;
+		if (!message) continue;
 		trailingCandidates.push(index);
 	}
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -60,8 +60,10 @@ import {
 import { createAbortSourceTracker } from "../utils/abort";
 import {
 	clearStreamingPartialJson,
+	copyPerCallContextMessage,
 	type ConversationalUserCarrier,
 	isConversationalUser,
+	isPerCallContextMessage,
 	isSyntheticUser,
 	kConversationalUser,
 	kStreamingBlockIndex,
@@ -3901,7 +3903,7 @@ function applyPromptCaching(params: MessageCreateParamsStreaming, cacheControl?:
 	const trailingCandidates: number[] = [];
 	for (let index = messageEnd; index >= 0 && trailingCandidates.length < 2; index--) {
 		const message = params.messages[index];
-		if (!message || message.clear_at === "next_user_message") continue;
+		if (!message || message.clear_at === "next_user_message" || isPerCallContextMessage(message)) continue;
 		trailingCandidates.push(index);
 	}
 
@@ -4764,7 +4766,12 @@ export function convertAnthropicMessages(
 			(msg.role === "user" || msg.role === "developer") &&
 			isReplayableAnthropicCompaction(msg.providerPayload, model)
 		) {
-			params.push({ role: "assistant", content: [compactionBlockParam(msg.providerPayload)] });
+			const compactionParam: AnthropicMessageParam = {
+				role: "assistant",
+				content: [compactionBlockParam(msg.providerPayload)],
+			};
+			copyPerCallContextMessage(compactionParam, msg);
+			params.push(compactionParam);
 			// The block carries the verbatim API summary, so the message text
 			// (which holds the harness file lists) would be dropped with it.
 			// Queue the file metadata for after the block: it sits past the
@@ -4835,6 +4842,7 @@ export function convertAnthropicMessages(
 			if (msg.role === "user" && !agentAuthored && !isSyntheticUser(msg)) {
 				param[kConversationalUser] = true;
 			}
+			copyPerCallContextMessage(param, msg);
 			params.push(param);
 		} else if (msg.role === "assistant") {
 			const blocks: ContentBlockParam[] = [];
@@ -4972,10 +4980,12 @@ export function convertAnthropicMessages(
 				blocks.push(...nonToolUse, ...toolUse);
 			}
 			if (blocks.length === 0) continue;
-			params.push({
+			const assistantParam: AnthropicMessageParam = {
 				role: "assistant",
 				content: blocks,
-			});
+			};
+			copyPerCallContextMessage(assistantParam, msg);
+			params.push(assistantParam);
 			// Flush queued file metadata unless this turn left tool calls open:
 			// their results must follow the turn contiguously, so the metadata
 			// waits for the merged result message (or the end of the list).
@@ -4987,15 +4997,21 @@ export function convertAnthropicMessages(
 			const toolResults: ContentBlockParam[] = [];
 			// Images stripped out of error tool results, re-attached after the run.
 			const hoistedImages: ContentBlockParam[] = [];
+			const toolResultParam: AnthropicMessageParam = {
+				role: "user",
+				content: toolResults,
+			};
 
 			// Add the current tool result
 			toolResults.push(buildToolResultBlock(model, msg, hoistedImages));
+			copyPerCallContextMessage(toolResultParam, msg);
 
 			// Look ahead for consecutive toolResult messages
 			let j = i + 1;
 			while (j < transformedMessages.length && transformedMessages[j].role === "toolResult") {
 				const nextMsg = transformedMessages[j] as ToolResultMessage; // We know it's a toolResult
 				toolResults.push(buildToolResultBlock(model, nextMsg, hoistedImages));
+				copyPerCallContextMessage(toolResultParam, nextMsg);
 				j++;
 			}
 
@@ -5010,10 +5026,7 @@ export function convertAnthropicMessages(
 			}
 
 			// Add a single user message with all tool results
-			params.push({
-				role: "user",
-				content: toolResults,
-			});
+			params.push(toolResultParam);
 			// An open tool_use turn's results are whole again; queued file
 			// metadata can follow without splitting the pairing.
 			flushCompactionFiles();
@@ -5050,20 +5063,24 @@ export function convertAnthropicMessages(
 				const controlContent = content.filter(block => block.type !== "text");
 				if (scopedContent.length > 0) {
 					params[idx] = {
+						...params[idx],
 						role: "system",
 						content: scopedContent,
 						clear_at: "next_user_message",
 					};
-					params.splice(idx + 1, 0, {
+					const controlParam: AnthropicMessageParam = {
 						role: "system",
 						content: controlContent,
 						...(hasEffort ? { output_config: { effort: developer.payload?.effort } } : {}),
-					});
+					};
+					copyPerCallContextMessage(controlParam, params[idx]);
+					params.splice(idx + 1, 0, controlParam);
 					continue;
 				}
 			}
 
 			params[idx] = {
+				...params[idx],
 				role: "system",
 				content,
 				...(turnScoped && !hasEffort && !hasToolChanges ? { clear_at: "next_user_message" } : {}),

--- a/packages/ai/src/utils/block-symbols.ts
+++ b/packages/ai/src/utils/block-symbols.ts
@@ -172,3 +172,29 @@ export function copyPerCallContextMessage(
 export function isPerCallContextMessage(message: PerCallContextMessageCarrier | null | undefined): boolean {
 	return message?.[kPerCallContextMessage] === true;
 }
+
+/**
+ * Original history position carried by a context message clone.
+ *
+ * Object-spread transforms retain this symbol, allowing the extension runner
+ * to distinguish byte-identical historical copies from inserted messages.
+ */
+export const kContextHistoryIndex = Symbol("agent.message.contextHistoryIndex");
+
+/** Carries a context message's original history position. */
+export type ContextHistoryIndexCarrier = object & { [kContextHistoryIndex]?: number };
+
+/** Reads a context message's original history position. */
+export function getContextHistoryIndex(message: ContextHistoryIndexCarrier | null | undefined): number | undefined {
+	return message?.[kContextHistoryIndex];
+}
+
+/** Records a context message's original history position. */
+export function setContextHistoryIndex(message: ContextHistoryIndexCarrier, index: number): void {
+	message[kContextHistoryIndex] = index;
+}
+
+/** Removes context-history tracking before provider conversion. */
+export function clearContextHistoryIndex(message: ContextHistoryIndexCarrier): void {
+	delete message[kContextHistoryIndex];
+}

--- a/packages/ai/src/utils/block-symbols.ts
+++ b/packages/ai/src/utils/block-symbols.ts
@@ -141,3 +141,34 @@ export type SyntheticUserCarrier = object & { [kSyntheticUser]?: boolean };
 export function isSyntheticUser(message: SyntheticUserCarrier | null | undefined): boolean {
 	return message?.[kSyntheticUser] === true;
 }
+
+/**
+ * Marks a message synthesized by a per-call context transform rather than
+ * loaded from persisted conversation history.
+ *
+ * Prompt-cache boundaries must skip these messages: their content is rebuilt
+ * for each request and cannot anchor a prefix reused by the next turn.
+ * Symbol-keyed so the marker never persists or reaches the provider wire.
+ */
+export const kPerCallContextMessage = Symbol("agent.message.perCallContext");
+
+/** Carries per-call context provenance without exposing a string-keyed property. */
+export type PerCallContextMessageCarrier = object & { [kPerCallContextMessage]?: true };
+
+/** Marks a message as synthesized for the current provider call. */
+export function markPerCallContextMessage(message: PerCallContextMessageCarrier): void {
+	message[kPerCallContextMessage] = true;
+}
+
+/** Copies per-call context provenance to a converted or projected message. */
+export function copyPerCallContextMessage(
+	target: PerCallContextMessageCarrier,
+	source: PerCallContextMessageCarrier,
+): void {
+	if (source[kPerCallContextMessage] === true) target[kPerCallContextMessage] = true;
+}
+
+/** True when a message was synthesized for the current provider call. */
+export function isPerCallContextMessage(message: PerCallContextMessageCarrier | null | undefined): boolean {
+	return message?.[kPerCallContextMessage] === true;
+}

--- a/packages/ai/test/anthropic-head-caching.test.ts
+++ b/packages/ai/test/anthropic-head-caching.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it } from "bun:test";
 import type { MessageCreateParams } from "@oh-my-pi/pi-ai/providers/anthropic-wire";
 import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
 import type { AssistantMessage, CacheRetention, Context, Message, Model, ModelSpec } from "@oh-my-pi/pi-ai/types";
+import { markPerCallContextMessage } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 
 const MODEL_SPEC: ModelSpec<"anthropic-messages"> = {
@@ -162,6 +163,29 @@ describe("anthropic head caching (general API-key path)", () => {
 		if (!Array.isArray(trailing.content)) return;
 		const lastBlock = trailing.content[trailing.content.length - 1] as { cache_control?: { type?: string } };
 		expect(lastBlock.cache_control?.type).toBe("ephemeral");
+	});
+
+	it("keeps rolling and decimation breakpoints before per-call context", async () => {
+		const messages: Message[] = [
+			{ role: "user", content: "stable user", timestamp: 1 },
+			assistantMessage("stable assistant", 2),
+		];
+		const perCallMessage: Message = {
+			role: "developer",
+			content: "per-call context",
+			attribution: "agent",
+			timestamp: 3,
+		};
+		markPerCallContextMessage(perCallMessage);
+		messages.push(perCallMessage);
+		for (let turn = 1; turn <= 15; turn++) {
+			messages.push({ role: "user", content: `later user ${turn}`, timestamp: turn * 2 + 2 });
+			messages.push(assistantMessage(`later assistant ${turn}`, turn * 2 + 3));
+		}
+
+		const body = await captureWireBody(undefined, { ...CONTEXT, messages });
+
+		expect(findCachedMessageIndices(body)).toEqual([0, 1]);
 	});
 
 	it("stays within Anthropic's 4-breakpoint budget", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Invalid `WATCHDOG.yml` entries now produce startup/editor warnings while healthy advisors remain available ([#11882](https://github.com/can1357/oh-my-pi/pull/11882) by [@olegpulatov](https://github.com/olegpulatov)).
+- Anthropic prompt caching now keeps rolling breakpoints on persisted history when multiple `context` extension handlers append per-call messages ([#11897](https://github.com/can1357/oh-my-pi/issues/11897)).
 - Claude Code session imports now preserve typed user text stored alongside tool results ([#11854](https://github.com/can1357/oh-my-pi/issues/11854)).
 - Extension commands now settle BTW writes before creating, switching, or branching sessions, preventing side requests from outliving their source session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).
 - Session selection and active-session deletion now settle BTW writes before switching or removing history, preventing stale saves from blocking the next session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -10,7 +10,12 @@ import type {
 	AgentToolUpdateCallback,
 } from "@oh-my-pi/pi-agent-core";
 import type { CredentialDisabledEvent, ImageContent, Model, ProviderResponseMetadata } from "@oh-my-pi/pi-ai";
-import { markPerCallContextMessage } from "@oh-my-pi/pi-ai/utils/block-symbols";
+import {
+	clearContextHistoryIndex,
+	getContextHistoryIndex,
+	markPerCallContextMessage,
+	setContextHistoryIndex,
+} from "@oh-my-pi/pi-ai/utils/block-symbols";
 import type { KeyId } from "@oh-my-pi/pi-tui";
 import { logger } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../../config/model-registry";
@@ -1638,7 +1643,10 @@ export class ExtensionRunner {
 			// return new message arrays rather than mutating in place.
 			currentMessages = [...messages];
 		}
-		const persistedMessages = new Set(currentMessages);
+		for (let index = 0; index < currentMessages.length; index++) {
+			const message = currentMessages[index];
+			if (message) setContextHistoryIndex(message, index);
+		}
 
 		for (const ext of this.extensions) {
 			const handlers = ext.handlers.get("context");
@@ -1655,14 +1663,32 @@ export class ExtensionRunner {
 				);
 
 				if (handlerResult && (handlerResult as ContextEventResult).messages) {
-					currentMessages = (handlerResult as ContextEventResult).messages!;
+					const nextMessages = (handlerResult as ContextEventResult).messages!;
+					for (let index = 0; index < nextMessages.length; index++) {
+						const message = nextMessages[index];
+						if (!message || getContextHistoryIndex(message) !== undefined) continue;
+						const previousMessage = currentMessages[index];
+						if (!previousMessage) continue;
+						const historyIndex = getContextHistoryIndex(previousMessage);
+						if (historyIndex === undefined) continue;
+						setContextHistoryIndex(message, historyIndex);
+						if (!Bun.deepEquals(message, previousMessage)) clearContextHistoryIndex(message);
+					}
+					currentMessages = nextMessages;
 				}
 			}
 		}
 
 		for (const message of currentMessages) {
-			if (!persistedMessages.has(message)) markPerCallContextMessage(message);
+			const historyIndex = getContextHistoryIndex(message);
+			const historyMessage = historyIndex === undefined ? undefined : messages[historyIndex];
+			if (historyMessage && historyIndex !== undefined) setContextHistoryIndex(historyMessage, historyIndex);
+			const unchanged = historyMessage !== undefined && Bun.deepEquals(message, historyMessage);
+			clearContextHistoryIndex(message);
+			if (historyMessage) clearContextHistoryIndex(historyMessage);
+			if (!unchanged) markPerCallContextMessage(message);
 		}
+		for (const message of messages) clearContextHistoryIndex(message);
 		return currentMessages;
 	}
 

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -10,6 +10,7 @@ import type {
 	AgentToolUpdateCallback,
 } from "@oh-my-pi/pi-agent-core";
 import type { CredentialDisabledEvent, ImageContent, Model, ProviderResponseMetadata } from "@oh-my-pi/pi-ai";
+import { markPerCallContextMessage } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import type { KeyId } from "@oh-my-pi/pi-tui";
 import { logger } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../../config/model-registry";
@@ -1637,6 +1638,7 @@ export class ExtensionRunner {
 			// return new message arrays rather than mutating in place.
 			currentMessages = [...messages];
 		}
+		const persistedMessages = new Set(currentMessages);
 
 		for (const ext of this.extensions) {
 			const handlers = ext.handlers.get("context");
@@ -1658,6 +1660,9 @@ export class ExtensionRunner {
 			}
 		}
 
+		for (const message of currentMessages) {
+			if (!persistedMessages.has(message)) markPerCallContextMessage(message);
+		}
 		return currentMessages;
 	}
 

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -23,6 +23,7 @@ import type {
 	UserMessage,
 } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
+import { copyPerCallContextMessage } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { isRecord, logger, prompt } from "@oh-my-pi/pi-utils";
 import { COLLAB_PROMPT_MESSAGE_TYPE } from "@oh-my-pi/pi-wire";
 import userInterjectionTemplate from "../prompts/steering/user-interjection.md" with { type: "text" };
@@ -1324,6 +1325,7 @@ function convertOneCached(m: AgentMessage, interruptedNext: boolean): Message[] 
 	const cached = convertCache.get(m);
 	if (cached !== undefined && cached.interruptedNext === interruptedNext) return cached.fragment;
 	const fragment = convertOne(m, interruptedNext);
+	for (const message of fragment) copyPerCallContextMessage(message, m);
 	convertCache.set(m, { interruptedNext, fragment });
 	return fragment;
 }

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -7,8 +7,11 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { Type } from "@oh-my-pi/omptype/typebox";
 import type { AgentMessage, AgentTool } from "@oh-my-pi/pi-agent-core";
+import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
+import type { MessageCreateParams } from "@oh-my-pi/pi-ai/providers/anthropic-wire";
 import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { ExtensionRuntime, loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
@@ -3948,6 +3951,94 @@ describe("ExtensionRunner", () => {
 			const image: ImageContent = { type: "image", mimeType: "image/png", data: "aW1hZ2U=" };
 
 			expect(await runner.emitInput("rewrite me", [image], "interactive")).toEqual({ text: "REWRITE ME" });
+		});
+	});
+
+	describe("context prompt caching", () => {
+		it("anchors Anthropic rolling breakpoints on persisted history behind injected messages", async () => {
+			const extensionCode = `
+				export default function(pi) {
+					const name = import.meta.path.endsWith("inject-a.ts") ? "a" : "b";
+					pi.on("context", async event => ({
+						messages: [...event.messages, {
+							role: "custom",
+							customType: "probe." + name,
+							content: "<probe-" + name + ">",
+							display: false,
+							attribution: "agent",
+							timestamp: Date.now(),
+						}],
+					}));
+				}
+			`;
+			await Bun.write(path.join(extensionsDir, "inject-a.ts"), extensionCode);
+			await Bun.write(path.join(extensionsDir, "inject-b.ts"), extensionCode);
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const model = getBundledModel<"anthropic-messages">("anthropic", "claude-sonnet-4-5");
+			if (!model) throw new Error("Expected bundled Anthropic model to exist");
+			const messages: AgentMessage[] = [
+				{ role: "user", content: "persisted user", timestamp: 1 },
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "persisted assistant" }],
+					api: "anthropic-messages",
+					provider: "anthropic",
+					model: model.id,
+					usage: {
+						input: 1,
+						output: 1,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 2,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+					timestamp: 2,
+				},
+			];
+			const transformed = await runner.emitContext(messages);
+			let body: MessageCreateParams | undefined;
+			const fetchMock = (async (_input: string | URL | Request, init?: RequestInit) => {
+				body = JSON.parse(String(init?.body ?? "{}")) as MessageCreateParams;
+				return new Response(
+					JSON.stringify({ type: "error", error: { type: "invalid_request_error", message: "captured" } }),
+					{ status: 400, headers: { "Content-Type": "application/json" } },
+				);
+			}) as typeof fetch;
+
+			await streamAnthropic(
+				model,
+				{
+					systemPrompt: ["system"],
+					messages: convertToLlm(transformed),
+					tools: [
+						{
+							name: "lookup",
+							description: "Lookup a value",
+							parameters: { type: "object", properties: {}, additionalProperties: false },
+						},
+					],
+				},
+				{ apiKey: "sk-ant-api-test", fetch: fetchMock },
+			)
+				.result()
+				.catch(() => undefined);
+			if (!body) throw new Error("Expected Anthropic wire body");
+
+			const cachedTexts = body.messages.flatMap(message => {
+				if (!Array.isArray(message.content)) return [];
+				return message.content.flatMap(block =>
+					"cache_control" in block && block.cache_control != null && block.type === "text" ? [block.text] : [],
+				);
+			});
+			expect(cachedTexts).toEqual(["persisted user", "persisted assistant"]);
 		});
 	});
 });

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -3960,7 +3960,7 @@ describe("ExtensionRunner", () => {
 				export default function(pi) {
 					const name = import.meta.path.endsWith("inject-a.ts") ? "a" : "b";
 					pi.on("context", async event => ({
-						messages: [...event.messages, {
+						messages: [...event.messages.map(message => ({ ...message })), {
 							role: "custom",
 							customType: "probe." + name,
 							content: "<probe-" + name + ">",


### PR DESCRIPTION
## Repro

Two or more `pi.on("context")` extension handlers that each append a message silently reduce Anthropic prompt-cache reuse to zero. A no-network wire-capture reproduction using `bun test packages/coding-agent/test/extensions-runner.test.ts -t "anchors Anthropic rolling breakpoints"` expected the two cached message texts to be the persisted user/assistant tail but received the two per-call `<probe-a>`/`<probe-b>` messages.

## Cause

`ExtensionRunner.emitContext` in `packages/coding-agent/src/extensibility/extensions/runner.ts` returned appended messages without provenance, so `convertToLlm` and `convertAnthropicMessages` could not distinguish them from persisted history. `applyPromptCaching` in `packages/ai/src/providers/anthropic.ts` therefore selected those two transient tail messages for the two rolling breakpoints.

## Fix

- Mark message objects introduced by a `context` transform as per-call context.
- Preserve that symbol-keyed provenance through coding-agent and Anthropic message conversion.
- Skip per-call messages while selecting rolling Anthropic cache breakpoints, leaving the markers on the latest persisted messages.
- Add a two-extension wire-capture regression test and an Unreleased changelog entry.

## Verification

`bun test packages/coding-agent/test/extensions-runner.test.ts` passed 85 tests; `bun test packages/ai/test/anthropic-head-caching.test.ts` passed 16 tests; `bun check` passed. The original wire-capture reproduction now reports cached texts `["persisted user", "persisted assistant"]`.

Fixes #11897