### PR TITLE
fix(coding-agent): humanize model browser labels

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -84,6 +84,8 @@
 
 ## [18.1.17] - 2026-09-10
 
+- Model pickers now show human model and provider names without changing routing identifiers, and refreshed catalogs continue respecting `enabledModels`.
+- Marketplace plugins that share a repository root now load only their declared skills instead of every skill in the repository ([#11513](https://github.com/can1357/oh-my-pi/issues/11513)).
 ### Added
 
 - Unsent prompts cleared with Ctrl+C can now be recalled with Up, including pastes and images; disable Recall Cleared Drafts in settings to discard future clears instead ([#11524](https://github.com/can1357/oh-my-pi/pull/11524) by [@camjac251](https://github.com/camjac251)).

--- a/packages/coding-agent/src/modes/components/model-browser.ts
+++ b/packages/coding-agent/src/modes/components/model-browser.ts
@@ -10,7 +10,9 @@
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { authPolicyFor } from "@oh-my-pi/pi-catalog/compat/auth";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
+import { getCatalogProviderEntry } from "@oh-my-pi/pi-catalog/provider-models";
 import {
 	type Component,
 	fuzzyRank,
@@ -317,13 +319,42 @@ function compactModelSearchText(value: string): string {
 	return value.toLowerCase().replace(/[^\p{Letter}\p{Mark}\p{Number}]+/gu, "");
 }
 
-/** Exact id/selector → contiguous literal → fuzzy-only. */
+/** Human provider label from canonical catalog/auth metadata; custom providers may already use a display label as the id. */
+export function modelProviderDisplayName(provider: string): string {
+	return getCatalogProviderEntry(provider)?.catalogDiscovery?.label ?? authPolicyFor(provider)?.name ?? provider;
+}
+
+/** Search surface: human names plus every technical identity field, without changing the rendered label. */
+export function modelBrowserSearchText(item: ModelBrowserItem): string {
+	const identity = [
+		item.model.name || item.id,
+		item.id,
+		item.provider,
+		modelProviderDisplayName(item.provider),
+		item.selector,
+	].join(" ");
+	return isFreeModel(item.model) ? `${identity} free` : identity;
+}
+
+/** Exact/contiguous human name or technical identity → fuzzy-only. */
 function modelSearchTier(query: string, item: ModelBrowserItem): number {
 	if (!query) return 2;
+	const name = compactModelSearchText(item.model.name || item.id);
 	const id = compactModelSearchText(item.id);
+	const provider = compactModelSearchText(item.provider);
+	const providerName = compactModelSearchText(modelProviderDisplayName(item.provider));
 	const selector = compactModelSearchText(item.selector);
-	if (query === id || query === selector) return 0;
-	if (id.includes(query) || selector.includes(query)) return 1;
+	if (query === name || query === id || query === selector) return 0;
+	if (query === provider || query === providerName) return 1;
+	if (
+		name.includes(query) ||
+		id.includes(query) ||
+		provider.includes(query) ||
+		providerName.includes(query) ||
+		selector.includes(query)
+	) {
+		return 1;
+	}
 	return 2;
 }
 
@@ -428,6 +459,12 @@ function formatTtft(ms: number): string {
 function padLeftVisible(text: string, width: number): string {
 	const missing = width - visibleWidth(text);
 	return missing > 0 ? " ".repeat(missing) + text : text;
+}
+
+/** Pad a plain/styled cell on the right to `width` terminal columns. */
+function padRightVisible(text: string, width: number): string {
+	const missing = width - visibleWidth(text);
+	return missing > 0 ? text + " ".repeat(missing) : text;
 }
 
 /** Behavior switches for {@link ModelBrowser}. */
@@ -576,7 +613,7 @@ export class ModelBrowser implements Component {
 	}
 
 	get visibleCount(): number {
-		return this.#visibleItems.length;
+		return this.#visibleItems.filter(item => !this.#isDisabled(item)).length;
 	}
 
 	/** Move selection to `selector`; false when it is not in the current view. */
@@ -723,10 +760,9 @@ export class ModelBrowser implements Component {
 		const query = this.#searchInput.getValue();
 		let items: ModelBrowserItem[];
 		if (query.trim()) {
-			// Match against the displayed row text so the user can type what
-			// they see: bare names, provider prefixes, scoped queries, and the
-			// cost column's `free` all flow through the same fuzzy matcher.
-			const ranked = fuzzyRank(this.#baseItems, query, modelSearchText);
+			// Search human labels, canonical wire identity, and displayed cost
+			// text without exposing technical selectors as row labels.
+			const ranked = fuzzyRank(this.#baseItems, query, modelBrowserSearchText);
 			const matches = ranked.map(result => result.item);
 			if (this.#preserveQueryOrder) {
 				items = matches;
@@ -908,6 +944,7 @@ export class ModelBrowser implements Component {
 		hovered: boolean,
 		ctxWidth: number,
 		costWidth: number,
+		providerWidth: number,
 		intelligenceWidth: number,
 		perfWidth: number,
 		perfMode: PerfMode,
@@ -919,28 +956,29 @@ export class ModelBrowser implements Component {
 		}
 		const overContext = this.isOverContext(item);
 		const prefix = selected && this.#focused ? `${theme.fg("accent", theme.nav.cursor)} ` : "  ";
-		const providerPrefix = this.#showProvider ? theme.fg("dim", `${item.provider}/`) : "";
-		const name = item.labelColor
-			? theme.fg(item.labelColor, item.id)
-			: selected
-				? theme.fg("accent", item.id)
-				: item.id;
+		const label = item.labelColor ? item.id : item.model.name || item.id;
+		const name = item.labelColor ? theme.fg(item.labelColor, label) : selected ? theme.fg("accent", label) : label;
 		const currentMark =
 			item.selector === this.#currentSelector ? ` ${theme.fg("success", theme.status.enabled)}` : "";
 		const overLimit = overContext
 			? ` ${theme.status.disabled} context>${formatNumber(item.model.contextWindow ?? 0).toLowerCase()}`
 			: "";
-		let left = `${prefix}${providerPrefix}${name}${currentMark}${overLimit}`;
+		let left = `${prefix}${name}${currentMark}${overLimit}`;
 
 		// Metric columns collapse independently when no visible row has data.
+		const providerCol =
+			providerWidth > 0
+				? `${theme.fg("dim", padRightVisible(truncateToWidth(modelProviderDisplayName(item.provider), providerWidth), providerWidth))}  `
+				: "";
 		const intelligenceCol =
 			intelligenceWidth > 0
 				? `${theme.fg("dim", padLeftVisible(formatIntelligence(item.model), intelligenceWidth))}  `
 				: "";
 		const perfCol =
 			perfWidth > 0 ? `${theme.fg("dim", padLeftVisible(this.#perfCell(item, perfMode), perfWidth))}  ` : "";
-		const meta = `${intelligenceCol}${perfCol}${theme.fg("dim", padLeftVisible(formatContext(item.model), ctxWidth))}  ${theme.fg("dim", padLeftVisible(formatCostPair(item.model), costWidth))}`;
+		const meta = `${providerCol}${intelligenceCol}${perfCol}${theme.fg("dim", padLeftVisible(formatContext(item.model), ctxWidth))}  ${theme.fg("dim", padLeftVisible(formatCostPair(item.model), costWidth))}`;
 		const metaWidth =
+			(providerWidth > 0 ? providerWidth + 2 : 0) +
 			ctxWidth +
 			costWidth +
 			2 +
@@ -970,7 +1008,7 @@ export class ModelBrowser implements Component {
 		if (!selected) return ["", ""];
 		const model = selected.model;
 
-		const facts: string[] = [model.name];
+		const facts: string[] = [];
 		// Upstream badges sit next to the name; the provider blurb goes last so
 		// width truncation eats prose before context, cost, or perf facts.
 		if (model.isNew) facts.push("new");
@@ -1043,10 +1081,22 @@ export class ModelBrowser implements Component {
 			lines.push(truncateToWidth(theme.fg("muted", message), width));
 			for (let i = 1; i < this.#maxVisible; i++) lines.push("");
 		} else {
-			// Per-window column widths keep the metadata block aligned without
-			// scanning the entire catalog on every render.
+			// Metric widths follow the visible window. Provider width is stable for
+			// the whole filtered scope so scrolling cannot shift the model column.
 			let ctxWidth = 0;
 			let costWidth = 0;
+			const providerWidth = this.#showProvider
+				? Math.min(
+						Math.max(8, Math.floor(width / 4)),
+						this.#visibleItems.reduce(
+							(max, item) =>
+								this.#isDisabled(item)
+									? max
+									: Math.max(max, visibleWidth(modelProviderDisplayName(item.provider))),
+							0,
+						),
+					)
+				: 0;
 			const perfMode: PerfMode = width >= PERF_FULL_MIN_WIDTH ? "full" : width >= PERF_TPS_MIN_WIDTH ? "tps" : "off";
 			let intelligenceWidth = 0;
 			let perfWidth = 0;
@@ -1073,6 +1123,7 @@ export class ModelBrowser implements Component {
 						i === this.#hoveredIndex,
 						ctxWidth,
 						costWidth,
+						providerWidth,
 						intelligenceWidth,
 						perfWidth,
 						perfMode,

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -29,6 +29,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import type { ModelRegistry } from "../../config/model-registry";
 import {
+	filterAvailableModelsByEnabledPatterns,
 	formatModelSelectorValue,
 	type ModelRoleLookup,
 	parseModelString,
@@ -44,9 +45,10 @@ import { theme } from "../theme/theme";
 import { matchesSelectCancel, matchesSelectDown, matchesSelectUp } from "../utils/keybinding-matchers";
 import {
 	buildBrowserItems,
+	modelBrowserSearchText,
+	modelProviderDisplayName,
 	ModelBrowser,
 	type ModelBrowserItem,
-	modelSearchText,
 	type RoleAssignments,
 	resolveRoleAssignments,
 	sortModelItems,
@@ -344,7 +346,11 @@ export class ModelHubComponent implements Component {
 			this.#configError = loadError ? String(loadError) : undefined;
 			allModels = this.#registry.getAll();
 			try {
-				availableModels = this.#registry.getAvailable();
+				availableModels = filterAvailableModelsByEnabledPatterns(
+					this.#registry.getAvailable(),
+					this.#settings.get("enabledModels"),
+					this.#settings,
+				);
 			} catch (error) {
 				this.#configError = error instanceof Error ? error.message : String(error);
 				availableModels = [];
@@ -431,7 +437,7 @@ export class ModelHubComponent implements Component {
 		const providerEntry = (providerId: string, isLocked: boolean): SidebarEntry => ({
 			id: `provider:${providerId}`,
 			kind: "provider",
-			label: providerId,
+			label: modelProviderDisplayName(providerId),
 			providerId,
 			locked: isLocked,
 			annotation: isLocked ? undefined : String(availableCounts.get(providerId) ?? 0),
@@ -665,7 +671,7 @@ export class ModelHubComponent implements Component {
 			this.#composeEntries();
 			return;
 		}
-		const matches = fuzzyFilter(this.#availableItems, query, modelSearchText);
+		const matches = fuzzyFilter(this.#availableItems, query, modelBrowserSearchText);
 		const counts = new Map<string, number>();
 		for (const item of matches) {
 			counts.set(item.provider, (counts.get(item.provider) ?? 0) + 1);
@@ -2034,7 +2040,8 @@ export class ModelHubComponent implements Component {
 			if (assignment && !assignment.autoSelected) {
 				dot = theme.fg(info.color ?? "muted", theme.status.enabled);
 				tagStyled = theme.fg(info.color ?? "muted", tag);
-				value = `${theme.fg("dim", `${assignment.model.provider}/`)}${selected ? theme.fg("accent", assignment.model.id) : assignment.model.id}`;
+				const modelName = assignment.model.name || assignment.model.id;
+				value = `${theme.fg("dim", `${modelProviderDisplayName(assignment.model.provider)} · `)}${selected ? theme.fg("accent", modelName) : modelName}`;
 				const glyph = thinkingLevelGlyph(assignment.thinkingLevel, theme);
 				const label = getConfiguredThinkingLevelMetadata(assignment.thinkingLevel).label;
 				if (assignment.thinkingLevel !== ThinkingLevel.Inherit) {
@@ -2043,7 +2050,10 @@ export class ModelHubComponent implements Component {
 			} else if (assignment) {
 				dot = theme.fg("dim", theme.status.shadowed);
 				tagStyled = theme.fg("dim", tag);
-				value = theme.fg("dim", `auto → ${assignment.model.provider}/${assignment.model.id}`);
+				value = theme.fg(
+					"dim",
+					`auto → ${assignment.model.name || assignment.model.id} · ${modelProviderDisplayName(assignment.model.provider)}`,
+				);
 			} else {
 				dot = theme.fg("dim", theme.status.shadowed);
 				tagStyled = theme.fg("dim", tag);
@@ -2128,7 +2138,7 @@ export class ModelHubComponent implements Component {
 			for (const model of preview) {
 				if (model.provider !== entry.providerId) continue;
 				if (lines.length >= rows) break;
-				lines.push(truncateToWidth(theme.fg("dim", `    ${model.id}`), width));
+				lines.push(truncateToWidth(theme.fg("dim", `    ${model.name || model.id}`), width));
 			}
 		}
 		while (lines.length < rows) lines.push("");
@@ -2202,8 +2212,8 @@ export class ModelHubComponent implements Component {
 
 		const prefix =
 			strip.kind === "role"
-				? `${theme.fg("accent", strip.item.id)}${theme.fg("dim", " →")} `
-				: `${theme.fg(getRoleInfo(strip.role ?? "", this.#settings).color ?? "muted", (getRoleInfo(strip.role ?? "", this.#settings).tag ?? strip.role ?? "").toLowerCase())}${theme.fg("dim", ` · ${strip.item.id} →`)} `;
+				? `${theme.fg("accent", strip.item.model.name || strip.item.id)}${theme.fg("dim", " →")} `
+				: `${theme.fg(getRoleInfo(strip.role ?? "", this.#settings).color ?? "muted", (getRoleInfo(strip.role ?? "", this.#settings).tag ?? strip.role ?? "").toLowerCase())}${theme.fg("dim", ` · ${strip.item.model.name || strip.item.id} →`)} `;
 
 		// Horizontal window: once the strip overflows, drop leading chips behind
 		// a dim ellipsis so the selected chip (plus one chip of lookahead when it

--- a/packages/coding-agent/src/modes/components/model-picker.ts
+++ b/packages/coding-agent/src/modes/components/model-picker.ts
@@ -6,6 +6,7 @@
  */
 import type { Model } from "@oh-my-pi/pi-ai";
 import { addKeyAliases, type Component, canonicalKeyId, type KeyId, parseKey, type TUI } from "@oh-my-pi/pi-tui";
+import { filterAvailableModelsByEnabledPatterns } from "../../config/model-resolver";
 import type { ModelRegistry } from "../../config/model-registry";
 import type { Settings } from "../../config/settings";
 import type { ResolvedRoleModel } from "../../session/agent-session";
@@ -175,7 +176,11 @@ export class ModelPickerComponent implements Component {
 			const loadError = this.#registry.getError();
 			this.#configError = loadError ? String(loadError) : undefined;
 			try {
-				models = this.#registry.getAvailable();
+				models = filterAvailableModelsByEnabledPatterns(
+					this.#registry.getAvailable(),
+					this.#settings.get("enabledModels"),
+					this.#settings,
+				);
 			} catch (error) {
 				this.#configError = error instanceof Error ? error.message : String(error);
 				models = [];

--- a/packages/coding-agent/test/model-browser.test.ts
+++ b/packages/coding-agent/test/model-browser.test.ts
@@ -6,6 +6,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
 	buildBrowserItems,
 	ModelBrowser,
+	modelProviderDisplayName,
 	type RoleAssignments,
 	resolveRoleAssignments,
 	sortModelItems,
@@ -29,6 +30,21 @@ function makeModel(provider: string, id: string, metadata?: NativeMetadata): Mod
 		contextWindow: 128_000,
 		maxTokens: 1024,
 		...metadata,
+	});
+}
+
+function makeNamedModel(provider: string, id: string, name: string): Model {
+	return buildModel({
+		id,
+		name,
+		api: "ollama-chat",
+		provider,
+		baseUrl: "https://example.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 1024,
 	});
 }
 
@@ -83,6 +99,16 @@ describe("ModelBrowser search ranking", () => {
 		browser.setQuery("gpt-5.5");
 
 		expect(browser.getSelected()?.selector).toBe("openai-codex/gpt-5.5");
+	});
+
+	test("an exact model-name match outranks models that only match by provider", () => {
+		const exact = makeNamedModel("other", "some-model", "Groq");
+		const providerPeer = makeNamedModel("groq", "some-other-model", "Other Model");
+		const browser = makeBrowser([exact, providerPeer], ["groq/some-other-model"]);
+
+		browser.setQuery("Groq");
+
+		expect(browser.getSelected()?.selector).toBe("other/some-model");
 	});
 
 	test("MRU breaks ties between equally good matches", () => {
@@ -217,6 +243,15 @@ describe("ModelBrowser search ranking", () => {
 		expect(browser.visibleCount).toBe(1);
 		expect(browser.getSelected()?.selector).toBe("nvidia/moonshotai/kimi-k3");
 	});
+
+	test("matches the human model name without exposing it as wire identity", () => {
+		const human = makeNamedModel("OpenCode GO", "opencode-go/deepseek-v4-pro", "Reasoning Flagship");
+		const browser = makeBrowser([makeModel("Other", "deepseek-v4-preview"), human], []);
+
+		browser.setQuery("Reasoning Flagship");
+
+		expect(browser.getSelected()?.selector).toBe("OpenCode GO/opencode-go/deepseek-v4-pro");
+	});
 });
 
 describe("ModelBrowser perf display", () => {
@@ -304,12 +339,100 @@ describe("ModelBrowser native model metadata", () => {
 			}),
 		);
 
-		expect(detail).toContain("swe-2 · new · beta · recommended · 128k ctx · 1k out · free per M");
+		expect(detail).toContain("new · beta · recommended · 128k ctx · 1k out · free per M");
+		expect(detail).not.toContain("swe-2 ·");
 		// Tabs and newlines are flattened so the blurb stays one detail row.
 		expect(detail).toMatch(/free per M · Fast {2,}agentic coder$/);
 	});
 
 	test("models without upstream metadata render the plain detail line", () => {
-		expect(renderDetail(makeModel("openai", "gpt-5"))).toContain("gpt-5 · 128k ctx · 1k out · free per M");
+		const detail = renderDetail(makeModel("openai", "gpt-5"));
+		expect(detail).toContain("128k ctx · 1k out · free per M");
+		expect(detail).not.toContain("gpt-5 ·");
+	});
+});
+
+describe("ModelBrowser row label", () => {
+	beforeAll(async () => {
+		await initTheme(false);
+	});
+
+	test("renders human-friendly model.name rather than raw model.id in row", () => {
+		const model = buildModel({
+			id: "deepseek-v4-pro",
+			name: "DeepSeek V4 Pro",
+			api: "ollama-chat",
+			provider: "deepseek",
+			baseUrl: "https://example.com",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 1024,
+		});
+		const browser = new ModelBrowser(Settings.isolated({}));
+		browser.setItems(buildBrowserItems([model]));
+
+		const row = Bun.stripANSI(browser.render(120)[2]);
+		expect(row).toContain("DeepSeek V4 Pro");
+		expect(row).not.toContain("deepseek-v4-pro");
+	});
+
+	test("uses canonical auth metadata when a built-in provider has no discovery label", () => {
+		expect(modelProviderDisplayName("groq")).toBe("Groq");
+		expect(modelProviderDisplayName("opencode-go")).toBe("OpenCode Go");
+	});
+
+	test("renders provider as a separate display column instead of a selector prefix", () => {
+		const browser = new ModelBrowser(Settings.isolated({}));
+		browser.setItems(
+			buildBrowserItems([makeNamedModel("OpenCode GO", "opencode-go/deepseek-v4-pro", "DeepSeek V4 Pro")]),
+		);
+
+		const row = Bun.stripANSI(browser.render(120)[2]);
+		expect(row).toContain("DeepSeek V4 Pro");
+		expect(row).toContain("OpenCode GO");
+		expect(row).not.toContain("OpenCode GO/DeepSeek");
+		expect(row).not.toContain("opencode-go/deepseek-v4-pro");
+	});
+
+	test("cross-provider name collisions stay distinguishable without wire ids", () => {
+		const browser = new ModelBrowser(Settings.isolated({}));
+		browser.setItems(
+			buildBrowserItems([
+				makeNamedModel("Moonshot", "moonshot/kimi-k2.6", "Kimi K2.6"),
+				makeNamedModel("OpenCode GO", "opencode-go/kimi-k2.6", "Kimi K2.6"),
+			]),
+		);
+
+		const rows = browser
+			.render(120)
+			.slice(2, 4)
+			.map(line => Bun.stripANSI(line));
+		expect(rows.some(row => row.includes("Kimi K2.6") && row.includes("Moonshot"))).toBe(true);
+		expect(rows.some(row => row.includes("Kimi K2.6") && row.includes("OpenCode GO"))).toBe(true);
+		expect(rows.join("\n")).not.toContain("moonshot/kimi-k2.6");
+		expect(rows.join("\n")).not.toContain("opencode-go/kimi-k2.6");
+	});
+
+	test("long provider labels cannot crowd model names out of narrow rows", () => {
+		const browser = new ModelBrowser(Settings.isolated({}));
+		browser.setItems(
+			buildBrowserItems([
+				makeNamedModel("An Extremely Long Custom Provider Display Name", "route/model-id", "Readable Model"),
+			]),
+		);
+
+		const row = Bun.stripANSI(browser.render(60)[2]);
+		expect(row).toContain("Readable Model");
+		expect(Bun.stringWidth(row)).toBeLessThanOrEqual(60);
+	});
+
+	test("visibleCount excludes the non-selectable recent separator", () => {
+		const recent = makeModel("a", "recent");
+		const other = makeModel("b", "other");
+		const browser = makeBrowser([recent, other], ["a/recent"]);
+
+		expect(browser.visibleCount).toBe(2);
 	});
 });

--- a/packages/coding-agent/test/model-hub.test.ts
+++ b/packages/coding-agent/test/model-hub.test.ts
@@ -321,8 +321,8 @@ describe("ModelHub", () => {
 
 			const rendered = normalize(hub.render(220));
 			expect(rendered).toContain("All models 1");
-			expect(rendered).toContain("nvidia 1");
-			expect(rendered).toContain("anthropic 0");
+			expect(rendered).toContain("NVIDIA 1");
+			expect(rendered).toContain("Anthropic 0");
 		});
 	});
 
@@ -420,7 +420,7 @@ describe("ModelHub", () => {
 			installTestTheme();
 
 			hub.handleInput(DOWN); // All models → locked anthropic
-			expect(normalize(hub.render(220))).toContain("anthropic has no credentials configured");
+			expect(normalize(hub.render(220))).toContain("Anthropic has no credentials configured");
 			expect(footerLine(hub.render(220))).toContain("Enter log in");
 
 			// Typing a search character switches to All models and focuses list
@@ -1241,7 +1241,7 @@ describe("ModelHub", () => {
 			// Scope-hop: All models → custom-provider → openrouter.
 			hub.handleInput(DOWN);
 			hub.handleInput(DOWN);
-			expect(normalize(hub.render(220))).toContain("openrouter ·");
+			expect(normalize(hub.render(220))).toContain("OpenRouter ·");
 
 			for (const ch of "glm-5.2") hub.handleInput(ch);
 			hub.handleInput("\n");
@@ -1259,8 +1259,12 @@ describe("ModelHub", () => {
 
 			for (const ch of "glm") hub.handleInput(ch);
 			const rendered = normalize(hub.render(220));
-			expect(rendered).toContain("openrouter/z-ai/glm-5.2");
-			expect(rendered).toContain("custom-provider/glm-5.2");
+			expect(rendered).toContain("z-ai/glm-5.2");
+			expect(rendered).toContain("OpenRouter");
+			expect(rendered).toContain("glm-5.2");
+			expect(rendered).toContain("custom-provider");
+			expect(rendered).not.toContain("openrouter/z-ai/glm-5.2");
+			expect(rendered).not.toContain("custom-provider/glm-5.2");
 		});
 
 		test("a provider scope that loses every match falls back to All models", () => {
@@ -1287,7 +1291,7 @@ describe("ModelHub", () => {
 			for (const ch of "z-ai") hub.handleInput(ch);
 			hub.handleInput(LEFT); // switch focus to sidebar
 			hub.handleInput(DOWN); // skips custom-provider (0 matches), lands on openrouter
-			expect(normalize(hub.render(220))).toContain("openrouter ·");
+			expect(normalize(hub.render(220))).toContain("OpenRouter ·");
 		});
 		test("providers with matches float to the top of the sidebar while searching", () => {
 			const noMatch = makeModel("aaa-provider", "different-model");
@@ -1345,6 +1349,28 @@ describe("ModelHub", () => {
 	});
 
 	describe("provider refresh lifecycle", () => {
+		test("registry refresh cannot reintroduce models outside enabledModels", async () => {
+			const allowed = makeModel("prov-a", "allowed-model");
+			const broadOnly = makeModel("prov-b", "broad-only-model");
+			const settings = Settings.isolated({ enabledModels: ["prov-a/allowed-model"] });
+			let available = [allowed];
+			const refreshGate = Promise.withResolvers<void>();
+			const { hub } = createHub({
+				models: () => available,
+				settings,
+				registry: { refresh: () => refreshGate.promise },
+			});
+
+			expect(normalize(hub.render(220))).toContain("allowed-model");
+			available = [allowed, broadOnly];
+			refreshGate.resolve();
+			await Bun.sleep(0);
+
+			const rendered = normalize(hub.render(220));
+			expect(rendered).toContain("allowed-model");
+			expect(rendered).not.toContain("broad-only-model");
+		});
+
 		test("auto-refreshes a provider once per process; F5 forces a re-fetch", async () => {
 			const model = makeModel("prov-a", "model-a");
 			const refreshProvider = vi.fn(async () => {});
@@ -1403,7 +1429,7 @@ describe("ModelHub", () => {
 
 			hub.handleInput(DOWN); // All models → locked anthropic (separator skipped)
 			const rendered = normalize(hub.render(220));
-			expect(rendered).toContain("anthropic has no credentials configured");
+			expect(rendered).toContain("Anthropic has no credentials configured");
 			expect(rendered).toContain("claude-locked-test");
 
 			hub.handleInput("\n");

--- a/packages/coding-agent/test/model-picker.test.ts
+++ b/packages/coding-agent/test/model-picker.test.ts
@@ -14,10 +14,10 @@ function normalize(lines: readonly string[]): string {
 	return stripVTControlCharacters(lines.join("\n")).replace(/\s+/g, " ").trim();
 }
 
-function makeModel(provider: string, id: string, contextWindow = 128_000): Model {
+function makeModel(provider: string, id: string, contextWindow = 128_000, name = id): Model {
 	return buildModel({
 		id,
-		name: id,
+		name,
 		api: "ollama-chat",
 		provider,
 		baseUrl: "https://example.com",
@@ -164,6 +164,39 @@ describe("ModelPicker", () => {
 		await Bun.sleep(0);
 		picker.handleInput("\n");
 		expect(onPick.mock.calls[0]?.[0]?.id).toBe("cc-model");
+	});
+
+	test("background refresh cannot reintroduce models outside enabledModels", async () => {
+		const allowed = makeModel("test", "allowed-model");
+		const broadOnly = makeModel("test", "broad-only-model");
+		const settings = Settings.isolated({ enabledModels: ["test/allowed-model"] });
+		let available = [allowed];
+		const refreshGate = Promise.withResolvers<void>();
+		const { picker } = createPicker({
+			models: () => available,
+			settings,
+			registry: { refresh: () => refreshGate.promise },
+		});
+
+		expect(normalize(picker.render(220))).toContain("allowed-model");
+		available = [allowed, broadOnly];
+		refreshGate.resolve();
+		await Bun.sleep(0);
+
+		const rendered = normalize(picker.render(220));
+		expect(rendered).toContain("allowed-model");
+		expect(rendered).not.toContain("broad-only-model");
+	});
+
+	test("compact picker renders the human model/provider labels without a duplicate model-name footer", () => {
+		const model = makeModel("OpenCode GO", "opencode-go/deepseek-v4-pro", 128_000, "DeepSeek V4 Pro");
+		const { picker } = createPicker({ models: [model], scoped: true });
+
+		const rendered = normalize(picker.render(220));
+		expect(rendered).toContain("DeepSeek V4 Pro");
+		expect(rendered).toContain("OpenCode GO");
+		expect(rendered).not.toContain("opencode-go/deepseek-v4-pro");
+		expect(rendered).not.toContain("Model Name:");
 	});
 
 	test("highlights and preselects the session's current model", () => {


### PR DESCRIPTION
## Problem
Model rows render provider plus raw wire ID, producing duplicated labels such as `Antigravity/antigravity/gemini-3.8-flash` even though the catalog carries human-readable names.

## Change
- render model and provider display names separately
- retain technical selectors for search, selection, persistence, and routing
- keep refreshed model sets constrained by `enabledModels`
- cap long provider columns so narrow rows retain the model name
- preserve current `thinkingLevelGlyph(level, theme)` behavior from main

## Verification
- focused model browser/hub/picker suite: 84 passed
- full TypeScript workspace check and typecheck passed
- `git diff --check` passed
