### PR TITLE
fix(coding-agent): version-robust fetch/socket/console typings

### DIFF
--- a/packages/coding-agent/src/blob-broker/exposure.ts
+++ b/packages/coding-agent/src/blob-broker/exposure.ts
@@ -186,10 +186,13 @@ export async function probeExposureHealth(
 	for (let attempt = 0; attempt < attempts; attempt++) {
 		healthUrl.searchParams.set("nonce", `${Date.now().toString(36)}-${attempt.toString(36)}`);
 		try {
-			const response = await fetchFn(healthUrl, {
+			// `cache` is absent from older undici RequestInit types; the
+			// intersection keeps this compiling against both old and new sets.
+			const init: RequestInit & { cache?: "no-store" } = {
 				cache: "no-store",
 				signal: AbortSignal.timeout(timeoutMs),
-			});
+			};
+			const response = await fetchFn(healthUrl, init);
 			if (response.status === 204) return;
 			finalStatus = `HTTP ${response.status}`;
 			try {

--- a/packages/coding-agent/src/cli/claude-trace-cli.ts
+++ b/packages/coding-agent/src/cli/claude-trace-cli.ts
@@ -639,15 +639,16 @@ export class ClaudeMessagesProxy {
 		if (rest.length > 0) {
 			clientTls.unshift(rest);
 		}
-		const upstreamTls = this.#track(
-			tls.connect({
-				host: target.host,
-				port: target.port,
-				servername: net.isIP(target.host) ? undefined : target.host,
-				rejectUnauthorized: this.#upstreamTlsRejectUnauthorized,
-				ALPNProtocols: ["http/1.1"],
-			}),
-		);
+		const upstreamTlsSocket: tls.TLSSocket = tls.connect({
+			host: target.host,
+			port: target.port,
+			servername: net.isIP(target.host) ? undefined : target.host,
+			rejectUnauthorized: this.#upstreamTlsRejectUnauthorized,
+			ALPNProtocols: ["http/1.1"],
+		});
+		// Annotate: `tls.connect` infers `any` under some @types/node versions,
+		// which would leave the "data" listener parameter untyped below.
+		const upstreamTls = this.#track(upstreamTlsSocket);
 		const requestParser = new HttpMessageParser("request");
 		const responseParser = new HttpMessageParser("response");
 		const responseQueue: Array<PendingCapturedRequest | null> = [];

--- a/packages/coding-agent/src/eval/js/shared/runtime.ts
+++ b/packages/coding-agent/src/eval/js/shared/runtime.ts
@@ -658,7 +658,10 @@ export class JsRuntime {
 					},
 				});
 				const tableConsole = new Console({ stdout: stream, colorMode: false });
-				(tableConsole.table as (...a: unknown[]) => void)(...args);
+				// `table` is missing from some @types/node Console shapes, but the
+				// Node runtime always provides it.
+				const tableCapable = tableConsole as unknown as { table: (...args: unknown[]) => void };
+				tableCapable.table(...args);
 				hooks.onText(buffer.endsWith("\n") ? buffer : `${buffer}\n`);
 			},
 			__omp_display__: (value: unknown) => this.displayValue(value),

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -408,7 +408,9 @@ async function loadImageFromUrl(
 	if (!contentType?.startsWith("image/")) {
 		throw new Error(`Unsupported image type from URL: ${imageUrl}`);
 	}
-	const buffer = await response.bytes();
+	// `Response.bytes()` is absent from older undici types; `arrayBuffer`
+	// exists in both and yields identical bytes.
+	const buffer = new Uint8Array(await response.arrayBuffer());
 	return { data: buffer.toBase64(), mimeType: contentType };
 }
 

--- a/packages/coding-agent/test/blob-resilience.test.ts
+++ b/packages/coding-agent/test/blob-resilience.test.ts
@@ -134,7 +134,10 @@ describe("public exposure health", () => {
 		let calls = 0;
 		const fetch = injectedFetch(async (input, init) => {
 			urls.push(String(input));
-			expect(init?.cache).toBe("no-store");
+			// `cache` is absent from older undici RequestInit types; read it
+			// through an intersection so the assertion compiles on both.
+			const initWithCache: RequestInit & { cache?: unknown } = init ?? {};
+			expect(initWithCache.cache).toBe("no-store");
 			calls++;
 			return new Response(null, { status: calls === 3 ? 204 : 503 });
 		});


### PR DESCRIPTION
## What

> Fixes build failures caused by @types/node version drift ("version drift fix")

Makes five call sites compile under both old and new lib types without changing runtime behavior: annotated `tls.connect` results as `tls.TLSSocket` (`cli/claude-trace-cli.ts`), `RequestInit & { cache?: ... }` intersection consts for the `cache: "no-store"` inits (`blob-broker/exposure.ts`, `test/blob-resilience.test.ts` — assertions unchanged), `arrayBuffer()`-wrapped read instead of `Response.bytes()` (`tools/image-gen.ts`), and a named-const structural cast for `Console.table` (`eval/js/shared/runtime.ts`).

## Why

Release `bun run check` failed with type errors on correct code because the release's `bun install` re-resolved floating transitive deps: `@types/node` 26.5.0 → 22.20.2 (npm's `latest` tag) plus `undici-types` 8.9.0 → 6.21.0. The old type set lacks `RequestInit.cache`, `Response.bytes()`, and narrows some `tls.connect` calls to `any` / drops `Console.table` from constructed instances. Nothing constrains `@types/node` (only transitive `*`/`>=` ranges), so any re-resolution can repeat the float; these sites no longer care which set is installed.

## Testing

- Reproduced all errors under the floated set (`@types/node` 22.20.2) with `tsgo` and classic `tsc`; fixed tree passes full `bun run check` (TS all packages + Rust) EXIT 0 in that env.
- Ported branch re-verified under pinned `@types/node` 26.5.0: `oxfmt`, `oxlint`, `tsgo` on `coding-agent` + `catalog` + `ai` all clean.
- Behavior suites (run where the native binding is built): `proxy.test.ts` 45/45, `blob-resilience` + `console-table` 10/10, `image-gen` 16/16.
- No new tests: fixes are type-level with identical runtime (existing suites cover the paths); `check:types` is the regression gate.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (n/a — type-only fix, no user-facing change)
