### PR TITLE
fix(eval): bound persisted display values

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Large eval `display()` values now stay bounded in session history while remaining available through output artifacts, preventing slow `--resume` startup ([#11920](https://github.com/can1357/oh-my-pi/issues/11920)).
+
 ## [18.1.19] - 2026-09-12
 
 - Fixed `--mode json` returning exit 0 on a turn-fatal provider/auth/network error ([#11498](https://github.com/can1357/oh-my-pi/issues/11498)).

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -829,6 +829,10 @@ export class OutputSink {
 	#artifactTailRing = "";
 	#artifactTailRingBytes = 0;
 	#artifactTailIncomingBytes = 0;
+	// Set when the spill file could not be created, or a final flush/close threw
+	// after creation. `dump()` withholds `artifactId` in that case so callers
+	// never advertise `artifact://<id>` for output that was never fully written.
+	#artifactWriteFailed = false;
 
 	constructor(options?: OutputSinkOptions) {
 		const {
@@ -1187,6 +1191,7 @@ export class OutputSink {
 				this.#pendingFileWrites = undefined;
 			}
 		} catch {
+			this.#artifactWriteFailed = true;
 			try {
 				await this.#file?.sink?.end();
 			} catch {
@@ -1384,7 +1389,7 @@ export class OutputSink {
 			columnDroppedBytes: this.#columnDroppedBytes > 0 ? this.#columnDroppedBytes : undefined,
 			columnTruncatedLines: this.#columnTruncatedLines > 0 ? this.#columnTruncatedLines : undefined,
 			columnMax: this.#columnTruncatedLines > 0 ? this.#maxColumns : undefined,
-			artifactId: this.#file?.artifactId,
+			artifactId: this.#artifactWriteFailed ? undefined : this.#file?.artifactId,
 		};
 	}
 
@@ -1408,17 +1413,19 @@ export class OutputSink {
 		// write error). Closing the descriptor MUST still happen — otherwise the
 		// fd leaks and the replay error masks the original tool error that put us
 		// on this path. Both failures are swallowed so dispose() never throws.
+		let flushFailed = false;
 		try {
 			this.#flushArtifactTailIfCapped();
 		} catch {
-			/* ignore */
+			flushFailed = true;
 		} finally {
 			try {
 				await file.sink.end();
 			} catch {
-				/* ignore */
+				flushFailed = true;
 			}
 		}
+		if (flushFailed) this.#artifactWriteFailed = true;
 	}
 
 	/**

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -890,22 +890,29 @@ export class OutputSink {
 	/**
 	 * Push a chunk of output. The buffer management and onChunk callback run
 	 * synchronously. File sink writes are deferred and serialized internally.
+	 *
+	 * `inline` substitutes a bounded representation for the in-memory buffer and
+	 * live preview while the complete chunk is mirrored to the artifact.
+	 * `emitInline: false` keeps that representation out of the live callback.
 	 */
-	push(chunk: string): void {
+	push(chunk: string, options?: { inline?: string; emitInline?: boolean }): void {
 		if (this.#finalized) return;
 		chunk = sanitizeWithOptionalSixelPassthrough(chunk, text => sanitizeText(this.#normalizeCarriageReturns(text)));
+		const inline = options?.inline;
+		const substituted = inline !== undefined;
+		const inlineChunk = inline === undefined ? chunk : sanitizeText(inline);
 
 		// Throttled onChunk: coalesce chunks arriving inside the throttle window.
 		// A timer flushes quiet tails at the throttle boundary; dump() catches a
 		// final pending chunk when the process exits before that timer fires.
-		// Live preview gets the raw (pre-cap) chunk so the TUI never lags behind
-		// what reached the sink — the column cap is for the persisted LLM view.
-		if (this.#onChunk) {
+		// Live preview gets the inline (pre-cap) chunk so the TUI never lags behind
+		// what reached the in-memory sink — the column cap is for the persisted LLM view.
+		if (this.#onChunk && options?.emitInline !== false && inlineChunk.length > 0) {
 			const now = Date.now();
 			if (now - this.#lastChunkTime >= this.#chunkThrottleMs) {
-				this.#emitPendingChunkWith(chunk, now);
+				this.#emitPendingChunkWith(inlineChunk, now);
 			} else {
-				this.#pendingChunk += chunk;
+				this.#pendingChunk += inlineChunk;
 				this.#schedulePendingChunkFlush();
 			}
 		}
@@ -918,20 +925,24 @@ export class OutputSink {
 			this.#totalLines += countNewlines(chunk);
 		}
 
+		const inlineBytes = substituted ? Buffer.byteLength(inlineChunk, "utf-8") : rawBytes;
 		// Per-line column cap. State persists across chunks so a mid-line split
-		// still respects the budget. Operates on the sanitized chunk; the cap is
-		// applied before head/tail accounting but after artifact mirroring decides.
-		const capped = this.#maxColumns > 0 ? this.#applyColumnCap(chunk) : chunk;
-		const cappedBytes = capped === chunk ? rawBytes : Buffer.byteLength(capped, "utf-8");
-		const cappedThisChunk = cappedBytes < rawBytes;
+		// still respects the budget. Operates on the inline chunk; the complete
+		// chunk is mirrored to the artifact before any cap is applied.
+		const capped = this.#maxColumns > 0 ? this.#applyColumnCap(inlineChunk) : inlineChunk;
+		const cappedBytes = capped === inlineChunk ? inlineBytes : Buffer.byteLength(capped, "utf-8");
+		const cappedThisChunk = cappedBytes < inlineBytes;
+		if (substituted) this.#truncated = true;
 
-		// Mirror RAW chunk to the artifact file so the on-disk record is the full
-		// uncapped stream. Mirror triggers on: in-memory overflow OR this chunk's
-		// column cap dropped bytes (otherwise we'd lose data) OR file already open.
-		if (this.#artifactPath && (this.#file != null || cappedThisChunk || this.#willOverflow(cappedBytes))) {
+		// Mirror the complete chunk to the artifact file whenever the inline
+		// representation differs, overflows memory, hits the column cap, or a
+		// prior chunk already opened the artifact.
+		if (
+			this.#artifactPath &&
+			(this.#file != null || substituted || cappedThisChunk || this.#willOverflow(cappedBytes))
+		) {
 			this.#writeToFile(chunk);
 		}
-
 		if (cappedBytes === 0) return;
 
 		// Head retention: drain the (capped) chunk into #head until the budget is

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -144,10 +144,19 @@ interface FormattedDisplayJson {
 	fullText: string;
 	previewText: string;
 	detailsValue: unknown;
-	truncated: boolean;
+	/** Full value must be mirrored to the output artifact; `detailsValue` holds only a preview. */
+	spillFullValue: boolean;
 }
 
-function formatDisplayJson(value: unknown): FormattedDisplayJson {
+/**
+ * Format one structured `display()` value for the model text and the tool
+ * `details`. The model-visible preview is always capped at
+ * {@link MAX_DISPLAY_TEXT_BYTES}. When the value exceeds that cap, the full
+ * value is retained in `details` only if `canSpill` is false (no persistence,
+ * so nothing to bloat); otherwise `details` keeps a bounded metadata object and
+ * the caller mirrors the full value to the session output artifact.
+ */
+function formatDisplayJson(value: unknown, canSpill: boolean): FormattedDisplayJson {
 	let fullText: string;
 	try {
 		fullText = JSON.stringify(value, null, 2) ?? String(value);
@@ -156,11 +165,17 @@ function formatDisplayJson(value: unknown): FormattedDisplayJson {
 	}
 	const totalBytes = Buffer.byteLength(fullText, "utf-8");
 	if (totalBytes <= MAX_DISPLAY_TEXT_BYTES) {
-		return { fullText, previewText: fullText, detailsValue: value, truncated: false };
+		return { fullText, previewText: fullText, detailsValue: value, spillFullValue: false };
 	}
 
 	const head = truncateHeadBytes(fullText, MAX_DISPLAY_TEXT_BYTES - DISPLAY_ELISION_RESERVE_BYTES);
 	const previewText = `${head.text}\n[…${fullText.length - head.text.length}ch elided…]`;
+	// Without an artifact to mirror into, keep the full value in details: there
+	// is no session JSONL to bloat, and discarding it would strand large
+	// displays from SDK consumers that read `details.jsonOutputs`.
+	if (!canSpill) {
+		return { fullText, previewText, detailsValue: value, spillFullValue: false };
+	}
 	return {
 		fullText,
 		previewText,
@@ -169,7 +184,7 @@ function formatDisplayJson(value: unknown): FormattedDisplayJson {
 			truncated: true,
 			totalBytes,
 		},
-		truncated: true,
+		spillFullValue: true,
 	};
 }
 
@@ -842,11 +857,11 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 				let cellHasMarkdown = false;
 				for (const output of result.displayOutputs) {
 					if (output.type === "json") {
-						const formatted = formatDisplayJson(output.data);
+						const formatted = formatDisplayJson(output.data, artifactPath !== undefined);
 						const label = `display[${cellDisplayTexts.length + 1}]:\n`;
 						jsonOutputs.push(formatted.detailsValue);
 						cellDisplayTexts.push(`${label}${formatted.previewText}`);
-						if (formatted.truncated) {
+						if (formatted.spillFullValue) {
 							outputSink.push(`${label}${formatted.fullText}\n`, {
 								inline: `${label}${formatted.previewText}\n`,
 								emitInline: false,

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -713,6 +713,25 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 			const jsonOutputs: unknown[] = [];
 			const images: ImageContent[] = [];
 			const statusEvents: EvalStatusEvent[] = [];
+			// Oversized displays land in `jsonOutputs` as bounded previews and stream
+			// their full value to the output artifact. Until the artifact write is
+			// confirmed (see `commitDisplaySpills`), the full value is kept here so a
+			// silently failed spill can restore it instead of stranding it.
+			const spilledDisplays: Array<{ index: number; fullValue: unknown }> = [];
+			const commitDisplaySpills = (summary: OutputSummary | undefined): void => {
+				if (spilledDisplays.length === 0) return;
+				// Artifact persistence confirmed: keep the bounded preview. Otherwise
+				// restore the full value so `details` never points at an artifact that
+				// was never (fully) written.
+				if (summary?.artifactId !== undefined) {
+					spilledDisplays.length = 0;
+					return;
+				}
+				for (const spill of spilledDisplays) {
+					jsonOutputs[spill.index] = spill.fullValue;
+				}
+				spilledDisplays.length = 0;
+			};
 
 			const cellResults: EvalCellResult[] = cells.map(cell => ({
 				index: cell.index,
@@ -862,6 +881,7 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 						jsonOutputs.push(formatted.detailsValue);
 						cellDisplayTexts.push(`${label}${formatted.previewText}`);
 						if (formatted.spillFullValue) {
+							spilledDisplays.push({ index: jsonOutputs.length - 1, fullValue: output.data });
 							outputSink.push(`${label}${formatted.fullText}\n`, {
 								inline: `${label}${formatted.previewText}\n`,
 								emitInline: false,
@@ -925,6 +945,7 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 					const outputText = combinedOutput || errorMsg;
 
 					const summaryForMeta = await summarizeFinal(combinedOutput, finalizeOutput);
+					commitDisplaySpills(summaryForMeta);
 					const details: EvalToolDetails = {
 						language: languages[0],
 						languages,
@@ -951,6 +972,7 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 						: `Command exited with code ${result.exitCode}`;
 
 					const summaryForMeta = await summarizeFinal(combinedOutput, finalizeOutput);
+					commitDisplaySpills(summaryForMeta);
 					const details: EvalToolDetails = {
 						language: languages[0],
 						languages,
@@ -980,6 +1002,7 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 					? `(displayed ${images.length} image${images.length === 1 ? "" : "s"}; no text output)`
 					: "(no output)");
 			const summaryForMeta = await summarizeFinal(combinedOutput, finalizeOutput);
+			commitDisplaySpills(summaryForMeta);
 
 			const details: EvalToolDetails = {
 				language: languages[0],

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -23,10 +23,16 @@ import type { BackendProbeOptions } from "../eval/probe";
 import { defaultEvalSessionId } from "../eval/session-id";
 import { EvalShadowCellSession } from "../eval/speculation/cell-session";
 import { runWithEvalShadowCell } from "../eval/speculation/runtime-context";
-import type { EvalCellResult, EvalDisplayOutput, EvalLanguage, EvalStatusEvent, EvalToolDetails } from "../eval/types";
+import type { EvalCellResult, EvalLanguage, EvalStatusEvent, EvalToolDetails } from "../eval/types";
 import evalDescription from "../prompts/tools/eval.md" with { type: "text" };
 import evalCodeModeDescription from "../prompts/tools/eval-code-mode.md" with { type: "text" };
-import { DEFAULT_MAX_BYTES, OutputSink, type OutputSummary, TailBuffer } from "../session/streaming-output";
+import {
+	DEFAULT_MAX_BYTES,
+	OutputSink,
+	type OutputSummary,
+	TailBuffer,
+	truncateHeadBytes,
+} from "../session/streaming-output";
 import { sessionDelegationBias } from "../task/prompt-policy";
 import { resolveSpawnPolicy } from "../task/spawn-policy";
 import { webpExclusionForModel } from "../utils/image-loading";
@@ -130,36 +136,41 @@ export type EvalToolResult = {
 
 export type EvalProxyExecutor = (params: EvalToolParams, signal?: AbortSignal) => Promise<EvalToolResult>;
 
-/** Cap per `display()` value sent back to the model. */
+/** Shared cap for each structured `display()` preview returned by eval. */
 const MAX_DISPLAY_TEXT_BYTES = 8000;
+const DISPLAY_ELISION_RESERVE_BYTES = 64;
 
-function formatDisplayJsonForText(value: unknown): string {
-	let text: string;
-	try {
-		text = JSON.stringify(value, null, 2) ?? String(value);
-	} catch {
-		text = String(value);
-	}
-	if (text.length > MAX_DISPLAY_TEXT_BYTES) {
-		text = `${text.slice(0, MAX_DISPLAY_TEXT_BYTES)}\n[…${text.length - MAX_DISPLAY_TEXT_BYTES}ch elided…]`;
-	}
-	return text;
+interface FormattedDisplayJson {
+	fullText: string;
+	previewText: string;
+	detailsValue: unknown;
+	truncated: boolean;
 }
 
-/**
- * Format display() JSON values into text the model can see. Images are surfaced
- * separately as ImageContent so the model can actually inspect them; this helper
- * intentionally does not touch images.
- */
-function formatDisplayOutputsForText(outputs: EvalDisplayOutput[]): string {
-	const chunks: string[] = [];
-	let displayIndex = 0;
-	for (const output of outputs) {
-		if (output.type !== "json") continue;
-		displayIndex++;
-		chunks.push(`display[${displayIndex}]:\n${formatDisplayJsonForText(output.data)}`);
+function formatDisplayJson(value: unknown): FormattedDisplayJson {
+	let fullText: string;
+	try {
+		fullText = JSON.stringify(value, null, 2) ?? String(value);
+	} catch {
+		fullText = String(value);
 	}
-	return chunks.join("\n\n");
+	const totalBytes = Buffer.byteLength(fullText, "utf-8");
+	if (totalBytes <= MAX_DISPLAY_TEXT_BYTES) {
+		return { fullText, previewText: fullText, detailsValue: value, truncated: false };
+	}
+
+	const head = truncateHeadBytes(fullText, MAX_DISPLAY_TEXT_BYTES - DISPLAY_ELISION_RESERVE_BYTES);
+	const previewText = `${head.text}\n[…${fullText.length - head.text.length}ch elided…]`;
+	return {
+		fullText,
+		previewText,
+		detailsValue: {
+			preview: previewText,
+			truncated: true,
+			totalBytes,
+		},
+		truncated: true,
+	};
 }
 
 export interface EvalToolDescriptionOptions {
@@ -826,13 +837,21 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 				const durationMs = Date.now() - startTime;
 
 				const cellStatusEvents: EvalStatusEvent[] = [];
-				const cellDisplayOutputs: EvalDisplayOutput[] = [];
+				const cellDisplayTexts: string[] = [];
 				const cellImageNotes: string[] = [];
 				let cellHasMarkdown = false;
 				for (const output of result.displayOutputs) {
 					if (output.type === "json") {
-						jsonOutputs.push(output.data);
-						cellDisplayOutputs.push(output);
+						const formatted = formatDisplayJson(output.data);
+						const label = `display[${cellDisplayTexts.length + 1}]:\n`;
+						jsonOutputs.push(formatted.detailsValue);
+						cellDisplayTexts.push(`${label}${formatted.previewText}`);
+						if (formatted.truncated) {
+							outputSink.push(`${label}${formatted.fullText}\n`, {
+								inline: `${label}${formatted.previewText}\n`,
+								emitInline: false,
+							});
+						}
 					}
 					if (output.type === "image") {
 						const resized = await resizeImage(
@@ -849,11 +868,6 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 							mimeType: resized.mimeType,
 						};
 						images.push(image);
-						cellDisplayOutputs.push({
-							type: "image",
-							data: image.data,
-							mimeType: image.mimeType,
-						});
 						const dimensionNote = formatDimensionNote(resized);
 						if (dimensionNote) {
 							cellImageNotes.push(`display image ${cellImageNotes.length + 1}: ${dimensionNote}`);
@@ -870,7 +884,7 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 
 				const stdoutTrimmed = result.output.trim();
 				const imageText = cellImageNotes.join("\n");
-				const displayText = formatDisplayOutputsForText(cellDisplayOutputs);
+				const displayText = cellDisplayTexts.join("\n\n");
 				const visibleDisplayText =
 					displayText && imageText ? `${displayText}\n\n${imageText}` : displayText || imageText;
 				const cellOutput =

--- a/packages/coding-agent/test/tools/eval-display-text.test.ts
+++ b/packages/coding-agent/test/tools/eval-display-text.test.ts
@@ -204,4 +204,28 @@ describe("EvalTool display() text surfacing", () => {
 		expect(await Bun.file(artifactPath).text()).toContain(huge);
 		expect(result.details?.meta?.truncation?.artifactId).toBe("large-display");
 	});
+
+	it("retains the full display value in details when no artifact is available", async () => {
+		const huge = `start-${"x".repeat(100_000)}-end`;
+		vi.spyOn(pyKernel, "checkPythonKernelAvailability").mockResolvedValue({ ok: true });
+		vi.spyOn(evalIndex.jsBackend, "execute").mockResolvedValue(
+			baseResult({
+				displayOutputs: [{ type: "json", data: { payload: huge } }],
+			}) as never,
+		);
+
+		// makeSession() has no allocateOutputArtifact, mirroring a non-persistent
+		// SDK session: there is no session JSONL to bloat, so the full structured
+		// value must survive in details for SDK consumers.
+		const tool = new EvalTool(makeSession());
+		const result = await tool.execute("call-huge-no-artifact", {
+			language: "js",
+			code: "display({ payload: huge });",
+		});
+
+		expect(result.details?.jsonOutputs?.[0]).toEqual({ payload: huge });
+		const text = result.content.map(c => (c.type === "text" ? c.text : "")).join("\n");
+		expect(text).toContain("ch elided");
+		expect(text).not.toContain(huge);
+	});
 });

--- a/packages/coding-agent/test/tools/eval-display-text.test.ts
+++ b/packages/coding-agent/test/tools/eval-display-text.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { TempDir } from "@oh-my-pi/pi-utils";
 import * as evalIndex from "@oh-my-pi/pi-coding-agent/eval";
 import * as pyKernel from "@oh-my-pi/pi-coding-agent/eval/py/kernel";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
@@ -177,5 +178,30 @@ describe("EvalTool display() text surfacing", () => {
 		const text = result.content.map(c => (c.type === "text" ? c.text : "")).join("\n");
 		expect(text).toContain("ch elided");
 		expect(text.length).toBeLessThan(20000);
+	});
+
+	it("keeps oversized display details bounded and spills the full value to the artifact", async () => {
+		using tempDir = TempDir.createSync("@omp-eval-display-");
+		const artifactPath = tempDir.join("eval.log");
+		const huge = `start-${"x".repeat(100_000)}-end`;
+		vi.spyOn(pyKernel, "checkPythonKernelAvailability").mockResolvedValue({ ok: true });
+		vi.spyOn(evalIndex.jsBackend, "execute").mockResolvedValue(
+			baseResult({
+				displayOutputs: [{ type: "json", data: { payload: huge } }],
+			}) as never,
+		);
+
+		const tool = new EvalTool({
+			...makeSession(),
+			allocateOutputArtifact: async () => ({ id: "large-display", path: artifactPath }),
+		});
+		const result = await tool.execute("call-huge-details", {
+			language: "js",
+			code: "display({ payload: huge });",
+		});
+
+		expect(Buffer.byteLength(JSON.stringify(result.details), "utf-8")).toBeLessThan(20_000);
+		expect(await Bun.file(artifactPath).text()).toContain(huge);
+		expect(result.details?.meta?.truncation?.artifactId).toBe("large-display");
 	});
 });

--- a/packages/coding-agent/test/tools/eval-display-text.test.ts
+++ b/packages/coding-agent/test/tools/eval-display-text.test.ts
@@ -228,4 +228,32 @@ describe("EvalTool display() text surfacing", () => {
 		expect(text).toContain("ch elided");
 		expect(text).not.toContain(huge);
 	});
+
+	it("restores the full display value when the artifact write fails", async () => {
+		using tempDir = TempDir.createSync("@omp-eval-display-fail-");
+		// Parent directory is never created, so the spill FileSink cannot open —
+		// OutputSink swallows the error, so persistence must be treated as
+		// unconfirmed and the full value restored into details.
+		const artifactPath = tempDir.join("missing", "eval.log");
+		const huge = `start-${"x".repeat(100_000)}-end`;
+		vi.spyOn(pyKernel, "checkPythonKernelAvailability").mockResolvedValue({ ok: true });
+		vi.spyOn(evalIndex.jsBackend, "execute").mockResolvedValue(
+			baseResult({
+				displayOutputs: [{ type: "json", data: { payload: huge } }],
+			}) as never,
+		);
+
+		const tool = new EvalTool({
+			...makeSession(),
+			allocateOutputArtifact: async () => ({ id: "doomed-display", path: artifactPath }),
+		});
+		const result = await tool.execute("call-huge-failed-spill", {
+			language: "js",
+			code: "display({ payload: huge });",
+		});
+
+		expect(await Bun.file(artifactPath).exists()).toBe(false);
+		expect(result.details?.jsonOutputs?.[0]).toEqual({ payload: huge });
+		expect(result.details?.meta?.truncation?.artifactId).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## Repro
A mocked eval backend returning one 100 KB structured `display()` value made `JSON.stringify(result.details)` reach 108,253 bytes despite the 8 KB model-visible cap. Reproduce with `bun test packages/coding-agent/test/tools/eval-display-text.test.ts`; the new regression failed before the fix and passes after it.

## Cause
`EvalTool.#runCells()` in `packages/coding-agent/src/tools/eval.ts` pushed `output.data` directly into `details.jsonOutputs`, while `formatDisplayJsonForText()` bounded only the separate text content. Session persistence therefore serialized the complete structured value into the main JSONL, and the existing `OutputSink` artifact never received display values.

## Fix
- Serialize each structured display once, retain the original value only below the shared 8 KB preview cap, and store bounded truncation metadata otherwise.
- Extend `OutputSink.push()` with an inline representation so eval can account for the bounded preview while mirroring the complete value to the existing artifact.
- Add regression coverage for bounded details, full artifact recovery, and artifact metadata; document the user-visible resume fix.

## Verification
`bun test packages/coding-agent/test/tools/eval-display-text.test.ts packages/coding-agent/test/tools/eval-streaming-output.test.ts packages/coding-agent/test/streaming-output.test.ts` passed 72 tests. `bun check` passed. The original 100 KB reproduction now keeps serialized details below 20 KB and preserves the complete value in the linked eval artifact.

Fixes #11920