### PR TITLE
feat(theme): make the Vim-mode status colors themable

### DIFF
--- a/docs/theme.md
+++ b/docs/theme.md
@@ -38,7 +38,7 @@ Color values accept:
 
 ## Required and optional color tokens
 
-All tokens below are required in `colors` except `thinkingMax`, which is optional for compatibility and falls back to `thinkingXhigh`.
+All tokens below are required in `colors` except `thinkingMax`, which is optional for compatibility and falls back to `thinkingXhigh`, and the `statusLineVim*` tokens, which are optional and fall back to `accent`/`success`/`warning`.
 
 ### Core text and borders (11)
 
@@ -65,9 +65,11 @@ All tokens below are required in `colors` except `thinkingMax`, which is optiona
 
 `thinkingOff`, `thinkingMinimal`, `thinkingLow`, `thinkingMedium`, `thinkingHigh`, `thinkingXhigh`, optional `thinkingMax`, `bashMode`, `pythonMode`
 
-### Status line segment colors (13)
+### Status line segment colors (13 required, 4 optional)
 
 `statusLineSep`, `statusLineModel`, `statusLinePath`, `statusLineGitClean`, `statusLineGitDirty`, `statusLineContext`, `statusLineSpend`, `statusLineStaged`, `statusLineDirty`, `statusLineUntracked`, `statusLineOutput`, `statusLineCost`, `statusLineSubagents`
+
+The Vim-mode indicator (the `vim` segment and the composer border, both shown while `tui.vimMode` is on) takes four optional tokens: `statusLineVimNormal` (defaults to `accent`), `statusLineVimInsert` (`success`), `statusLineVimVisual` (`warning`) and `statusLineVimVisualLine` (`warning`).
 
 ## Optional tokens
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added optional `statusLineVimNormal`, `statusLineVimInsert`, `statusLineVimVisual`, and `statusLineVimVisualLine` theme colors, so the Vim-mode status segment and the composer border follow the active theme like the mode icons already do; a theme that omits them keeps today's `accent`/`success`/`warning` rendering.
+
 ## [18.1.19] - 2026-09-12
 
 - Fixed `--mode json` returning exit 0 on a turn-fatal provider/auth/network error ([#11498](https://github.com/can1357/oh-my-pi/issues/11498)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added optional `statusLineVimNormal`, `statusLineVimInsert`, `statusLineVimVisual`, and `statusLineVimVisualLine` theme colors, so the Vim-mode status segment and the composer border follow the active theme like the mode icons already do; a theme that omits them keeps today's `accent`/`success`/`warning` rendering.
+- Added optional `statusLineVimNormal`, `statusLineVimInsert`, `statusLineVimVisual`, and `statusLineVimVisualLine` theme colors, so the Vim-mode status segment and the composer border follow the active theme like the mode icons already do; a theme that omits them keeps today's `accent`/`success`/`warning` rendering ([#11915](https://github.com/can1357/oh-my-pi/pull/11915) by [@georgesleen](https://github.com/georgesleen)).
 
 ## [18.1.19] - 2026-09-12
 

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -806,11 +806,15 @@ const VIM_MODE_ICON_KEYS: Record<NonNullable<SegmentContext["vim"]>["mode"], Sym
 	"visual-line": "icon.vimVisualLine",
 };
 
-const VIM_MODE_COLORS: Record<NonNullable<SegmentContext["vim"]>["mode"], ThemeColor> = {
-	insert: "success",
-	normal: "accent",
-	visual: "warning",
-	"visual-line": "warning",
+/**
+ * Colors resolve through the theme like the icons above; `createTheme` defaults an omitted key to
+ * the token named here before. Exported because the composer border colors the same four modes.
+ */
+export const VIM_MODE_COLORS: Record<NonNullable<SegmentContext["vim"]>["mode"], ThemeColor> = {
+	insert: "statusLineVimInsert",
+	normal: "statusLineVimNormal",
+	visual: "statusLineVimVisual",
+	"visual-line": "statusLineVimVisualLine",
 };
 
 const vimSegment: StatusLineSegment = {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -190,6 +190,7 @@ import { type PlanReviewAnnotationState, PlanReviewOverlay } from "./components/
 import { PlanSaveOverlay, type PlanSaveOverlayResult } from "./components/plan-save-overlay";
 import { SessionInfoOverlay } from "./components/session-info-overlay";
 import { StatusLineComponent } from "./components/status-line";
+import { VIM_MODE_COLORS } from "./components/status-line/segments";
 import { stopSharedSpinnerTicker, type ToolExecutionHandle } from "./components/tool-execution";
 import { TranscriptContainer } from "./components/transcript-container";
 import type { LspServerInfo as WelcomeLspServerInfo } from "./components/welcome";
@@ -2537,15 +2538,9 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.editor.borderColor = theme.getBashModeBorderColor();
 		} else if (this.isPythonMode) {
 			this.editor.borderColor = theme.getPythonModeBorderColor();
-		} else if (vimMode === "visual" || vimMode === "visual-line") {
-			this.editor.borderColor = (str: string) => theme.fg("warning", str);
-		} else if (vimMode === "normal") {
-			this.editor.borderColor = (str: string) => theme.fg("accent", str);
-		} else if (vimMode === "insert") {
-			// Insert gets its own colour rather than falling through to the session accent: with Normal
-			// and Visual both coloured, an uncoloured Insert made the border unreadable as a mode.
-			// Matches the `vim` status-line segment, which uses the same three colours.
-			this.editor.borderColor = (str: string) => theme.fg("success", str);
+		} else if (vimMode !== undefined) {
+			// Same map as the `vim` status-line segment, so border and label cannot disagree.
+			this.editor.borderColor = (str: string) => theme.fg(VIM_MODE_COLORS[vimMode], str);
 		} else {
 			const accentEnabled = !isSettingsInitialized() || settings.get("statusLine.sessionAccent") !== false;
 			const sessionName = accentEnabled ? this.sessionManager.getSessionName() : undefined;

--- a/packages/coding-agent/src/modes/theme/loader.ts
+++ b/packages/coding-agent/src/modes/theme/loader.ts
@@ -147,7 +147,15 @@ const COLORBLIND_ADJUSTMENT = { h: 60, s: 0.71 };
 export function createTheme(themeJson: ThemeJson, options: CreateThemeOptions = {}): Theme {
 	const { mode, symbolPresetOverride, colorBlindMode } = options;
 	const colorMode = mode ?? detectColorMode();
-	const resolvedColors = resolveThemeColors(themeJson.colors, themeJson.vars);
+	// Optional keys, defaulted before resolution so a `vars` reference still resolves.
+	const colors = {
+		...themeJson.colors,
+		statusLineVimNormal: themeJson.colors.statusLineVimNormal ?? themeJson.colors.accent,
+		statusLineVimInsert: themeJson.colors.statusLineVimInsert ?? themeJson.colors.success,
+		statusLineVimVisual: themeJson.colors.statusLineVimVisual ?? themeJson.colors.warning,
+		statusLineVimVisualLine: themeJson.colors.statusLineVimVisualLine ?? themeJson.colors.warning,
+	};
+	const resolvedColors = resolveThemeColors(colors, themeJson.vars);
 
 	if (colorBlindMode) {
 		const added = resolvedColors.toolDiffAdded;

--- a/packages/coding-agent/src/modes/theme/schema.ts
+++ b/packages/coding-agent/src/modes/theme/schema.ts
@@ -75,6 +75,11 @@ const themeColorsSchema = type({
 	statusLineOutput: "string | number",
 	statusLineCost: "string | number",
 	statusLineSubagents: "string | number",
+	// Vim-mode indicator; omitted keys default in `createTheme`.
+	"statusLineVimNormal?": "string | number",
+	"statusLineVimInsert?": "string | number",
+	"statusLineVimVisual?": "string | number",
+	"statusLineVimVisualLine?": "string | number",
 });
 const spinnerFramesSchema = type("unknown").narrow((value): value is SpinnerFramesOverride => {
 	if (Array.isArray(value)) {
@@ -178,7 +183,11 @@ export type ThemeColor =
 	| "statusLineUntracked"
 	| "statusLineOutput"
 	| "statusLineCost"
-	| "statusLineSubagents";
+	| "statusLineSubagents"
+	| "statusLineVimNormal"
+	| "statusLineVimInsert"
+	| "statusLineVimVisual"
+	| "statusLineVimVisualLine";
 
 /** Set of all valid ThemeColor string values for runtime validation */
 const THEME_COLOR_RECORD = {
@@ -242,6 +251,10 @@ const THEME_COLOR_RECORD = {
 	statusLineOutput: true,
 	statusLineCost: true,
 	statusLineSubagents: true,
+	statusLineVimNormal: true,
+	statusLineVimInsert: true,
+	statusLineVimVisual: true,
+	statusLineVimVisualLine: true,
 } satisfies Record<ThemeColor, true>;
 
 const VALID_THEME_COLORS: ReadonlySet<string> = new Set(Object.keys(THEME_COLOR_RECORD));

--- a/packages/coding-agent/src/modes/theme/theme-schema.json
+++ b/packages/coding-agent/src/modes/theme/theme-schema.json
@@ -33,7 +33,7 @@
 		},
 		"colors": {
 			"type": "object",
-			"description": "Theme color definitions (all required except thinkingMax)",
+			"description": "Theme color definitions (all required except thinkingMax and the statusLineVim* keys)",
 			"required": [
 				"accent",
 				"border",
@@ -370,6 +370,22 @@
 				"statusLineSubagents": {
 					"$ref": "#/$defs/colorValue",
 					"description": "Status line subagents segment"
+				},
+				"statusLineVimNormal": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Status line Vim indicator, Normal mode (defaults to accent)"
+				},
+				"statusLineVimInsert": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Status line Vim indicator, Insert mode (defaults to success)"
+				},
+				"statusLineVimVisual": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Status line Vim indicator, Visual mode (defaults to warning)"
+				},
+				"statusLineVimVisualLine": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Status line Vim indicator, Visual Line mode (defaults to warning)"
 				}
 			},
 			"additionalProperties": false

--- a/packages/coding-agent/test/theme-vim-mode-colors.test.ts
+++ b/packages/coding-agent/test/theme-vim-mode-colors.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { createTheme, getBuiltinThemes } from "@oh-my-pi/pi-coding-agent/modes/theme/loader";
+import type { ColorValue, ThemeColor, ThemeJson } from "@oh-my-pi/pi-coding-agent/modes/theme/schema";
+import type { Theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme-class";
+
+/** Optional keys: a theme that omits one must keep rendering in the token the segment used before. */
+
+const dark = getBuiltinThemes().dark;
+
+/** Opening SGR sequence for a color, which is what the segment actually emits. */
+function sgr(theme: Theme, color: ThemeColor): string {
+	const styled = theme.fg(color, "\u0001");
+	return styled.slice(0, styled.indexOf("\u0001"));
+}
+
+function themeWith(colors: Partial<Record<ThemeColor, ColorValue>>): Theme {
+	return createTheme({ ...dark, colors: { ...dark.colors, ...colors } } as ThemeJson, { mode: "truecolor" });
+}
+
+describe("vim mode theme colors", () => {
+	it("falls back to the pre-existing tokens when a theme omits the keys", () => {
+		// `dark` states its colors as `vars` references, so the fallback has to be resolved too.
+		const theme = createTheme(dark, { mode: "truecolor" });
+		expect(sgr(theme, "statusLineVimNormal")).toBe(sgr(theme, "accent"));
+		expect(sgr(theme, "statusLineVimInsert")).toBe(sgr(theme, "success"));
+		expect(sgr(theme, "statusLineVimVisual")).toBe(sgr(theme, "warning"));
+		expect(sgr(theme, "statusLineVimVisualLine")).toBe(sgr(theme, "warning"));
+	});
+
+	it("takes the theme's own values, and defaults the keys the theme leaves out", () => {
+		const theme = themeWith({
+			statusLineVimNormal: dark.colors.success,
+			statusLineVimInsert: dark.colors.accent,
+			statusLineVimVisualLine: dark.colors.error,
+		});
+		expect(sgr(theme, "statusLineVimNormal")).toBe(sgr(theme, "success"));
+		expect(sgr(theme, "statusLineVimNormal")).not.toBe(sgr(theme, "accent"));
+		expect(sgr(theme, "statusLineVimInsert")).toBe(sgr(theme, "accent"));
+		expect(sgr(theme, "statusLineVimVisualLine")).toBe(sgr(theme, "error"));
+		// An unset key keeps defaulting even when its siblings are overridden.
+		expect(sgr(theme, "statusLineVimVisual")).toBe(sgr(theme, "warning"));
+	});
+});


### PR DESCRIPTION
## What

Add support for custom vim mode colours.

## Why

Currently the vim mode colours are locked into certain values in the theme that cannot be changed.
This change allows users to update the colours they want displayed when in different modes, falling back to the default behaviour supported now.

## Testing

- `bun run check` runs clean.
- New suite `test/theme-vim-mode-colors.test.ts` is added and passes.
- Ran the TUI with a custom theme setting and the colours changed.
- Ran the same TUI with a theme defining none of the new keys and it fell back to the original behaviour

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)
