### PR TITLE
fix(memory): stop advertising memory://root where it can never resolve

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,8 +26,8 @@
 ### Fixed
 
 - Fixed completed tool cards reverting to pending after refocusing live sessions, and tool output collapsing behind finished reasoning segments ([#11868](https://github.com/can1357/oh-my-pi/pull/11868) by [@serverinspector](https://github.com/serverinspector)).
-- `memory://root` now names the active memory backend and points at `recall`/`reflect` instead of telling Hindsight and Mnemopi users to enable memories they already enabled, and prompt autocomplete stops offering the namespace on backends that never create it ([#11909](https://github.com/can1357/oh-my-pi/issues/11909)).
-- Rejected `memory://` glob patterns now name the accepted form (`memory://root/**`) instead of echoing the rejected pattern back as the requirement ([#11909](https://github.com/can1357/oh-my-pi/issues/11909)).
+- `memory://root` now names the active memory backend and points at `recall`/`reflect` instead of telling Hindsight and Mnemopi users to enable memories they already enabled, and prompt autocomplete stops offering the namespace on backends that never create it ([#11917](https://github.com/can1357/oh-my-pi/pull/11917) by [@oldschoola](https://github.com/oldschoola)).
+- Rejected `memory://` glob patterns now name the accepted form (`memory://root/**`) instead of echoing the rejected pattern back as the requirement ([#11917](https://github.com/can1357/oh-my-pi/pull/11917) by [@oldschoola](https://github.com/oldschoola)).
 - Invalid `WATCHDOG.yml` entries now produce startup/editor warnings while healthy advisors remain available ([#11882](https://github.com/can1357/oh-my-pi/pull/11882) by [@olegpulatov](https://github.com/olegpulatov)).
 - Claude Code session imports now preserve typed user text stored alongside tool results ([#11854](https://github.com/can1357/oh-my-pi/issues/11854)).
 - Extension commands now settle BTW writes before creating, switching, or branching sessions, preventing side requests from outliving their source session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,6 +26,8 @@
 ### Fixed
 
 - Fixed completed tool cards reverting to pending after refocusing live sessions, and tool output collapsing behind finished reasoning segments ([#11868](https://github.com/can1357/oh-my-pi/pull/11868) by [@serverinspector](https://github.com/serverinspector)).
+- `memory://root` now names the active memory backend and points at `recall`/`reflect` instead of telling Hindsight and Mnemopi users to enable memories they already enabled, and prompt autocomplete stops offering the namespace on backends that never create it ([#11909](https://github.com/can1357/oh-my-pi/issues/11909)).
+- Rejected `memory://` glob patterns now name the accepted form (`memory://root/**`) instead of echoing the rejected pattern back as the requirement ([#11909](https://github.com/can1357/oh-my-pi/issues/11909)).
 - Invalid `WATCHDOG.yml` entries now produce startup/editor warnings while healthy advisors remain available ([#11882](https://github.com/can1357/oh-my-pi/pull/11882) by [@olegpulatov](https://github.com/olegpulatov)).
 - Claude Code session imports now preserve typed user text stored alongside tool results ([#11854](https://github.com/can1357/oh-my-pi/issues/11854)).
 - Extension commands now settle BTW writes before creating, switching, or branching sessions, preventing side requests from outliving their source session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).

--- a/packages/coding-agent/src/internal-urls/memory-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/memory-protocol.ts
@@ -53,6 +53,43 @@ function memoryRootsForContext(context: ResolveContext | undefined, caller: Agen
 	return memoryRootsFromRegistry();
 }
 
+/**
+ * `memory://root` reads the summary that the *local* consolidation pipeline
+ * writes. A server-side backend never creates that directory, so the generic
+ * "enable memories" advice names a fix the caller has already applied. Point
+ * those callers at the tools that can actually answer instead (issue #11909).
+ */
+function fileBackedUnavailableError(backend: string | undefined): Error {
+	if (backend === "hindsight" || backend === "mnemopi") {
+		return new Error(
+			`File-backed memory artifacts only exist with memory.backend=local (active backend: ${backend}). Use \`recall\` to search stored memories, or \`reflect\` to synthesize across them.`,
+		);
+	}
+	return new Error(
+		"Memory artifacts are not available for this project yet. Run a session with memories enabled first.",
+	);
+}
+
+/**
+ * Whether `memory://root` is worth advertising. The local pipeline owns that
+ * namespace, so it stays offered there even before the first consolidation —
+ * its "not available yet" error names a real next step. A server-side backend
+ * never writes the root, so offering it is a guaranteed dead end unless an
+ * earlier local run left the directory behind (issue #11909).
+ */
+async function offersFileBackedRoot(backend: string | undefined, roots: string[]): Promise<boolean> {
+	if (backend !== "hindsight" && backend !== "mnemopi") return roots.length > 0;
+	for (const root of roots) {
+		try {
+			await fs.stat(root);
+			return true;
+		} catch {
+			// Completion is advisory: a missing or unreadable root is simply not offered.
+		}
+	}
+	return false;
+}
+
 function ensureWithinRoot(targetPath: string, rootPath: string): void {
 	if (targetPath !== rootPath && !targetPath.startsWith(`${rootPath}${path.sep}`)) {
 		throw new Error("memory:// URL escapes memory root");
@@ -95,7 +132,9 @@ export function splitMemoryGlobPattern(input: string): MemoryGlobPattern {
 	const url = parseInternalUrl(urlMatch[1]);
 	const namespace = url.rawHost || url.hostname;
 	if (url.protocol !== "memory:" || namespace !== MEMORY_NAMESPACE) {
-		throw new Error(`Memory glob patterns require the ${MEMORY_NAMESPACE} namespace: ${input}`);
+		throw new Error(
+			`Memory glob patterns require the ${MEMORY_NAMESPACE} namespace (e.g. memory://${MEMORY_NAMESPACE}/**); got: ${input}`,
+		);
 	}
 
 	const rawPathname = urlMatch[2] ?? "";
@@ -426,9 +465,7 @@ export class MemoryProtocolHandler implements ProtocolHandler {
 
 		const roots = memoryRootsForContext(context, caller.session);
 		if (roots.length === 0) {
-			throw new Error(
-				"Memory artifacts are not available for this project yet. Run a session with memories enabled first.",
-			);
+			throw fileBackedUnavailableError(backend);
 		}
 
 		let anyExists = false;
@@ -445,9 +482,7 @@ export class MemoryProtocolHandler implements ProtocolHandler {
 		}
 
 		if (!anyExists) {
-			throw new Error(
-				"Memory artifacts are not available for this project yet. Run a session with memories enabled first.",
-			);
+			throw fileBackedUnavailableError(backend);
 		}
 
 		throw new Error(`Memory file not found: ${url.href}`);
@@ -457,7 +492,7 @@ export class MemoryProtocolHandler implements ProtocolHandler {
 		const caller = resolveMemoryCaller(context);
 		if (caller.backend === "off") return [];
 		const completions: UrlCompletion[] = [];
-		if (memoryRootsForContext(context, caller.session).length > 0) {
+		if (await offersFileBackedRoot(caller.backend, memoryRootsForContext(context, caller.session))) {
 			completions.push({ value: MEMORY_NAMESPACE, description: "Project memory summary" });
 		}
 		const mnemopiAvailable = caller.legacy

--- a/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
@@ -824,12 +824,12 @@ describe("MemoryProtocolHandler — mnemopi bridge (issue #4443)", () => {
 			expect(bound?.items.map(item => item.value)).toContain("memory://<memory-id>");
 
 			// Typing into the child instead binds to its hindsight backend, which has
-			// no addressable ids, rather than to the peer bank in the same cwd.
+			// no addressable ids and no file-backed root, so it is offered nothing.
 			const childBound = await getInternalUrlSuggestions("memory://", undefined, undefined, () => ({
 				cwd: sharedCwd,
 				sessionFile: childSessionFile,
 			}));
-			expect(childBound?.items.map(item => item.value)).not.toContain("memory://<memory-id>");
+			expect(childBound).toBeNull();
 
 			// A caller that is no longer registered is offered nothing at all.
 			expect(
@@ -948,5 +948,125 @@ describe("MemoryProtocolHandler — hindsight (issue #7587)", () => {
 		await expect(router.resolve("memory://a1b2c3d4e5f6")).rejects.toThrow(
 			/Unknown memory namespace: a1b2c3d4e5f6\. Supported: root/,
 		);
+	});
+});
+
+/**
+ * Register a live session on a throwaway cwd whose file-backed memory root is
+ * deliberately absent — the state every server-side backend is permanently in,
+ * because only the local consolidation pipeline ever creates that directory.
+ */
+async function withBackendSession(
+	backend: string,
+	fn: (ctx: { cwd: string; sessionId: string; memoryRoot: string }) => Promise<void>,
+): Promise<void> {
+	const cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-root-backend-"));
+	const previousAgentDir = getAgentDir();
+	try {
+		const agentDir = path.join(cleanupRoot, "agent");
+		const cwd = path.join(cleanupRoot, "project");
+		await fs.mkdir(agentDir, { recursive: true });
+		await fs.mkdir(cwd, { recursive: true });
+		setAgentDir(agentDir);
+		const sessionId = `test-${backend}-root`;
+		AgentRegistry.global().register({
+			id: sessionId,
+			displayName: sessionId,
+			kind: "main",
+			session: {
+				sessionManager: {
+					getCwd: () => cwd,
+					getArtifactsDir: () => null,
+					getSessionId: () => sessionId,
+				},
+				settings: Settings.isolated({ "memory.backend": backend }),
+			} as unknown as AgentSession,
+			sessionFile: null,
+		});
+		await fn({ cwd, sessionId, memoryRoot: getMemoryRoot(agentDir, cwd) });
+	} finally {
+		setAgentDir(previousAgentDir);
+		await removeWithRetries(cleanupRoot);
+	}
+}
+
+describe("MemoryProtocolHandler — file-backed root (issue #11909)", () => {
+	beforeEach(() => {
+		AgentRegistry.resetGlobalForTests();
+		InternalUrlRouter.resetForTests();
+	});
+
+	afterEach(() => {
+		AgentRegistry.resetGlobalForTests();
+		InternalUrlRouter.resetForTests();
+	});
+
+	// Regression: under hindsight the old message prescribed enabling memories
+	// that were already enabled, so the agent had no way to learn that
+	// memory:// is simply not its access path.
+	it("names the active backend instead of advising that memories be enabled", async () => {
+		await withBackendSession("hindsight", async ({ cwd, sessionId }) => {
+			const error = await InternalUrlRouter.instance()
+				.resolve("memory://root", { cwd, sessionId })
+				.then(
+					() => undefined,
+					(err: unknown) => err as Error,
+				);
+
+			expect(error?.message).toContain("memory.backend=local");
+			expect(error?.message).toContain("active backend: hindsight");
+			expect(error?.message).not.toContain("Run a session with memories enabled first");
+		});
+	});
+
+	// The local backend genuinely can populate the root, so its advice stays.
+	it("keeps the actionable advice for the file-backed backend", async () => {
+		await withBackendSession("local", async ({ cwd, sessionId }) => {
+			await expect(InternalUrlRouter.instance().resolve("memory://root", { cwd, sessionId })).rejects.toThrow(
+				"Run a session with memories enabled first",
+			);
+		});
+	});
+
+	// Regression: the old error interpolated the rejected input directly after
+	// "require the root namespace", so it named `memory://**` as its own fix.
+	it("names the expected namespace form instead of echoing the rejected pattern", async () => {
+		await withMemoryFixture(async ({ cwd }) => {
+			const error = await createGlobTool(cwd)
+				.execute("memory-glob-bare-namespace", { path: "memory://**" })
+				.then(
+					() => undefined,
+					(err: unknown) => err as Error,
+				);
+
+			expect(error?.message).toContain("memory://root/**");
+		});
+	});
+
+	// Regression: completion gated on `memoryRootsForContext(...).length`, which
+	// counts the path a root *would* occupy, so `memory://root` was advertised
+	// under hindsight, where nothing ever creates it.
+	it("advertises memory://root under hindsight only once the root exists", async () => {
+		await withBackendSession("hindsight", async ({ cwd, memoryRoot }) => {
+			const absent = await getInternalUrlSuggestions("memory://", cwd);
+			expect(absent?.items.map(item => item.value) ?? []).not.toContain("memory://root");
+
+			// A directory left behind by an earlier local run is readable, so it
+			// is offered again even though hindsight would never create one.
+			await fs.mkdir(memoryRoot, { recursive: true });
+			InternalUrlRouter.resetForTests();
+
+			const present = await getInternalUrlSuggestions("memory://", cwd);
+			expect(present?.items.map(item => item.value) ?? []).toContain("memory://root");
+		});
+	});
+
+	// The local pipeline owns this namespace, so its affordance survives even
+	// before the first consolidation writes anything.
+	it("keeps advertising memory://root under the local backend before consolidation", async () => {
+		await withBackendSession("local", async ({ cwd }) => {
+			const suggestions = await getInternalUrlSuggestions("memory://", cwd);
+			expect(suggestions?.items.map(item => item.value) ?? []).toContain("memory://root");
+		});
 	});
 });


### PR DESCRIPTION
## What

I had an issue with Hindsight tool calls: `memory://root` kept telling me to enable memories that were already enabled. I reviewed the full diff; this makes that error name the active backend and stops autocomplete advertising a namespace that can never resolve.

Concretely, three fixes to the `memory://` URL surface in `packages/coding-agent/src/internal-urls/memory-protocol.ts`:

- The `memory://root` failure names the active backend and points at `recall`/`reflect` instead of prescribing a fix the caller has already applied.
- Prompt autocomplete stops offering `memory://root` under `hindsight`/`mnemopi` unless the directory actually exists. The `local` backend keeps the affordance: it owns that namespace, and its "not available yet" error names a real next step even before the first consolidation.
- `splitMemoryGlobPattern` names the accepted form instead of echoing the rejected input back as the requirement.

## Why

Refs #11909.

`memory://root` reads the summary the *local* consolidation pipeline writes. Under `memory.backend=hindsight` that directory is never created, so the namespace was advertised by `complete()`, which gated on `memoryRootsForContext(...).length` (the path a root *would* occupy, always at least 1) and then failed with advice that was already satisfied, since selecting Hindsight *is* enabling memories.

This is the same class as #7673 (fixed for `backend=off`) and #7587 (fixed for `memory://<id>` on Hindsight). The `root` namespace was the remaining hole; #10704 in fact describes Hindsight as throwing only "for any non-`root` host", which reads as though `root` were the working path.

The glob message was separately self-contradictory: `[^/?#]*` swallows `**` into the URL authority, so `namespace === "**"`, and the throw interpolated `${input}` immediately after the words "require the root namespace".

## Testing

Reproduced and confirmed fixed by exercising the real `InternalUrlRouter` and `GlobTool` under `memory.backend=hindsight` in a project directory with no memory root (throwaway script, not committed), comparing the parent commit against this one:

**Before**
```
read memory://root   -> Memory artifacts are not available for this project yet. Run a session with memories enabled first.
glob memory://**     -> Memory glob patterns require the root namespace: memory://**
```

**After**
```
read memory://root   -> File-backed memory artifacts only exist with memory.backend=local (active backend: hindsight). Use `recall` to search stored memories, or `reflect` to synthesize across them.
glob memory://**     -> Memory glob patterns require the root namespace (e.g. memory://root/**); got: memory://**
```

The original symptom was hit live on omp 18.1.18 against a self-hosted hindsight-api 0.9.2, which is what prompted #11909.

Automated:

- `bun test packages/coding-agent/test/internal-urls/ .../input-controller-internal-url-caller.test.ts .../advisor-memory.test.ts .../memories/ .../memories-runtime.test.ts` gives 259 pass, 1 fail; the failure is a pre-existing Windows path-separator assertion in `internal-urls/artifact-path-only.test.ts` (`\` vs `/`), confirmed failing on a clean tree and untouched here.
- Reverted only the source change to confirm the four new assertions fail before the fix and pass after.
- `bun check` passes.

One existing assertion changed rather than added: the child-session case in `memory-protocol.test.ts` binds to `memory.backend: "hindsight"` and its own comment says it "has no addressable ids", yet it was still being offered `memory://root`. It now asserts the caller is offered nothing, matching the `toBeNull()` pattern used for the unregistered caller a few lines below.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)
