### PR TITLE
fix(install): pwsh version check for pwsh installer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -37,7 +37,7 @@
 - JavaScript speculation now validates coercion intrinsics used by `String()` and `.join()` inputs, not just template and `+` operands ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
 - Speculative reads now infer the summary language from the requested path while reading the resolved target, so cross-language symlinks summarize exactly like ordinary reads (by [@h4vc](https://github.com/h4vc)).
 - The structural summary cache now keys on the parser language path, so one file read through different extensions no longer reuses a stale summary (by [@h4vc](https://github.com/h4vc)).
-- Fixed the Windows installer failing on Windows PowerShell 5.1: OS architecture detection no longer depends on the .NET `RuntimeInformation` type that only resolves reliably on PowerShell 7, and the script now requires PowerShell 5.1+ with a clear upgrade message instead of failing cryptically ([#11905](https://github.com/can1357/oh-my-pi/pull/11905) by [@brit](https://github.com/brit)).
+- Fixed the Windows installer failing on Windows PowerShell 5.1: OS architecture detection no longer depends on the .NET `RuntimeInformation` type that only resolves reliably on PowerShell 7, and the script now requires PowerShell 5.1+ with a clear upgrade message instead of failing cryptically ([#11905](https://github.com/can1357/oh-my-pi/pull/11905)).
 ### Added
 
 - Added session-local `/btw` history with persistent answers and follow-ups; bare `/btw` reopens history, Escape cancels running answers before closing, and new questions no longer replace an in-progress answer.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -37,6 +37,7 @@
 - JavaScript speculation now validates coercion intrinsics used by `String()` and `.join()` inputs, not just template and `+` operands ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
 - Speculative reads now infer the summary language from the requested path while reading the resolved target, so cross-language symlinks summarize exactly like ordinary reads (by [@h4vc](https://github.com/h4vc)).
 - The structural summary cache now keys on the parser language path, so one file read through different extensions no longer reuses a stale summary (by [@h4vc](https://github.com/h4vc)).
+- Fixed the Windows installer failing on Windows PowerShell 5.1: OS architecture detection no longer depends on the .NET `RuntimeInformation` type that only resolves reliably on PowerShell 7, and the script now requires PowerShell 5.1+ with a clear upgrade message instead of failing cryptically.
 ### Added
 
 - Added session-local `/btw` history with persistent answers and follow-ups; bare `/btw` reopens history, Escape cancels running answers before closing, and new questions no longer replace an in-progress answer.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -37,7 +37,7 @@
 - JavaScript speculation now validates coercion intrinsics used by `String()` and `.join()` inputs, not just template and `+` operands ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
 - Speculative reads now infer the summary language from the requested path while reading the resolved target, so cross-language symlinks summarize exactly like ordinary reads (by [@h4vc](https://github.com/h4vc)).
 - The structural summary cache now keys on the parser language path, so one file read through different extensions no longer reuses a stale summary (by [@h4vc](https://github.com/h4vc)).
-- Fixed the Windows installer failing on Windows PowerShell 5.1: OS architecture detection no longer depends on the .NET `RuntimeInformation` type that only resolves reliably on PowerShell 7, and the script now requires PowerShell 5.1+ with a clear upgrade message instead of failing cryptically.
+- Fixed the Windows installer failing on Windows PowerShell 5.1: OS architecture detection no longer depends on the .NET `RuntimeInformation` type that only resolves reliably on PowerShell 7, and the script now requires PowerShell 5.1+ with a clear upgrade message instead of failing cryptically ([#11905](https://github.com/can1357/oh-my-pi/pull/11905)).
 ### Added
 
 - Added session-local `/btw` history with persistent answers and follow-ups; bare `/btw` reopens history, Escape cancels running answers before closing, and new questions no longer replace an in-progress answer.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -37,7 +37,7 @@
 - JavaScript speculation now validates coercion intrinsics used by `String()` and `.join()` inputs, not just template and `+` operands ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
 - Speculative reads now infer the summary language from the requested path while reading the resolved target, so cross-language symlinks summarize exactly like ordinary reads (by [@h4vc](https://github.com/h4vc)).
 - The structural summary cache now keys on the parser language path, so one file read through different extensions no longer reuses a stale summary (by [@h4vc](https://github.com/h4vc)).
-- Fixed the Windows installer failing on Windows PowerShell 5.1: OS architecture detection no longer depends on the .NET `RuntimeInformation` type that only resolves reliably on PowerShell 7, and the script now requires PowerShell 5.1+ with a clear upgrade message instead of failing cryptically ([#11905](https://github.com/can1357/oh-my-pi/pull/11905)).
+- Fixed the Windows installer failing on Windows PowerShell 5.1: OS architecture detection no longer depends on the .NET `RuntimeInformation` type that only resolves reliably on PowerShell 7, and the script now requires PowerShell 5.1+ with a clear upgrade message instead of failing cryptically ([#11905](https://github.com/can1357/oh-my-pi/pull/11905) by [@brit](https://github.com/brit)).
 ### Added
 
 - Added session-local `/btw` history with persistent answers and follow-ups; bare `/btw` reopens history, Escape cancels running answers before closing, and new questions no longer replace an in-progress answer.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -37,7 +37,7 @@
 - JavaScript speculation now validates coercion intrinsics used by `String()` and `.join()` inputs, not just template and `+` operands ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
 - Speculative reads now infer the summary language from the requested path while reading the resolved target, so cross-language symlinks summarize exactly like ordinary reads (by [@h4vc](https://github.com/h4vc)).
 - The structural summary cache now keys on the parser language path, so one file read through different extensions no longer reuses a stale summary (by [@h4vc](https://github.com/h4vc)).
-- Fixed the Windows installer failing on Windows PowerShell 5.1: OS architecture detection no longer depends on the .NET `RuntimeInformation` type that only resolves reliably on PowerShell 7, and the script now requires PowerShell 5.1+ with a clear upgrade message instead of failing cryptically ([#11905](https://github.com/can1357/oh-my-pi/pull/11905)).
+- Fixed the Windows installer failing on Windows PowerShell 5.1: OS architecture detection no longer depends on the .NET `RuntimeInformation` type that only resolves reliably on PowerShell 7, and the script now requires PowerShell 5.1+ with a clear upgrade message instead of failing cryptically ([#11905](https://github.com/can1357/oh-my-pi/pull/11905) by [@h4vc](https://github.com/h4vc)).
 ### Added
 
 - Added session-local `/btw` history with persistent answers and follow-ups; bare `/btw` reopens history, Escape cancels running answers before closing, and new questions no longer replace an in-progress answer.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -16,12 +16,31 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# Fail fast on hosts older than Windows PowerShell 5.1: cmdlets used below
+# (e.g. Invoke-WebRequest -TimeoutSec) are missing or unreliable there and
+# fail with cryptic errors halfway through the install. Anything newer,
+# including PowerShell 7+, passes this check.
+if ($PSVersionTable.PSVersion -lt [version]"5.1") {
+    throw "Windows PowerShell 5.1 or newer is required (found $($PSVersionTable.PSVersion)). Install PowerShell 7 from https://aka.ms/powershell and re-run the installer."
+}
+
 $Repo = "can1357/oh-my-pi"
 $Package = "@oh-my-pi/pi-coding-agent"
 $InstallDir = if ($env:PI_INSTALL_DIR) { $env:PI_INSTALL_DIR } else { "$env:LOCALAPPDATA\omp" }
-$NativeArchitecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
-if ($NativeArchitecture -notin @("x64", "arm64")) {
-    throw "Unsupported Windows architecture: $NativeArchitecture"
+# Windows PowerShell 5.1 (.NET Framework) does not reliably resolve
+# [System.Runtime.InteropServices.RuntimeInformation] without an
+# assembly-qualified name, while PowerShell 7+ (Core) loads that type from a
+# different assembly — so read the OS architecture from the environment
+# instead, which works on both. Prefer PROCESSOR_ARCHITEW6432 so a 32-bit
+# host on 64-bit Windows still reports the OS architecture.
+$RawArchitecture = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
+if (-not $RawArchitecture) {
+    throw "Unable to determine Windows architecture"
+}
+$NativeArchitecture = switch ($RawArchitecture.ToUpperInvariant()) {
+    "AMD64" { "x64" }
+    "ARM64" { "arm64" }
+    default { throw "Unsupported Windows architecture: $RawArchitecture" }
 }
 $BinaryName = "omp-windows-$NativeArchitecture.exe"
 $MinimumBunVersion = "1.3.14"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -33,6 +33,10 @@ $InstallDir = if ($env:PI_INSTALL_DIR) { $env:PI_INSTALL_DIR } else { "$env:LOCA
 # different assembly — so read the OS architecture from the environment
 # instead, which works on both. Prefer PROCESSOR_ARCHITEW6432 so a 32-bit
 # host on 64-bit Windows still reports the OS architecture.
+# Note: PROCESSOR_ARCHITEW6432 is only set for 32-bit (WOW64) processes, so
+# x64 PowerShell under ARM64 emulation reports AMD64 and installs the x64
+# binary (runs emulated, not natively). Native ARM64 and x86-on-ARM64 hosts
+# still resolve to arm64.
 $RawArchitecture = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
 if (-not $RawArchitecture) {
     throw "Unable to determine Windows architecture"


### PR DESCRIPTION
## What

In my own words: pwsh version check for pwsh installer.

`scripts/install.ps1` now fails fast on PowerShell older than 5.1 with a clear upgrade message, and OS-architecture detection no longer depends on the .NET `RuntimeInformation` type — it reads `PROCESSOR_ARCHITEW6432`/`PROCESSOR_ARCHITECTURE` instead, which resolves on both Windows PowerShell 5.1 and PowerShell 7+.

## Why

`irm https://omp.sh/install.ps1 | iex` errored on Windows PowerShell 5.1 at the `[System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture` lookup: that type lives in different assemblies per runtime (mscorlib on .NET Framework vs its own assembly on Core), so the unqualified reference does not resolve reliably on 5.1. Env-based detection removes the drift, and the version gate gives pre-5.1 hosts a clear error instead of cryptic mid-install failures.

## Testing

- Full script parse-checks clean on Windows PowerShell 5.1 (`5.1.22621.6133`) and PowerShell 7 (`7.7.0-preview.4`) via `[scriptblock]::Create`.
- Arch mapping exercised on both editions: real env → `x64`; simulated `ARM64` → `arm64`; simulated WOW64 (`x86` + `ARCHITEW6432=AMD64`) → `x64`; unknown (`MIPS`) → throws `Unsupported Windows architecture`.
- Version gate passes on both real editions; synthetic checks: `5.0 < 5.1` → True (would throw), `5.1`/`7.5` → False (pass).
- `bun check`: not applicable — no TypeScript/JavaScript changed (only `scripts/install.ps1` plus changelog).

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)
