### PR TITLE
fix(coding-agent): make memory://root backend-aware and fix glob error

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -41,6 +41,8 @@ The agent can read memory files directly using `memory://` URLs with the `read` 
 
 The `memory://<memory-id>` form returns the full stored row rather than the clipped recall preview (recall content that exceeds the preview cap ends with a trailing `…`); agents are instructed to read it before any `memory_edit update`.
 
+The `memory://root[/…]` rows are file-backed and only exist with `memory.backend: local`, which populates the on-disk memory root via the consolidation pipeline. Under `hindsight` or `mnemopi` the root is never written, so those URLs do not resolve — use `recall`/`reflect` (and `read memory://<memory-id>` on `mnemopi`) instead.
+
 ### `/memory` slash command
 
 | Subcommand            | Effect                                                    |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `memory://root` is now advertised in URL completion only on `memory.backend=local`, and reading it on `hindsight`/`mnemopi` reports the file-backed root as local-only (pointing at `recall`/`reflect`) instead of telling you to enable memories that are already enabled; the memory glob validator now names the expected form (`memory://root/**`) instead of echoing the rejected input ([#11909](https://github.com/can1357/oh-my-pi/issues/11909)).
+
 ## [18.1.19] - 2026-09-12
 
 - Fixed `--mode json` returning exit 0 on a turn-fatal provider/auth/network error ([#11498](https://github.com/can1357/oh-my-pi/issues/11498)).

--- a/packages/coding-agent/src/internal-urls/memory-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/memory-protocol.ts
@@ -95,7 +95,9 @@ export function splitMemoryGlobPattern(input: string): MemoryGlobPattern {
 	const url = parseInternalUrl(urlMatch[1]);
 	const namespace = url.rawHost || url.hostname;
 	if (url.protocol !== "memory:" || namespace !== MEMORY_NAMESPACE) {
-		throw new Error(`Memory glob patterns require the ${MEMORY_NAMESPACE} namespace: ${input}`);
+		throw new Error(
+			`Memory glob patterns require the ${MEMORY_NAMESPACE} namespace (e.g. memory://${MEMORY_NAMESPACE}/**); got: ${input}`,
+		);
 	}
 
 	const rawPathname = urlMatch[2] ?? "";
@@ -320,6 +322,31 @@ function unknownNamespaceError(namespace: string): Error {
 }
 
 /**
+ * Error for the file-backed `memory://root` namespace when no artifacts exist.
+ * Only `memory.backend=local` ever populates the on-disk root; hindsight keeps
+ * memory server-side and mnemopi in SQLite banks, so on those backends the root
+ * is permanently absent. The message is backend-aware so it never prescribes
+ * "enable memories" to a caller whose backend is already healthy — it points at
+ * the tools that can actually answer instead.
+ */
+function fileBackedRootUnavailableError(backend: string | undefined): Error {
+	if (backend === undefined || backend === "local") {
+		return new Error(
+			"Memory artifacts are not available for this project yet. Run a session with memories enabled first.",
+		);
+	}
+	const searchHint =
+		backend === "mnemopi"
+			? " Use `recall`/`reflect` to search Mnemopi memories, or `read memory://<memory-id>` for a full row."
+			: backend === "hindsight"
+				? " Use `recall`/`reflect` to search Hindsight memories."
+				: "";
+	return new Error(
+		`File-backed memory artifacts only exist with memory.backend=local (active backend: ${backend}).${searchHint}`,
+	);
+}
+
+/**
  * Look up a mnemopi memory row by id across every live session's scoped banks.
  * First hit wins; returns `null` when the id is not stored anywhere in scope.
  */
@@ -426,9 +453,7 @@ export class MemoryProtocolHandler implements ProtocolHandler {
 
 		const roots = memoryRootsForContext(context, caller.session);
 		if (roots.length === 0) {
-			throw new Error(
-				"Memory artifacts are not available for this project yet. Run a session with memories enabled first.",
-			);
+			throw fileBackedRootUnavailableError(backend);
 		}
 
 		let anyExists = false;
@@ -445,9 +470,7 @@ export class MemoryProtocolHandler implements ProtocolHandler {
 		}
 
 		if (!anyExists) {
-			throw new Error(
-				"Memory artifacts are not available for this project yet. Run a session with memories enabled first.",
-			);
+			throw fileBackedRootUnavailableError(backend);
 		}
 
 		throw new Error(`Memory file not found: ${url.href}`);
@@ -457,7 +480,7 @@ export class MemoryProtocolHandler implements ProtocolHandler {
 		const caller = resolveMemoryCaller(context);
 		if (caller.backend === "off") return [];
 		const completions: UrlCompletion[] = [];
-		if (memoryRootsForContext(context, caller.session).length > 0) {
+		if (caller.backend === "local") {
 			completions.push({ value: MEMORY_NAMESPACE, description: "Project memory summary" });
 		}
 		const mnemopiAvailable = caller.legacy

--- a/packages/coding-agent/src/internal-urls/memory-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/memory-protocol.ts
@@ -322,12 +322,12 @@ function unknownNamespaceError(namespace: string): Error {
 }
 
 /**
- * Error for the file-backed `memory://root` namespace when no artifacts exist.
- * Only `memory.backend=local` ever populates the on-disk root; hindsight keeps
- * memory server-side and mnemopi in SQLite banks, so on those backends the root
- * is permanently absent. The message is backend-aware so it never prescribes
- * "enable memories" to a caller whose backend is already healthy — it points at
- * the tools that can actually answer instead.
+ * Error for the file-backed `memory://root` namespace when it is unavailable.
+ * Only `memory.backend=local` owns this namespace; hindsight keeps memory
+ * server-side and mnemopi in SQLite banks. Non-local callers must not see
+ * potentially stale files left by an earlier local session. The backend-aware
+ * message points at the tools that can actually answer instead of prescribing
+ * "enable memories" to a caller whose backend is already healthy.
  */
 function fileBackedRootUnavailableError(backend: string | undefined): Error {
 	if (backend === undefined || backend === "local") {
@@ -449,6 +449,14 @@ export class MemoryProtocolHandler implements ProtocolHandler {
 			throw new Error(
 				`Mnemopi memory ${namespace} not found in any scoped bank. Use \`recall\` to list available ids.`,
 			);
+		}
+
+		// A project may retain files from an earlier local session. Reject known
+		// non-local callers before probing the filesystem so those stale
+		// artifacts cannot leak across backend changes. Contextless legacy
+		// callers have no active backend to gate and retain the registry sweep.
+		if (backend !== undefined && backend !== "local") {
+			throw fileBackedRootUnavailableError(backend);
 		}
 
 		const roots = memoryRootsForContext(context, caller.session);

--- a/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
@@ -780,9 +780,9 @@ describe("MemoryProtocolHandler — mnemopi bridge (issue #4443)", () => {
 				await expect(router.resolve(`memory://${twinId}`, context)).rejects.toThrow(
 					/not found in the calling session's scoped bank/,
 				);
-				await expect(router.resolve("memory://root", context)).resolves.toMatchObject({
-					content: "shared cwd summary",
-				});
+				await expect(router.resolve("memory://root", context)).rejects.toThrow(
+					"File-backed memory artifacts only exist with memory.backend=local (active backend: mnemopi).",
+				);
 			} finally {
 				setAgentDir(previousAgentDir);
 				await twinState?.dispose({ consolidate: false });
@@ -964,13 +964,16 @@ describe("MemoryProtocolHandler — file-backed root vs non-local backends (issu
 		InternalUrlRouter.resetForTests();
 	});
 
-	it("reports the file-backed root as local-only on hindsight instead of prescribing 'enable memories'", async () => {
+	it("rejects stale local root artifacts after switching to hindsight", async () => {
 		const cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-protocol-11909-hindsight-"));
 		const previousAgentDir = getAgentDir();
 		try {
 			setAgentDir(path.join(cleanupRoot, "agent"));
 			const cwd = path.join(cleanupRoot, "project");
 			await fs.mkdir(cwd, { recursive: true });
+			const memoryRoot = getMemoryRoot(getAgentDir(), cwd);
+			await fs.mkdir(memoryRoot, { recursive: true });
+			await Bun.write(path.join(memoryRoot, "memory_summary.md"), "stale local summary");
 			const settings = Settings.isolated({ "memory.backend": "hindsight" });
 			await expect(InternalUrlRouter.instance().resolve("memory://root", { cwd, settings })).rejects.toThrow(
 				"File-backed memory artifacts only exist with memory.backend=local (active backend: hindsight). Use `recall`/`reflect` to search Hindsight memories.",

--- a/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { InternalUrlRouter } from "@oh-my-pi/pi-coding-agent/internal-urls";
+import { splitMemoryGlobPattern } from "@oh-my-pi/pi-coding-agent/internal-urls/memory-protocol";
 import { getMemoryRoot } from "@oh-my-pi/pi-coding-agent/memories";
 import {
 	loadMnemopi,
@@ -824,12 +825,13 @@ describe("MemoryProtocolHandler — mnemopi bridge (issue #4443)", () => {
 			expect(bound?.items.map(item => item.value)).toContain("memory://<memory-id>");
 
 			// Typing into the child instead binds to its hindsight backend, which has
-			// no addressable ids, rather than to the peer bank in the same cwd.
+			// no addressable ids and no file-backed root, so it is offered nothing.
 			const childBound = await getInternalUrlSuggestions("memory://", undefined, undefined, () => ({
 				cwd: sharedCwd,
 				sessionFile: childSessionFile,
 			}));
-			expect(childBound?.items.map(item => item.value)).not.toContain("memory://<memory-id>");
+			expect(childBound?.items.map(item => item.value) ?? []).not.toContain("memory://<memory-id>");
+			expect(childBound?.items.map(item => item.value) ?? []).not.toContain("memory://root");
 
 			// A caller that is no longer registered is offered nothing at all.
 			expect(
@@ -947,6 +949,70 @@ describe("MemoryProtocolHandler — hindsight (issue #7587)", () => {
 		const router = InternalUrlRouter.instance();
 		await expect(router.resolve("memory://a1b2c3d4e5f6")).rejects.toThrow(
 			/Unknown memory namespace: a1b2c3d4e5f6\. Supported: root/,
+		);
+	});
+});
+
+describe("MemoryProtocolHandler — file-backed root vs non-local backends (issue #11909)", () => {
+	beforeEach(() => {
+		AgentRegistry.resetGlobalForTests();
+		InternalUrlRouter.resetForTests();
+	});
+
+	afterEach(() => {
+		AgentRegistry.resetGlobalForTests();
+		InternalUrlRouter.resetForTests();
+	});
+
+	it("reports the file-backed root as local-only on hindsight instead of prescribing 'enable memories'", async () => {
+		const cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-protocol-11909-hindsight-"));
+		const previousAgentDir = getAgentDir();
+		try {
+			setAgentDir(path.join(cleanupRoot, "agent"));
+			const cwd = path.join(cleanupRoot, "project");
+			await fs.mkdir(cwd, { recursive: true });
+			const settings = Settings.isolated({ "memory.backend": "hindsight" });
+			await expect(InternalUrlRouter.instance().resolve("memory://root", { cwd, settings })).rejects.toThrow(
+				"File-backed memory artifacts only exist with memory.backend=local (active backend: hindsight). Use `recall`/`reflect` to search Hindsight memories.",
+			);
+		} finally {
+			setAgentDir(previousAgentDir);
+			await removeWithRetries(cleanupRoot);
+		}
+	});
+
+	it("keeps the 'run a session' message for local backend before consolidation writes the root", async () => {
+		const cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-protocol-11909-local-"));
+		const previousAgentDir = getAgentDir();
+		try {
+			setAgentDir(path.join(cleanupRoot, "agent"));
+			const cwd = path.join(cleanupRoot, "project");
+			await fs.mkdir(cwd, { recursive: true });
+			const settings = Settings.isolated({ "memory.backend": "local" });
+			await expect(InternalUrlRouter.instance().resolve("memory://root", { cwd, settings })).rejects.toThrow(
+				"Memory artifacts are not available for this project yet. Run a session with memories enabled first.",
+			);
+		} finally {
+			setAgentDir(previousAgentDir);
+			await removeWithRetries(cleanupRoot);
+		}
+	});
+
+	it("advertises memory://root only on the local backend that can populate it", async () => {
+		const router = InternalUrlRouter.instance();
+		const hindsight = await router.complete("memory", "", {
+			settings: Settings.isolated({ "memory.backend": "hindsight" }),
+		});
+		expect((hindsight ?? []).map(item => item.value)).not.toContain("root");
+		const local = await router.complete("memory", "", {
+			settings: Settings.isolated({ "memory.backend": "local" }),
+		});
+		expect((local ?? []).map(item => item.value)).toContain("root");
+	});
+
+	it("names the expected glob form rather than the rejected input", () => {
+		expect(() => splitMemoryGlobPattern("memory://**")).toThrow(
+			"Memory glob patterns require the root namespace (e.g. memory://root/**); got: memory://**",
 		);
 	});
 });


### PR DESCRIPTION
## Repro
On a healthy `memory.backend: hindsight` session (recall/retain/reflect all functional), exercising the `memory://` URL surface with a cwd that has no file-backed memory root:

```
read memory://root
→ Memory artifacts are not available for this project yet. Run a session with memories enabled first.

glob memory://**
→ Memory glob patterns require the root namespace: memory://**
```

Memories are enabled, so the first message misdirects; the second demands the exact string it just rejected (the accepted form is `memory://root/**`).

## Cause
In `packages/coding-agent/src/internal-urls/memory-protocol.ts`: the file-backed `memory://root` namespace is only ever populated by the local consolidation pipeline (`memory.backend=local`); hindsight keeps memory server-side and mnemopi in SQLite banks, so the on-disk root is never written on those backends. Yet `MemoryProtocolHandler.complete()` gated the `root` completion on `memoryRootsForContext(...).length > 0` — always true once a cwd is known — so `memory://root` was advertised on every backend, and `resolve()` threw the backend-agnostic `Run a session with memories enabled first` message on any `!anyExists`. Separately, `splitMemoryGlobPattern()` interpolated `${input}` (the rejected string) right after "require the root namespace".

## Fix
- `complete()` now gates the `root` completion on `caller.backend === "local"` rather than root-path length, so it is advertised only where it can be populated.
- New `fileBackedRootUnavailableError(backend)` helper: `local` keeps the original "run a session" hint (correct before first consolidation); `hindsight`/`mnemopi` report the file-backed root as local-only and point at `recall`/`reflect` (and `read memory://<memory-id>` on mnemopi). `resolve()` throws it on both the empty-roots and `!anyExists` paths. Resolution of an existing root is unchanged.
- `splitMemoryGlobPattern()` now names the expected form (`memory://root/**`) instead of echoing the rejected input.
- `docs/memory.md` documents that the `memory://root[/…]` rows are file-backed and only exist with `memory.backend: local`.

## Verification
`bun test test/internal-urls/memory-protocol.test.ts` — 38 pass (4 new regression tests: backend-aware hindsight error, local-backend message preserved, completion advertised only on local, corrected glob message). `bun test test/input-controller-internal-url-caller.test.ts` passes. `bun test test/advisor-memory.test.ts` shows behavior identical to `main` (3 pass, 1 pre-existing hindsight `Memory file not found` realpath-fixture failure that fails the same way on the pristine `HEAD` source, which this change does not touch). Fixes #11909