### PR TITLE
fix(auth): register zcode:// handler with a shell-launchable path

### DIFF
--- a/crates/pi-natives/src/oauth_callback/windows.rs
+++ b/crates/pi-natives/src/oauth_callback/windows.rs
@@ -3,7 +3,7 @@ use std::{
 	ffi::{OsStr, OsString},
 	io,
 	os::windows::ffi::{OsStrExt, OsStringExt},
-	path::{Component, Path},
+	path::{Component, Path, PathBuf, Prefix},
 	ptr,
 };
 
@@ -459,7 +459,45 @@ fn refuse_protected_default(scheme: &str) -> Result<()> {
 	)
 }
 
+/// Rewrite a canonicalized transaction path into a form the Windows shell can
+/// launch.
+///
+/// Transaction paths descend from `fs::canonicalize`, which returns verbatim
+/// (`\\?\`) paths. `ShellExecuteEx` — the API browsers use to hand a custom
+/// scheme to its registered handler — refuses those, so registering a verbatim
+/// command installs a handler that resolves but never starts: association
+/// lookup succeeds, the relay never runs, and sign-in waits out its deadline on
+/// a callback that cannot arrive.
+fn shell_path(path: &Path) -> Result<PathBuf> {
+	let mut components = path.components();
+	let Some(Component::Prefix(prefix)) = components.next() else {
+		return Ok(path.to_path_buf());
+	};
+	let mut shell = match prefix.kind() {
+		Prefix::Disk(_) | Prefix::UNC(..) => return Ok(path.to_path_buf()),
+		Prefix::VerbatimDisk(letter) => {
+			PathBuf::from(format!("{}:\\", char::from(letter.to_ascii_uppercase())))
+		},
+		Prefix::VerbatimUNC(server, share) => {
+			let mut root = OsString::from(r"\\");
+			root.push(server);
+			root.push(r"\");
+			root.push(share);
+			root.push(r"\");
+			PathBuf::from(root)
+		},
+		Prefix::Verbatim(_) | Prefix::DeviceNS(_) => bail!(
+			"the Windows shell cannot launch an OAuth callback handler stored under {}",
+			path.display()
+		),
+	};
+	shell.extend(components.filter(|component| !matches!(component, Component::RootDir)));
+	Ok(shell)
+}
+
 fn relay_command(helper: &Path, callback: &Path) -> Result<OsString> {
+	let helper = shell_path(helper)?;
+	let callback = shell_path(callback)?;
 	if helper.as_os_str().encode_wide().any(|unit| unit == 0)
 		|| callback.as_os_str().encode_wide().any(|unit| unit == 0)
 	{
@@ -675,6 +713,47 @@ mod tests {
 				r#""C:\Program Files\omp\callback \"helper\".exe" "C:\OAuth callbacks\pending\\" "%1""#
 			)
 		);
+	}
+
+	#[test]
+	fn command_rewrites_canonicalized_verbatim_paths_the_shell_cannot_launch() {
+		let command = relay_command(
+			Path::new(r"\\?\C:\Users\dev\.omp\oauth\callback-helper.exe"),
+			Path::new(r"\\?\C:\Users\dev\.omp\oauth\callback.url"),
+		)
+		.unwrap();
+		assert_eq!(
+			command,
+			OsString::from(
+				r#""C:\Users\dev\.omp\oauth\callback-helper.exe" "C:\Users\dev\.omp\oauth\callback.url" "%1""#
+			)
+		);
+	}
+
+	#[test]
+	fn command_rewrites_verbatim_unc_paths_to_their_shell_form() {
+		let command = relay_command(
+			Path::new(r"\\?\UNC\files\home\dev\callback-helper.exe"),
+			Path::new(r"\\?\UNC\files\home\dev\callback.url"),
+		)
+		.unwrap();
+		assert_eq!(
+			command,
+			OsString::from(
+				r#""\\files\home\dev\callback-helper.exe" "\\files\home\dev\callback.url" "%1""#
+			)
+		);
+	}
+
+	#[test]
+	fn command_refuses_volume_paths_instead_of_registering_a_dead_handler() {
+		let error = relay_command(
+			Path::new(r"\\?\Volume{d0e5f6a7-0000-0000-0000-000000000000}\callback-helper.exe"),
+			Path::new(r"\\?\Volume{d0e5f6a7-0000-0000-0000-000000000000}\callback.url"),
+		)
+		.unwrap_err()
+		.to_string();
+		assert!(error.contains("cannot launch"), "{error}");
 	}
 
 	#[test]

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed Kimi Code's 7-day rate-limiting window being mislabeled as "Total quota" in `omp usage`, causing accounts whose monthly subscription pool is exhausted to appear 100% free while chat completions fail; parsed `totalQuota` add-on packs into the true "Total quota" row when present, and recognized Kimi's HTTP 403 `access_terminated_error` as a credential-rotatable usage limit. ([#11827](https://github.com/can1357/oh-my-pi/pull/11827) by [@revofusion](https://github.com/revofusion))
 - Fixed provider streams that die after emitting `toolcall_start` but before any argument content failing validation with empty `{}` arguments; the uncommitted attempt is now discarded and retried ([#11823](https://github.com/can1357/oh-my-pi/pull/11823) by [@justdoGIT](https://github.com/justdoGIT)).
+- Fixed Windows `zcode://` (Z.AI coding-plan) OAuth sign-in never completing after a successful browser authorization: the native callback handler is now registered with a path the Windows shell can launch, so the `zcode://zai-auth/callback` redirect reaches omp instead of being silently dropped by the browser.
 ### Added
 
 - Charm Hyper accounts now report their remaining prepaid credit balance in `/usage` ([#11656](https://github.com/can1357/oh-my-pi/pull/11656) by [@oldschoola](https://github.com/oldschoola)).

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Fixed Kimi Code's 7-day rate-limiting window being mislabeled as "Total quota" in `omp usage`, causing accounts whose monthly subscription pool is exhausted to appear 100% free while chat completions fail; parsed `totalQuota` add-on packs into the true "Total quota" row when present, and recognized Kimi's HTTP 403 `access_terminated_error` as a credential-rotatable usage limit. ([#11827](https://github.com/can1357/oh-my-pi/pull/11827) by [@revofusion](https://github.com/revofusion))
 - Fixed provider streams that die after emitting `toolcall_start` but before any argument content failing validation with empty `{}` arguments; the uncommitted attempt is now discarded and retried ([#11823](https://github.com/can1357/oh-my-pi/pull/11823) by [@justdoGIT](https://github.com/justdoGIT)).
-- Fixed Windows `zcode://` (Z.AI coding-plan) OAuth sign-in never completing after a successful browser authorization: the native callback handler is now registered with a path the Windows shell can launch, so the `zcode://zai-auth/callback` redirect reaches omp instead of being silently dropped by the browser.
+- Fixed Windows `zcode://` (Z.AI coding-plan) OAuth sign-in never completing after a successful browser authorization: the native callback handler is now registered with a path the Windows shell can launch, so the `zcode://zai-auth/callback` redirect reaches omp instead of being silently dropped by the browser ([#11907](https://github.com/can1357/oh-my-pi/pull/11907) by [@oldschoola](https://github.com/oldschoola)).
 ### Added
 
 - Charm Hyper accounts now report their remaining prepaid credit balance in `/usage` ([#11656](https://github.com/can1357/oh-my-pi/pull/11656) by [@oldschoola](https://github.com/oldschoola)).


### PR DESCRIPTION
## What

zcode was not working on windows.

The Windows `zcode://` handler was registered with a verbatim `\\?\` path from `fs::canonicalize`. `ShellExecuteEx` refuses those, so the handler resolved but never started — association lookup succeeded, the browser reported the redirect as delivered, the relay never ran, and sign-in waited out its deadline. `relay_command` now converts the helper/callback paths to their shell-launchable form (verbatim disk and UNC prefixes mapped back to `C:\...` and `\\server\share\...`; volume/device paths refused so the flow falls back to manual paste instead of registering a handler that can never start). Non-verbatim paths pass through untouched, preserving the existing quoting and non-UTF-16 behavior.

## Why

Z.AI coding-plan OAuth could not complete on Windows in any browser (observed with Helium). The `zcode://zai-auth/callback?code=…&state=…` redirect was visible in the browser console but never reached omp, so login hung at the paste prompt.

## Testing

Reproduced first: `ShellExecute` against the verbatim registration hung for 90s and delivered nothing. After the fix, the same launch delivered the full callback URL (`&state=` intact) in 0.64s and restored the registry cleanly on dispose:

```
start() -> true
registered command:
  "C:\Users\...\callback-helper.exe" "C:\...\callback.url" "%1"
callback -> zcode://zai-auth/callback?code=code-fa74e757644a&state=eb63d108de423137e2086f1871bb6655
disposed; leftover registration: (none)
```

- `cargo nextest run -p pi-natives -E 'test(oauth_callback)'` — 18/18 pass (3 new regression tests covering verbatim disk, verbatim UNC, and the refusal path)
- `packages/ai/test/zai-oauth.test.ts` — 13/13 pass
- `bun check` — passes

Note: `bun run test:rs` cannot run the full workspace on Windows — `pi-builtins`' `stat.rs` tests reference a `tempdir` helper that is not in scope on this platform. That failure is pre-existing on `main` and unrelated to this change, so the crate under test was verified with a package-scoped nextest run.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution
