### PR TITLE
fix(ai): anchor proxy tunnel socket in a typed const

### DIFF
--- a/packages/ai/src/utils/proxy.ts
+++ b/packages/ai/src/utils/proxy.ts
@@ -380,14 +380,15 @@ export async function connectProxiedSocket(
 		}
 
 		const tlsOptions = options?.tls;
-		tunnelSocket = tls.connect({
+		const newTunnelSocket: tls.TLSSocket = tls.connect({
 			...tlsOptions,
 			socket: rawSocket,
 			servername: tlsOptions?.servername ?? targetHost,
 			ALPNProtocols: tlsOptions?.ALPNProtocols ?? ["h2"],
 		});
-		tunnelSocket.once("secureConnect", onTunnelReady);
-		tunnelSocket.once("error", onTunnelError);
+		tunnelSocket = newTunnelSocket;
+		newTunnelSocket.once("secureConnect", onTunnelReady);
+		newTunnelSocket.once("error", onTunnelError);
 	};
 	const onProxyReady = (): void => {
 		if (!rawSocket) return;


### PR DESCRIPTION
## What

> this fixex ai proxy tunnel narrowing testthe sente

Anchors the proxied TLS socket in a declared-type const (`const newTunnelSocket: tls.TLSSocket`) in `connectProxiedSocket` (`packages/ai/src/utils/proxy.ts`) instead of assigning `tls.connect(...)` directly to the `| undefined` outer binding. Identical runtime behavior.

## Why

Release `bun run check` failed with `TS18048 'tunnelSocket' is possibly 'undefined'` at `packages/ai/src/utils/proxy.ts:389-390` (surfaced via `@oh-my-pi/omp-stats:check`, which typechecks pi-ai from source).

Root cause: the release's `bun install` re-resolved floating transitive deps and downgraded `@types/node` 26.5.0 → 22.20.2 in `bun.lock`. Under 22.20.2 (combined with `bun-types`' `node:tls` augmentation), that `tls.connect({...})` call types as `any` with no call-site diagnostic (confirmed under both `tsgo` and classic `tsc`), so assigning it to `let tunnelSocket: tls.TLSSocket | undefined` never narrows. The const-with-annotation form attaches listeners to a binding already declared `TLSSocket`, independent of inference quirks, while a genuinely incompatible call would still error at the annotation.

## Testing

- Reproduced `TS18048` under `@types/node` 22.20.2 (`tsgo` and `tsc`); fixed file typechecks clean under both 22.20.2 and 26.5.0 (`packages/ai` and `packages/stats` projects).
- `bun test packages/ai/test/proxy.test.ts`: 45 pass, 0 fail (includes both `connectProxiedSocket` timeout/abort tests exercising the changed function).
- `oxfmt --check` and `oxlint` clean on the changed file.
- No new tests: the fix is type-level with identical runtime, so no runtime test can fail pre-fix; `check:types` is the regression gate.

---

- [ ] `bun check` passes (ran the relevant subset instead: `oxfmt`, `oxlint`, `tsgo` on `ai` + `stats`, and the `proxy` test suite — full parallel `bun check` incl. Rust not run)
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (n/a — type-only fix, no user-facing change)
