### PR TITLE
fix(prompts): mark the tool-roster notice as a delta, not a roster

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The hidden notice announcing a mid-session tool-availability change now states that it lists only what changed, so an additions-only notice no longer reads as the complete tool set and the model keeps using tools that are still callable ([#11824](https://github.com/can1357/oh-my-pi/issues/11824) by [@camjac251](https://github.com/camjac251)).
+
 ## [18.1.19] - 2026-09-12
 
 - Fixed `--mode json` returning exit 0 on a turn-fatal provider/auth/network error ([#11498](https://github.com/can1357/oh-my-pi/issues/11498)).

--- a/packages/coding-agent/src/prompts/system/tool-roster-notice.md
+++ b/packages/coding-agent/src/prompts/system/tool-roster-notice.md
@@ -1,3 +1,3 @@
 <system-notice>
-Tool availability changed.{{#if added}} Now available: {{added}}.{{/if}}{{#if removed}} No longer available: {{removed}}.{{/if}} The provider-side tool list reflects this.
+Tool availability changed.{{#if added}} Now available: {{added}}.{{/if}}{{#if removed}} No longer available: {{removed}}.{{/if}} This lists only what changed; any tool not named here is unaffected. Your current tool schema is authoritative for the full set.
 </system-notice>


### PR DESCRIPTION
## What

The mid-session tool-availability notice now states that it lists only what changed, and points the model at its own tool schema as the authority for the full set. One line in `prompts/system/tool-roster-notice.md`.

Before:

```
Tool availability changed. Now available: read, bash, edit, glob, grep, task, hub, web_search, learn, manage_skill. The provider-side tool list reflects this.
```

After:

```
Tool availability changed. Now available: read, bash, edit, glob, grep, task, hub, web_search, learn, manage_skill. This lists only what changed; any tool not named here is unaffected. Your current tool schema is authoritative for the full set.
```

## Why

An `added`-only list followed by "The provider-side tool list reflects this" cannot be told apart from an exhaustive statement of the current surface, so every tool absent from the list reads as removed.

That is what turned #11824 from a cosmetic bug into an expensive one. A queued delta announced 10 of 14 tools as newly available. The schema still carried all 14 and every one of them stayed callable, but the agent concluded `ask`, `eval`, `todo`, and `write` were gone and shelled out to `cat > file <<EOF` for the remaining ~80 turns of the session. Asked to quote what it was reasoning from, a model in the repro said it plainly:

> the function schema I can see still lists ask, eval, todo, and write; the list above follows the system notice, which is authoritative

That is the correct reading of the old sentence, which is the problem. #11825 is fixing the delta computation, and it should land. This is the other half: with the wording unchanged, the next delta-computation regression costs a silently degraded session again. With it changed, a wrong delta is merely a wrong delta.

Opened separately at @roboomp's request, since the prompt file is out of scope for that workflow.

## Testing

`bun check` passes at the repo root. `bun test test/prefix-binding-tool-roster.test.ts test/agent-session-tool-rebuild-skip.test.ts` gives 44 pass, 0 fail.

The `Tool availability changed.` and `Now available: <names>.` strings are unchanged, so the existing assertions at `prefix-binding-tool-roster.test.ts:150-152` still hold, and this does not collide with the tests #11825 adds. Nothing anywhere asserted the clause being replaced.

Rendered through `prompt.render` across all three branches of the template:

```
added only (the #11824 shape)
  Tool availability changed. Now available: read, bash, edit, glob, grep, task, hub,
  web_search, learn, manage_skill. This lists only what changed; any tool not named
  here is unaffected. Your current tool schema is authoritative for the full set.

removed only
  Tool availability changed. No longer available: eval, write. This lists only what
  changed; ...

both
  Tool availability changed. Now available: todo. No longer available: ask. This
  lists only what changed; ...
```

No new test. The defect is prose, and a test pinning the replacement prose would guard nothing a consumer observes; it would just have to be rewritten the next time the wording is tuned.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)
