### PR TITLE
fix(catalog): disable encrypted reasoning replay for opencode muse-spark

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenCode Zen/Go Muse Spark models failing every tool-call turn with a 400 "reasoning encrypted_content was not issued to this caller" error: the gateways proxy the Responses lane to Meta but can't round-trip encrypted reasoning, so those SKUs no longer request or replay it ([#11928](https://github.com/can1357/oh-my-pi/issues/11928)).
+
 ## [18.1.19] - 2026-09-12
 
 ### Added

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -13223,7 +13223,19 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:49",
+				"source": "providers/opencode-go.kdl:55",
+				"class": "meta",
+				"providers": [
+					"opencode-go"
+				],
+				"family": "muse-spark",
+				"wire": {
+					"includeEncryptedReasoning": false,
+					"filterReasoningHistory": true
+				}
+			},
+			{
+				"source": "providers/opencode-go.kdl:61",
 				"class": "mimo",
 				"providers": [
 					"opencode-go"
@@ -13234,7 +13246,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:48",
+				"source": "providers/opencode-go.kdl:60",
 				"class": "mimo",
 				"providers": [
 					"opencode-go"
@@ -13244,7 +13256,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:56",
+				"source": "providers/opencode-go.kdl:68",
 				"class": "qwen",
 				"providers": [
 					"opencode-go"
@@ -13270,7 +13282,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:60",
+				"source": "providers/opencode-go.kdl:72",
 				"class": "qwen",
 				"providers": [
 					"opencode-go"
@@ -13296,7 +13308,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:66",
+				"source": "providers/opencode-go.kdl:78",
 				"providers": [
 					"opencode-go"
 				],
@@ -13321,7 +13333,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:71",
+				"source": "providers/opencode-go.kdl:83",
 				"providers": [
 					"opencode-go"
 				],
@@ -13341,7 +13353,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:76",
+				"source": "providers/opencode-go.kdl:88",
 				"providers": [
 					"opencode-go"
 				],
@@ -13363,7 +13375,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:81",
+				"source": "providers/opencode-go.kdl:93",
 				"providers": [
 					"opencode-go"
 				],
@@ -13384,7 +13396,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:85",
+				"source": "providers/opencode-go.kdl:97",
 				"providers": [
 					"opencode-go"
 				],
@@ -13411,7 +13423,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:89",
+				"source": "providers/opencode-go.kdl:101",
 				"providers": [
 					"opencode-go"
 				],
@@ -13433,7 +13445,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:94",
+				"source": "providers/opencode-go.kdl:106",
 				"providers": [
 					"opencode-go"
 				],
@@ -13448,7 +13460,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:98",
+				"source": "providers/opencode-go.kdl:110",
 				"providers": [
 					"opencode-go"
 				],
@@ -13540,7 +13552,19 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:30",
+				"source": "providers/opencode-zen.kdl:36",
+				"class": "meta",
+				"providers": [
+					"opencode-zen"
+				],
+				"family": "muse-spark",
+				"wire": {
+					"includeEncryptedReasoning": false,
+					"filterReasoningHistory": true
+				}
+			},
+			{
+				"source": "providers/opencode-zen.kdl:42",
 				"class": "mimo",
 				"providers": [
 					"opencode-zen"
@@ -13551,7 +13575,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:35",
+				"source": "providers/opencode-zen.kdl:47",
 				"class": "minimax",
 				"providers": [
 					"opencode-zen"
@@ -13562,7 +13586,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:40",
+				"source": "providers/opencode-zen.kdl:52",
 				"class": "openai",
 				"providers": [
 					"opencode-zen"
@@ -13582,7 +13606,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:44",
+				"source": "providers/opencode-zen.kdl:56",
 				"class": "unknown",
 				"providers": [
 					"opencode-zen"
@@ -13592,7 +13616,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:48",
+				"source": "providers/opencode-zen.kdl:60",
 				"class": "xai",
 				"providers": [
 					"opencode-zen"
@@ -13603,7 +13627,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:53",
+				"source": "providers/opencode-zen.kdl:65",
 				"providers": [
 					"opencode-zen"
 				],
@@ -13625,7 +13649,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:58",
+				"source": "providers/opencode-zen.kdl:70",
 				"providers": [
 					"opencode-zen"
 				],
@@ -13643,7 +13667,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:62",
+				"source": "providers/opencode-zen.kdl:74",
 				"providers": [
 					"opencode-zen"
 				],
@@ -13700,7 +13724,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:67",
+				"source": "providers/opencode-zen.kdl:79",
 				"providers": [
 					"opencode-zen"
 				],
@@ -13721,7 +13745,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:71",
+				"source": "providers/opencode-zen.kdl:83",
 				"providers": [
 					"opencode-zen"
 				],
@@ -13745,7 +13769,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:75",
+				"source": "providers/opencode-zen.kdl:87",
 				"providers": [
 					"opencode-zen"
 				],
@@ -13763,7 +13787,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:79",
+				"source": "providers/opencode-zen.kdl:91",
 				"providers": [
 					"opencode-zen"
 				],
@@ -13786,7 +13810,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:84",
+				"source": "providers/opencode-zen.kdl:96",
 				"providers": [
 					"opencode-zen"
 				],
@@ -13810,7 +13834,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:89",
+				"source": "providers/opencode-zen.kdl:101",
 				"providers": [
 					"opencode-zen"
 				],
@@ -13830,7 +13854,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:99",
+				"source": "providers/opencode-zen.kdl:111",
 				"providers": [
 					"opencode-zen"
 				],

--- a/packages/catalog/src/compat/rules/providers/opencode-go.kdl
+++ b/packages/catalog/src/compat/rules/providers/opencode-go.kdl
@@ -45,6 +45,18 @@ provider "opencode-go" {
 	class "kimi" {
 		thinking-mode "effort"
 	}
+	// The Go gateway proxies Muse Spark's Responses lane to Meta but cannot
+	// round-trip encrypted reasoning: the upstream issues `encrypted_content`
+	// bound to the gateway's own caller, so replaying it on a later step 400s
+	// with "reasoning `encrypted_content` was not issued to this caller"
+	// (#11928). Stop requesting it and drop native reasoning items from replay
+	// so multi-step tool-call turns stop failing.
+	class "meta" {
+		family "muse-spark" {
+			include-encrypted-reasoning #false
+			filter-reasoning-history #true
+		}
+	}
 	class "mimo" {
 		family "v2" {
 			thinking-mode "effort"

--- a/packages/catalog/src/compat/rules/providers/opencode-zen.kdl
+++ b/packages/catalog/src/compat/rules/providers/opencode-zen.kdl
@@ -26,6 +26,18 @@ provider "opencode-zen" {
 	class "kimi" {
 		thinking-mode "effort"
 	}
+	// The Zen gateway proxies Muse Spark's Responses lane to Meta but cannot
+	// round-trip encrypted reasoning: the upstream issues `encrypted_content`
+	// bound to the gateway's own caller, so replaying it on a later step 400s
+	// with "reasoning `encrypted_content` was not issued to this caller"
+	// (#11928). Stop requesting it and drop native reasoning items from replay
+	// so multi-step tool-call turns stop failing.
+	class "meta" {
+		family "muse-spark" {
+			include-encrypted-reasoning #false
+			filter-reasoning-history #true
+		}
+	}
 	class "mimo" {
 		family "v2" {
 			thinking-mode "effort"

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -77,6 +77,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -171,6 +172,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -270,6 +272,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -301,8 +304,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
-			"maxTokens": 393216,
+			"contextWindow": 1000000,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -311,14 +314,13 @@
 					"max"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "deepseek-v3",
 			"identity": {
 				"class": "deepseek",
 				"family": "flash"
 			},
-			"int": 51.8,
-			"tps": 140,
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -373,8 +375,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"deepseek-ai/deepseek-v4-pro": {
 			"id": "deepseek-ai/deepseek-v4-pro",
@@ -392,8 +393,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
-			"maxTokens": 393216,
+			"contextWindow": 1000000,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -402,14 +403,13 @@
 					"max"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "deepseek-v3",
 			"identity": {
 				"class": "deepseek",
 				"family": "pro"
 			},
-			"int": 53.2,
-			"tps": 60.2,
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -464,12 +464,11 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
-			"name": "Gemma 4 31B",
+			"name": "Gemma 4 31B IT",
 			"api": "openai-completions",
 			"provider": "aiand",
 			"baseUrl": "https://api.aiand.com/v1",
@@ -485,7 +484,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -496,10 +495,11 @@
 					"xhigh"
 				]
 			},
-			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "gemma"
 			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -553,12 +553,11 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
-		"moonshotai/kimi-k2.7-code": {
-			"id": "moonshotai/kimi-k2.7-code",
-			"name": "Kimi K2.7 Code",
+		"moonshotai/kimi-k2.6": {
+			"id": "moonshotai/kimi-k2.6",
+			"name": "Kimi K2.6",
 			"api": "openai-completions",
 			"provider": "aiand",
 			"baseUrl": "https://api.aiand.com/v1",
@@ -568,7 +567,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.75,
+				"input": 0.85,
 				"output": 3.5,
 				"cacheRead": 0,
 				"cacheWrite": 0
@@ -585,14 +584,13 @@
 					"xhigh"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "kimi-k2",
 			"identity": {
 				"class": "kimi",
-				"family": "k2.7-code"
+				"family": "k2.6"
 			},
-			"int": 43,
-			"tps": 39,
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -647,8 +645,99 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
+			}
+		},
+		"moonshotai/kimi-k2.7-code": {
+			"id": "moonshotai/kimi-k2.7-code",
+			"name": "Kimi K2.7 Code",
+			"api": "openai-completions",
+			"provider": "aiand",
+			"baseUrl": "https://api.aiand.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.75,
+				"output": 3.5,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "kimi",
+				"family": "k2.7-code"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": true,
+				"disableReasoningOnForcedToolChoice": true,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": true,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "moonshot-mfjs",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "kimi",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		},
 		"moonshotai/kimi-k3": {
 			"id": "moonshotai/kimi-k3",
@@ -857,7 +946,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 131072,
+			"maxTokens": 40960,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -866,13 +955,12 @@
 					"high"
 				]
 			},
-			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "gpt-oss",
 				"family": "120b"
 			},
-			"int": 24.1,
-			"tps": 153,
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -926,8 +1014,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"qwen/qwen3.6-27b": {
 			"id": "qwen/qwen3.6-27b",
@@ -937,17 +1024,16 @@
 			"baseUrl": "https://api.aiand.com/v1",
 			"reasoning": true,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
-				"input": 0.32,
-				"output": 3.2,
+				"input": 0,
+				"output": 0,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 262140,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -957,14 +1043,13 @@
 					"high"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "qwen3",
 			"identity": {
 				"class": "qwen",
 				"revision": "3.6.0"
 			},
-			"int": 37.7,
-			"tps": 52.5,
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -1018,8 +1103,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"qwen/qwen3.8-27b": {
 			"id": "qwen/qwen3.8-27b",
@@ -1113,9 +1197,9 @@
 			},
 			"supportsComputerUse": false
 		},
-		"zai-org/glm-5.2": {
-			"id": "zai-org/glm-5.2",
-			"name": "GLM 5.2",
+		"zai-org/glm-5.1": {
+			"id": "zai-org/glm-5.1",
+			"name": "GLM 5.1",
 			"api": "openai-completions",
 			"provider": "aiand",
 			"baseUrl": "https://api.aiand.com/v1",
@@ -1124,12 +1208,12 @@
 				"text"
 			],
 			"cost": {
-				"input": 1,
-				"output": 4,
+				"input": 1.4,
+				"output": 4.4,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 202752,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -1138,15 +1222,16 @@
 					"low",
 					"medium",
 					"high",
-					"max"
+					"xhigh"
 				]
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"identity": {
-				"class": "glm",
-				"revision": "5.2.0"
-			},
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -1200,8 +1285,97 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
+			}
+		},
+		"zai-org/glm-5.2": {
+			"id": "zai-org/glm-5.2",
+			"name": "GLM 5.2",
+			"api": "openai-completions",
+			"provider": "aiand",
+			"baseUrl": "https://api.aiand.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1,
+				"output": 4,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.2.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		},
 		"zai-org/glm-5.3": {
 			"id": "zai-org/glm-5.3",
@@ -29553,6 +29727,20 @@
 			"maxTokens": 16384,
 			"int": 34.5,
 			"tps": 97.2,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "4.7.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -29608,20 +29796,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "glm",
-				"revision": "4.7.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsDeveloperRole": false
@@ -29647,6 +29821,21 @@
 			"maxTokens": 16384,
 			"int": 40.6,
 			"tps": 66.5,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -29702,21 +29891,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "glm",
-				"revision": "5.0.0"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "glm5",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsDeveloperRole": false
@@ -29742,6 +29916,21 @@
 			"contextWindow": 262144,
 			"maxTokens": 32768,
 			"int": 36,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "kimi",
+				"family": "k2.5"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -29798,21 +29987,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "kimi",
-				"family": "k2.5"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "kimi-k2",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsDeveloperRole": false
@@ -29838,6 +30012,20 @@
 			"maxTokens": 24576,
 			"int": 34.5,
 			"tps": 97,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "minimax",
+				"family": "m2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -29893,20 +30081,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "minimax",
-				"family": "m2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsDeveloperRole": false
@@ -29932,6 +30106,12 @@
 			"maxTokens": 65536,
 			"int": 21.3,
 			"tps": 128.9,
+			"identity": {
+				"class": "qwen",
+				"family": "coder",
+				"revision": "3.0.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -29987,12 +30167,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"identity": {
-				"class": "qwen",
-				"family": "coder",
-				"revision": "3.0.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsDeveloperRole": false
@@ -30016,6 +30190,12 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
+			"identity": {
+				"class": "qwen",
+				"family": "coder",
+				"revision": "3.0.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -30071,12 +30251,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"identity": {
-				"class": "qwen",
-				"family": "coder",
-				"revision": "3.0.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsDeveloperRole": false
@@ -30100,6 +30274,11 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
+			"identity": {
+				"class": "qwen",
+				"revision": "3.0.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -30155,11 +30334,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"identity": {
-				"class": "qwen",
-				"revision": "3.0.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsDeveloperRole": false
@@ -30184,6 +30358,21 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "qwen",
+				"revision": "3.5.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -30239,21 +30428,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "qwen",
-				"revision": "3.5.0"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "qwen3",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsDeveloperRole": false
@@ -30278,6 +30452,21 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "qwen",
+				"revision": "3.6.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -30333,21 +30522,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "qwen",
-				"revision": "3.6.0"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "qwen3",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsDeveloperRole": false
@@ -30374,6 +30548,21 @@
 			"maxTokens": 65536,
 			"int": 40.5,
 			"tps": 55.7,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "qwen",
+				"revision": "3.6.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -30429,21 +30618,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "qwen",
-				"revision": "3.6.0"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "qwen3",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsDeveloperRole": false
@@ -30469,6 +30643,21 @@
 			"maxTokens": 65536,
 			"int": 46.7,
 			"tps": 203.9,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "qwen",
+				"revision": "3.7.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -30524,21 +30713,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "qwen",
-				"revision": "3.7.0"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "qwen3",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsDeveloperRole": false
@@ -30565,6 +30739,21 @@
 			"maxTokens": 64000,
 			"int": 39.4,
 			"tps": 56.1,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "qwen",
+				"revision": "3.7.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -30620,21 +30809,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "qwen",
-				"revision": "3.7.0"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "qwen3",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsDeveloperRole": false
@@ -31690,14 +31864,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic.claude-opus-4-7": {
 			"id": "anthropic.claude-opus-4-7",
@@ -31735,14 +31909,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic.claude-opus-4-8": {
 			"id": "anthropic.claude-opus-4-8",
@@ -31780,14 +31954,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic.claude-opus-5": {
 			"id": "anthropic.claude-opus-5",
@@ -31825,14 +31999,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 512,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic.claude-sonnet-5": {
 			"id": "anthropic.claude-sonnet-5",
@@ -31870,14 +32044,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"au.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "au.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -31914,14 +32088,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"au.anthropic.claude-opus-4-6-v1": {
 			"id": "au.anthropic.claude-opus-4-6-v1",
@@ -31958,14 +32132,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"au.anthropic.claude-opus-4-8": {
 			"id": "au.anthropic.claude-opus-4-8",
@@ -32003,14 +32177,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"au.anthropic.claude-opus-5": {
 			"id": "au.anthropic.claude-opus-5",
@@ -32048,14 +32222,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 512,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
 			"id": "au.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -32092,14 +32266,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"au.anthropic.claude-sonnet-4-6": {
 			"id": "au.anthropic.claude-sonnet-4-6",
@@ -32136,14 +32310,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"au.anthropic.claude-sonnet-5": {
 			"id": "au.anthropic.claude-sonnet-5",
@@ -32181,14 +32355,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"cohere.command-r-plus-v1:0": {
 			"id": "cohere.command-r-plus-v1:0",
@@ -32212,14 +32386,14 @@
 			"identity": {
 				"class": "unknown"
 			},
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"supportsComputerUse": false,
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"cohere.command-r-v1:0": {
 			"id": "cohere.command-r-v1:0",
@@ -32243,14 +32417,14 @@
 			"identity": {
 				"class": "unknown"
 			},
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"supportsComputerUse": false,
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"deepseek.v3-v1:0": {
 			"id": "deepseek.v3-v1:0",
@@ -32284,14 +32458,14 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek.v3.2": {
 			"id": "deepseek.v3.2",
@@ -32326,14 +32500,14 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek.v3.2-v1:0": {
 			"id": "deepseek.v3.2-v1:0",
@@ -32650,14 +32824,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"eu.anthropic.claude-fable-5-1": {
 			"id": "eu.anthropic.claude-fable-5-1",
@@ -32696,14 +32870,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -32740,14 +32914,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"eu.anthropic.claude-opus-4-1-20250805-v1:0": {
 			"id": "eu.anthropic.claude-opus-4-1-20250805-v1:0",
@@ -32784,14 +32958,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"eu.anthropic.claude-opus-4-20250514-v1:0": {
 			"id": "eu.anthropic.claude-opus-4-20250514-v1:0",
@@ -32872,14 +33046,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"eu.anthropic.claude-opus-4-6-v1": {
 			"id": "eu.anthropic.claude-opus-4-6-v1",
@@ -32916,14 +33090,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"eu.anthropic.claude-opus-4-7": {
 			"id": "eu.anthropic.claude-opus-4-7",
@@ -32961,14 +33135,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"eu.anthropic.claude-opus-4-8": {
 			"id": "eu.anthropic.claude-opus-4-8",
@@ -33006,14 +33180,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"eu.anthropic.claude-opus-5": {
 			"id": "eu.anthropic.claude-opus-5",
@@ -33051,14 +33225,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 512,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"eu.anthropic.claude-sonnet-4-20250514-v1:0": {
 			"id": "eu.anthropic.claude-sonnet-4-20250514-v1:0",
@@ -33139,14 +33313,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"eu.anthropic.claude-sonnet-4-6": {
 			"id": "eu.anthropic.claude-sonnet-4-6",
@@ -33183,14 +33357,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"eu.anthropic.claude-sonnet-5": {
 			"id": "eu.anthropic.claude-sonnet-5",
@@ -33228,14 +33402,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"global.amazon.nova-2-lite-v1:0": {
 			"id": "global.amazon.nova-2-lite-v1:0",
@@ -33270,14 +33444,14 @@
 				"family": "nova"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"global.anthropic.claude-fable-5": {
 			"id": "global.anthropic.claude-fable-5",
@@ -33315,14 +33489,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"global.anthropic.claude-fable-5-1": {
 			"id": "global.anthropic.claude-fable-5-1",
@@ -33361,14 +33535,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"global.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -33405,14 +33579,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"global.anthropic.claude-opus-4-5-20251101-v1:0": {
 			"id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
@@ -33449,14 +33623,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"global.anthropic.claude-opus-4-6-v1": {
 			"id": "global.anthropic.claude-opus-4-6-v1",
@@ -33493,14 +33667,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"global.anthropic.claude-opus-4-7": {
 			"id": "global.anthropic.claude-opus-4-7",
@@ -33538,14 +33712,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"global.anthropic.claude-opus-4-8": {
 			"id": "global.anthropic.claude-opus-4-8",
@@ -33583,14 +33757,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"global.anthropic.claude-opus-5": {
 			"id": "global.anthropic.claude-opus-5",
@@ -33628,14 +33802,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 512,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"global.anthropic.claude-sonnet-4-20250514-v1:0": {
 			"id": "global.anthropic.claude-sonnet-4-20250514-v1:0",
@@ -33716,14 +33890,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"global.anthropic.claude-sonnet-4-6": {
 			"id": "global.anthropic.claude-sonnet-4-6",
@@ -33760,14 +33934,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"global.anthropic.claude-sonnet-5": {
 			"id": "global.anthropic.claude-sonnet-5",
@@ -33805,14 +33979,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"global.openai.gpt-5.6-luna": {
 			"id": "global.openai.gpt-5.6-luna",
@@ -33848,7 +34022,7 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
@@ -33856,7 +34030,7 @@
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"global.openai.gpt-5.6-sol": {
 			"id": "global.openai.gpt-5.6-sol",
@@ -33892,7 +34066,7 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
@@ -33900,7 +34074,7 @@
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"global.openai.gpt-5.6-terra": {
 			"id": "global.openai.gpt-5.6-terra",
@@ -33936,7 +34110,7 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
@@ -33944,7 +34118,7 @@
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"google.gemma-3-27b-it": {
 			"id": "google.gemma-3-27b-it",
@@ -33969,14 +34143,14 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"google.gemma-3-4b-it": {
 			"id": "google.gemma-3-4b-it",
@@ -34001,14 +34175,14 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"jp.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "jp.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -34045,14 +34219,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"jp.anthropic.claude-opus-4-7": {
 			"id": "jp.anthropic.claude-opus-4-7",
@@ -34090,14 +34264,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"jp.anthropic.claude-opus-4-8": {
 			"id": "jp.anthropic.claude-opus-4-8",
@@ -34135,14 +34309,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
 			"id": "jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -34179,14 +34353,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"jp.anthropic.claude-sonnet-4-6": {
 			"id": "jp.anthropic.claude-sonnet-4-6",
@@ -34223,14 +34397,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"jp.anthropic.claude-sonnet-5": {
 			"id": "jp.anthropic.claude-sonnet-5",
@@ -34268,14 +34442,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta.llama3-1-405b-instruct-v1:0": {
 			"id": "meta.llama3-1-405b-instruct-v1:0",
@@ -34299,14 +34473,14 @@
 			"identity": {
 				"class": "unknown"
 			},
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"supportsComputerUse": false,
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"meta.llama3-1-70b-instruct-v1:0": {
 			"id": "meta.llama3-1-70b-instruct-v1:0",
@@ -34330,14 +34504,14 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"meta.llama3-1-8b-instruct-v1:0": {
 			"id": "meta.llama3-1-8b-instruct-v1:0",
@@ -34361,14 +34535,14 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"minimax.minimax-m2": {
 			"id": "minimax.minimax-m2",
@@ -34403,14 +34577,14 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax.minimax-m2.1": {
 			"id": "minimax.minimax-m2.1",
@@ -34445,14 +34619,14 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax.minimax-m2.5": {
 			"id": "minimax.minimax-m2.5",
@@ -34487,14 +34661,14 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral.devstral-2-123b": {
 			"id": "mistral.devstral-2-123b",
@@ -34519,13 +34693,13 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral.magistral-small-2509": {
 			"id": "mistral.magistral-small-2509",
@@ -34560,14 +34734,14 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral.ministral-3-14b-instruct": {
 			"id": "mistral.ministral-3-14b-instruct",
@@ -34592,13 +34766,13 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral.ministral-3-3b-instruct": {
 			"id": "mistral.ministral-3-3b-instruct",
@@ -34624,13 +34798,13 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral.ministral-3-8b-instruct": {
 			"id": "mistral.ministral-3-8b-instruct",
@@ -34655,13 +34829,13 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral.mistral-large-2402-v1:0": {
 			"id": "mistral.mistral-large-2402-v1:0",
@@ -34718,13 +34892,13 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral.pixtral-large-2502-v1:0": {
 			"id": "mistral.pixtral-large-2502-v1:0",
@@ -34750,13 +34924,13 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral.voxtral-mini-3b-2507": {
 			"id": "mistral.voxtral-mini-3b-2507",
@@ -34781,13 +34955,13 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral.voxtral-small-24b-2507": {
 			"id": "mistral.voxtral-small-24b-2507",
@@ -34812,13 +34986,13 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshot.kimi-k2-thinking": {
 			"id": "moonshot.kimi-k2-thinking",
@@ -34854,7 +35028,7 @@
 				"logicalId": "moonshot.kimi-k2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
@@ -34862,7 +35036,7 @@
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"moonshotai.kimi-k2.5": {
 			"id": "moonshotai.kimi-k2.5",
@@ -34896,7 +35070,7 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
@@ -34904,7 +35078,7 @@
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"nvidia.nemotron-nano-12b-v2": {
 			"id": "nvidia.nemotron-nano-12b-v2",
@@ -34929,14 +35103,14 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"nvidia.nemotron-nano-3-30b": {
 			"id": "nvidia.nemotron-nano-3-30b",
@@ -34969,7 +35143,7 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
@@ -34977,7 +35151,7 @@
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"nvidia.nemotron-nano-9b-v2": {
 			"id": "nvidia.nemotron-nano-9b-v2",
@@ -35003,14 +35177,14 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"nvidia.nemotron-super-3-120b": {
 			"id": "nvidia.nemotron-super-3-120b",
@@ -35043,7 +35217,7 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
@@ -35051,7 +35225,7 @@
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"openai.gpt-oss-120b": {
 			"id": "openai.gpt-oss-120b",
@@ -35085,14 +35259,14 @@
 				"family": "120b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai.gpt-oss-120b-1:0": {
 			"id": "openai.gpt-oss-120b-1:0",
@@ -35126,14 +35300,14 @@
 				"family": "120b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai.gpt-oss-20b": {
 			"id": "openai.gpt-oss-20b",
@@ -35167,14 +35341,14 @@
 				"family": "20b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai.gpt-oss-20b-1:0": {
 			"id": "openai.gpt-oss-20b-1:0",
@@ -35208,14 +35382,14 @@
 				"family": "20b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai.gpt-oss-safeguard-120b": {
 			"id": "openai.gpt-oss-safeguard-120b",
@@ -35239,13 +35413,13 @@
 				"class": "gpt-oss"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai.gpt-oss-safeguard-20b": {
 			"id": "openai.gpt-oss-safeguard-20b",
@@ -35269,13 +35443,13 @@
 				"class": "gpt-oss"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen.qwen3-235b-a22b-2507-v1:0": {
 			"id": "qwen.qwen3-235b-a22b-2507-v1:0",
@@ -35300,13 +35474,13 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen.qwen3-32b-v1:0": {
 			"id": "qwen.qwen3-32b-v1:0",
@@ -35340,14 +35514,14 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen.qwen3-coder-30b-a3b-v1:0": {
 			"id": "qwen.qwen3-coder-30b-a3b-v1:0",
@@ -35373,13 +35547,13 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen.qwen3-coder-480b-a35b-v1:0": {
 			"id": "qwen.qwen3-coder-480b-a35b-v1:0",
@@ -35405,13 +35579,13 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen.qwen3-coder-next": {
 			"id": "qwen.qwen3-coder-next",
@@ -35446,14 +35620,14 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen.qwen3-next-80b-a3b": {
 			"id": "qwen.qwen3-next-80b-a3b",
@@ -35479,13 +35653,13 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen.qwen3-vl-235b-a22b": {
 			"id": "qwen.qwen3-vl-235b-a22b",
@@ -35512,13 +35686,13 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us-gov.anthropic.claude-fable-5": {
 			"id": "us-gov.anthropic.claude-fable-5",
@@ -35556,14 +35730,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us-gov.anthropic.claude-fable-5-1": {
 			"id": "us-gov.anthropic.claude-fable-5-1",
@@ -35602,14 +35776,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us-gov.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "us-gov.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -35646,14 +35820,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us-gov.anthropic.claude-opus-4-1-20250805-v1:0": {
 			"id": "us-gov.anthropic.claude-opus-4-1-20250805-v1:0",
@@ -35690,14 +35864,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us-gov.anthropic.claude-opus-4-5-20251101-v1:0": {
 			"id": "us-gov.anthropic.claude-opus-4-5-20251101-v1:0",
@@ -35734,14 +35908,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us-gov.anthropic.claude-opus-4-6-v1": {
 			"id": "us-gov.anthropic.claude-opus-4-6-v1",
@@ -35778,14 +35952,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us-gov.anthropic.claude-opus-4-7": {
 			"id": "us-gov.anthropic.claude-opus-4-7",
@@ -35823,14 +35997,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us-gov.anthropic.claude-opus-4-8": {
 			"id": "us-gov.anthropic.claude-opus-4-8",
@@ -35868,14 +36042,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us-gov.anthropic.claude-opus-5": {
 			"id": "us-gov.anthropic.claude-opus-5",
@@ -35913,14 +36087,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 512,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0": {
 			"id": "us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -35957,14 +36131,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us-gov.anthropic.claude-sonnet-4-6": {
 			"id": "us-gov.anthropic.claude-sonnet-4-6",
@@ -36001,14 +36175,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us-gov.anthropic.claude-sonnet-5": {
 			"id": "us-gov.anthropic.claude-sonnet-5",
@@ -36046,14 +36220,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us.amazon.nova-lite-v1:0": {
 			"id": "us.amazon.nova-lite-v1:0",
@@ -36079,13 +36253,13 @@
 				"family": "nova"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us.amazon.nova-micro-v1:0": {
 			"id": "us.amazon.nova-micro-v1:0",
@@ -36110,13 +36284,13 @@
 				"family": "nova"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us.amazon.nova-premier-v1:0": {
 			"id": "us.amazon.nova-premier-v1:0",
@@ -36184,13 +36358,13 @@
 				"family": "nova"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us.anthropic.claude-3-7-sonnet-20250219-v1:0": {
 			"id": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
@@ -36262,14 +36436,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us.anthropic.claude-fable-5-1": {
 			"id": "us.anthropic.claude-fable-5-1",
@@ -36308,14 +36482,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -36352,14 +36526,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us.anthropic.claude-opus-4-1-20250805-v1:0": {
 			"id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
@@ -36396,14 +36570,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us.anthropic.claude-opus-4-20250514-v1:0": {
 			"id": "us.anthropic.claude-opus-4-20250514-v1:0",
@@ -36484,14 +36658,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us.anthropic.claude-opus-4-6-v1": {
 			"id": "us.anthropic.claude-opus-4-6-v1",
@@ -36528,14 +36702,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us.anthropic.claude-opus-4-7": {
 			"id": "us.anthropic.claude-opus-4-7",
@@ -36573,14 +36747,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us.anthropic.claude-opus-4-8": {
 			"id": "us.anthropic.claude-opus-4-8",
@@ -36618,14 +36792,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us.anthropic.claude-opus-5": {
 			"id": "us.anthropic.claude-opus-5",
@@ -36663,14 +36837,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 512,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us.anthropic.claude-sonnet-4-20250514-v1:0": {
 			"id": "us.anthropic.claude-sonnet-4-20250514-v1:0",
@@ -36751,14 +36925,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us.anthropic.claude-sonnet-4-6": {
 			"id": "us.anthropic.claude-sonnet-4-6",
@@ -36795,14 +36969,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us.anthropic.claude-sonnet-5": {
 			"id": "us.anthropic.claude-sonnet-5",
@@ -36840,14 +37014,14 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 900000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us.deepseek.r1-v1:0": {
 			"id": "us.deepseek.r1-v1:0",
@@ -36881,14 +37055,14 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"us.meta.llama3-2-11b-instruct-v1:0": {
 			"id": "us.meta.llama3-2-11b-instruct-v1:0",
@@ -36913,14 +37087,14 @@
 			"identity": {
 				"class": "unknown"
 			},
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"supportsComputerUse": false,
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"us.meta.llama3-2-1b-instruct-v1:0": {
 			"id": "us.meta.llama3-2-1b-instruct-v1:0",
@@ -36944,14 +37118,14 @@
 			"identity": {
 				"class": "unknown"
 			},
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"supportsComputerUse": false,
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"us.meta.llama3-2-3b-instruct-v1:0": {
 			"id": "us.meta.llama3-2-3b-instruct-v1:0",
@@ -36975,14 +37149,14 @@
 			"identity": {
 				"class": "unknown"
 			},
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"supportsComputerUse": false,
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"us.meta.llama3-2-90b-instruct-v1:0": {
 			"id": "us.meta.llama3-2-90b-instruct-v1:0",
@@ -37007,14 +37181,14 @@
 			"identity": {
 				"class": "unknown"
 			},
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"supportsComputerUse": false,
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"us.meta.llama3-3-70b-instruct-v1:0": {
 			"id": "us.meta.llama3-3-70b-instruct-v1:0",
@@ -37038,14 +37212,14 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"us.meta.llama4-maverick-17b-instruct-v1:0": {
 			"id": "us.meta.llama4-maverick-17b-instruct-v1:0",
@@ -37070,14 +37244,14 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"us.meta.llama4-scout-17b-instruct-v1:0": {
 			"id": "us.meta.llama4-scout-17b-instruct-v1:0",
@@ -37102,14 +37276,14 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"writer.palmyra-x4-v1:0": {
 			"id": "writer.palmyra-x4-v1:0",
@@ -37142,7 +37316,7 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
@@ -37150,7 +37324,7 @@
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"writer.palmyra-x5-v1:0": {
 			"id": "writer.palmyra-x5-v1:0",
@@ -37183,7 +37357,7 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
@@ -37191,7 +37365,7 @@
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"xai.grok-4.3": {
 			"id": "xai.grok-4.3",
@@ -37225,7 +37399,7 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
@@ -37233,7 +37407,7 @@
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"xai.grok-4.6": {
 			"id": "xai.grok-4.6",
@@ -37267,7 +37441,7 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
@@ -37275,7 +37449,7 @@
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"zai.glm-4.7": {
 			"id": "zai.glm-4.7",
@@ -37308,7 +37482,7 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
@@ -37316,7 +37490,7 @@
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"zai.glm-4.7-flash": {
 			"id": "zai.glm-4.7-flash",
@@ -37349,7 +37523,7 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
@@ -37357,7 +37531,7 @@
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		},
 		"zai.glm-5": {
 			"id": "zai.glm-5",
@@ -37390,7 +37564,7 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true,
 			"compat": {
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
@@ -37398,7 +37572,7 @@
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
 			},
-			"requiresToolResultImageHoisting": true
+			"supportsComputerUse": false
 		}
 	},
 	"anthropic": {
@@ -37586,8 +37760,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 62.1,
-			"tps": 69.6,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -37674,7 +37846,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": true,
 				"signingEndpoint": true,
@@ -37700,7 +37871,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-haiku-4-5": {
 			"id": "claude-haiku-4-5",
@@ -37738,7 +37910,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": true,
 				"signingEndpoint": true,
@@ -37764,7 +37935,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-haiku-4-5-20251001": {
 			"id": "claude-haiku-4-5-20251001",
@@ -37802,7 +37974,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": true,
 				"signingEndpoint": true,
@@ -37828,7 +37999,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-mythos-5": {
 			"id": "claude-mythos-5",
@@ -37860,13 +38032,14 @@
 				],
 				"supportsDisplay": true
 			},
-			"requiresGlyphTokenization": true,
-			"tokenizer": "claude-v5-sonnet",
 			"identity": {
 				"class": "anthropic",
 				"family": "mythos",
 				"revision": "5.0.0"
 			},
+			"requiresGlyphTokenization": true,
+			"tokenizer": "claude-v5-sonnet",
+			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": true,
 				"signingEndpoint": true,
@@ -37892,8 +38065,7 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"claude-opus-4-0": {
 			"id": "claude-opus-4-0",
@@ -38173,7 +38345,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": true,
 				"signingEndpoint": true,
@@ -38199,7 +38370,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-5-20251101": {
 			"id": "claude-opus-4-5-20251101",
@@ -38237,7 +38409,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": true,
 				"signingEndpoint": true,
@@ -38263,7 +38434,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-6": {
 			"id": "claude-opus-4-6",
@@ -38302,7 +38474,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": true,
 				"signingEndpoint": true,
@@ -38328,7 +38499,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-7": {
 			"id": "claude-opus-4-7",
@@ -38369,7 +38541,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": true,
 				"signingEndpoint": true,
@@ -38395,7 +38566,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-8": {
 			"id": "claude-opus-4-8",
@@ -38436,7 +38608,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": true,
 				"signingEndpoint": true,
@@ -38462,7 +38633,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-5": {
 			"id": "claude-opus-5",
@@ -38503,7 +38675,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": true,
 				"signingEndpoint": true,
@@ -38529,7 +38700,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-0": {
 			"id": "claude-sonnet-4-0",
@@ -38687,7 +38859,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": true,
 				"signingEndpoint": true,
@@ -38713,7 +38884,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-5-20250929": {
 			"id": "claude-sonnet-4-5-20250929",
@@ -38751,7 +38923,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": true,
 				"signingEndpoint": true,
@@ -38777,7 +38948,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-6": {
 			"id": "claude-sonnet-4-6",
@@ -38815,7 +38987,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": true,
 				"signingEndpoint": true,
@@ -38841,7 +39012,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-5": {
 			"id": "claude-sonnet-5",
@@ -38855,15 +39027,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 10,
-				"cacheRead": 0.2,
-				"cacheWrite": 2.5
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55.3,
-			"tps": 74.2,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -38945,7 +39115,6 @@
 				"family": "codex"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -38989,6 +39158,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -38999,7 +39169,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-4": {
 			"id": "gpt-4",
@@ -39069,6 +39240,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39149,6 +39321,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39189,7 +39362,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -39233,6 +39405,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39243,7 +39416,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-4-turbo-vision": {
 			"id": "gpt-4-turbo-vision",
@@ -39270,7 +39444,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -39314,6 +39487,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39324,7 +39498,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-4.1": {
 			"id": "gpt-4.1",
@@ -39353,7 +39528,6 @@
 				"revision": "4.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -39397,6 +39571,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39407,7 +39582,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-4.1-mini": {
 			"id": "gpt-4.1-mini",
@@ -39436,7 +39612,6 @@
 				"revision": "4.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -39480,6 +39655,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39490,7 +39666,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-4.1-nano": {
 			"id": "gpt-4.1-nano",
@@ -39519,7 +39696,6 @@
 				"revision": "4.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -39563,6 +39739,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39573,7 +39750,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-4o": {
 			"id": "gpt-4o",
@@ -39601,7 +39779,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -39645,6 +39822,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39655,7 +39833,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-4o-mini": {
 			"id": "gpt-4o-mini",
@@ -39683,7 +39862,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -39727,6 +39905,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39737,7 +39916,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5": {
 			"id": "gpt-5",
@@ -39775,7 +39955,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -39819,6 +39998,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39829,7 +40009,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5-codex": {
 			"id": "gpt-5-codex",
@@ -39866,7 +40047,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -39910,6 +40090,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39920,7 +40101,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5-mini": {
 			"id": "gpt-5-mini",
@@ -39958,7 +40140,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -40002,6 +40183,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40012,7 +40194,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5-nano": {
 			"id": "gpt-5-nano",
@@ -40050,7 +40233,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -40094,6 +40276,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40104,7 +40287,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5-pro": {
 			"id": "gpt-5-pro",
@@ -40140,7 +40324,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -40184,6 +40367,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40194,7 +40378,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.1": {
 			"id": "gpt-5.1",
@@ -40232,7 +40417,6 @@
 				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -40276,6 +40460,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40286,7 +40471,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.1-chat": {
 			"id": "gpt-5.1-chat",
@@ -40365,6 +40551,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40413,7 +40600,6 @@
 				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -40457,6 +40643,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40467,7 +40654,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.1-codex-max": {
 			"id": "gpt-5.1-codex-max",
@@ -40505,7 +40693,6 @@
 				"logicalId": "gpt-5.1-codex"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -40549,6 +40736,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40559,7 +40747,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.1-codex-mini": {
 			"id": "gpt-5.1-codex-mini",
@@ -40594,7 +40783,6 @@
 				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -40638,6 +40826,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40648,7 +40837,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.2": {
 			"id": "gpt-5.2",
@@ -40686,7 +40876,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -40730,6 +40919,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40740,7 +40930,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.2-chat": {
 			"id": "gpt-5.2-chat",
@@ -40819,6 +41010,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40867,7 +41059,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -40911,6 +41102,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40921,7 +41113,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.3-chat": {
 			"id": "gpt-5.3-chat",
@@ -41000,6 +41193,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41049,7 +41243,6 @@
 				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -41093,6 +41286,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41103,7 +41297,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.4": {
 			"id": "gpt-5.4",
@@ -41141,7 +41336,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -41185,6 +41379,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41195,7 +41390,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": true
 		},
 		"gpt-5.4-mini": {
 			"id": "gpt-5.4-mini",
@@ -41233,7 +41429,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -41277,6 +41472,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41287,7 +41483,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": true
 		},
 		"gpt-5.4-nano": {
 			"id": "gpt-5.4-nano",
@@ -41325,7 +41522,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -41369,6 +41565,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41379,7 +41576,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": true
 		},
 		"gpt-5.4-pro": {
 			"id": "gpt-5.4-pro",
@@ -41415,7 +41613,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -41459,6 +41656,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41469,7 +41667,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": true
 		},
 		"gpt-5.5": {
 			"id": "gpt-5.5",
@@ -41508,7 +41707,6 @@
 				"revision": "5.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -41552,6 +41750,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41562,7 +41761,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": true
 		},
 		"gpt-5.6-luna": {
 			"id": "gpt-5.6-luna",
@@ -41601,7 +41801,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -41645,6 +41844,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41655,7 +41855,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": true
 		},
 		"gpt-5.6-sol": {
 			"id": "gpt-5.6-sol",
@@ -41694,7 +41895,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -41738,6 +41938,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41748,7 +41949,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": true
 		},
 		"gpt-5.6-terra": {
 			"id": "gpt-5.6-terra",
@@ -41787,7 +41989,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -41831,6 +42032,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41841,7 +42043,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": true
 		},
 		"gpt-chat-latest": {
 			"id": "gpt-chat-latest",
@@ -41877,7 +42080,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -41921,6 +42123,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41931,7 +42134,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"o1": {
 			"id": "o1",
@@ -41969,7 +42173,6 @@
 				"family": "o-series"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -42013,6 +42216,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -42023,7 +42227,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"o1-mini": {
 			"id": "o1-mini",
@@ -42103,6 +42308,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -42153,7 +42359,6 @@
 				"family": "o-series"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -42197,6 +42402,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -42207,7 +42413,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"o3-mini": {
 			"id": "o3-mini",
@@ -42246,7 +42453,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -42290,6 +42496,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -42300,7 +42507,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"o4-mini": {
 			"id": "o4-mini",
@@ -42340,7 +42548,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -42384,6 +42591,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -42394,7 +42602,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"baseten": {
@@ -43893,6 +44102,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -43983,6 +44193,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -44073,6 +44284,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -44163,6 +44375,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -44253,6 +44466,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -44302,7 +44516,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -44356,7 +44569,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-oss-120b": {
 			"id": "gpt-oss-120b",
@@ -44391,7 +44605,6 @@
 				"family": "120b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -44445,7 +44658,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"llama3.1-8b": {
 			"id": "llama3.1-8b",
@@ -45053,7 +45267,6 @@
 				"class": "deepseek",
 				"family": "flash"
 			},
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -45108,7 +45321,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-v4-pro": {
 			"id": "deepseek-v4-pro",
@@ -45142,7 +45356,6 @@
 				"class": "deepseek",
 				"family": "pro"
 			},
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -45197,7 +45410,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-flash": {
 			"id": "deepseek/deepseek-v4-flash",
@@ -45325,7 +45539,6 @@
 				"class": "glm",
 				"revision": "5.2.0"
 			},
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -45379,7 +45592,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-5.3": {
 			"id": "glm-5.3",
@@ -45415,7 +45629,6 @@
 				"class": "glm",
 				"revision": "5.3.0"
 			},
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -45469,7 +45682,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-5.3-flash": {
 			"id": "glm-5.3-flash",
@@ -45767,7 +45981,6 @@
 				"class": "kimi",
 				"family": "k3"
 			},
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -45827,7 +46040,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mimo-v2.5": {
 			"id": "mimo-v2.5",
@@ -46197,7 +46411,6 @@
 				"class": "qwen",
 				"revision": "3.7.0"
 			},
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -46252,7 +46465,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.7-plus": {
 			"id": "qwen3.7-plus",
@@ -46300,7 +46514,6 @@
 				"class": "qwen",
 				"revision": "3.7.0"
 			},
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -46355,7 +46568,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.8-max": {
 			"id": "qwen3.8-max",
@@ -46393,7 +46607,6 @@
 				"class": "qwen",
 				"revision": "3.8.0"
 			},
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -46448,7 +46661,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5.3-flash": {
 			"id": "z-ai/glm-5.3-flash",
@@ -46563,7 +46777,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -46589,7 +46802,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"alibaba/qwen3.5-397b-a17b": {
 			"id": "alibaba/qwen3.5-397b-a17b",
@@ -46628,7 +46842,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -46654,7 +46867,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"alibaba/qwen3.7-max": {
 			"id": "alibaba/qwen3.7-max",
@@ -46692,7 +46906,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -46718,7 +46931,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"alibaba/qwen3.7-plus": {
 			"id": "alibaba/qwen3.7-plus",
@@ -46757,7 +46971,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -46783,7 +46996,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"alibaba/qwen3.8-max": {
 			"id": "alibaba/qwen3.8-max",
@@ -46822,7 +47036,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -46848,7 +47061,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-3-5-haiku": {
 			"id": "anthropic/claude-3-5-haiku",
@@ -47214,7 +47428,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -47240,7 +47453,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-haiku-4-5": {
 			"id": "anthropic/claude-haiku-4-5",
@@ -47342,7 +47556,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -47368,7 +47581,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4": {
 			"id": "anthropic/claude-opus-4",
@@ -47793,7 +48007,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -47819,7 +48032,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.6": {
 			"id": "anthropic/claude-opus-4.6",
@@ -47858,7 +48072,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -47884,7 +48097,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.7": {
 			"id": "anthropic/claude-opus-4.7",
@@ -47925,7 +48139,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -47951,7 +48164,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.8": {
 			"id": "anthropic/claude-opus-4.8",
@@ -47992,7 +48206,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -48018,7 +48231,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-5": {
 			"id": "anthropic/claude-opus-5",
@@ -48059,7 +48273,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -48085,7 +48298,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-sonnet-4": {
 			"id": "anthropic/claude-sonnet-4",
@@ -48313,7 +48527,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -48339,7 +48552,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-sonnet-4.6": {
 			"id": "anthropic/claude-sonnet-4.6",
@@ -48377,7 +48591,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -48403,7 +48616,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-sonnet-5": {
 			"id": "anthropic/claude-sonnet-5",
@@ -48444,7 +48658,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -48470,11 +48683,11 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-5": {
 			"id": "claude-sonnet-4-5",
-			"requiresGlyphTokenization": true,
 			"name": "Claude Sonnet 4.5",
 			"api": "anthropic-messages",
 			"provider": "cloudflare-ai-gateway",
@@ -48490,7 +48703,7 @@
 				"cacheRead": 0.3,
 				"cacheWrite": 3.75
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "budget",
@@ -48502,12 +48715,14 @@
 					"xhigh"
 				]
 			},
-			"tokenizer": "claude-v3",
 			"identity": {
 				"class": "anthropic",
 				"family": "sonnet",
 				"revision": "4.5.0"
 			},
+			"requiresGlyphTokenization": true,
+			"tokenizer": "claude-v3",
+			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -48533,8 +48748,7 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"deepseek/deepseek-v4-pro": {
 			"id": "deepseek/deepseek-v4-pro",
@@ -48572,7 +48786,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -48599,7 +48812,8 @@
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": true,
 				"thinkingLoopGuard": "deepseek"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k3": {
 			"id": "moonshotai/kimi-k3",
@@ -48638,7 +48852,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -48664,7 +48877,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4": {
 			"id": "openai/gpt-4",
@@ -48801,7 +49015,6 @@
 				"revision": "4.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -48827,7 +49040,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4.1-mini": {
 			"id": "openai/gpt-4.1-mini",
@@ -48856,7 +49070,6 @@
 				"revision": "4.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -48882,7 +49095,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4.1-nano": {
 			"id": "openai/gpt-4.1-nano",
@@ -48911,7 +49125,6 @@
 				"revision": "4.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -48937,7 +49150,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4o": {
 			"id": "openai/gpt-4o",
@@ -48965,7 +49179,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -48991,7 +49204,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4o-mini": {
 			"id": "openai/gpt-4o-mini",
@@ -49019,7 +49233,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -49045,7 +49258,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5": {
 			"id": "openai/gpt-5",
@@ -49083,7 +49297,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -49109,7 +49322,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5-mini": {
 			"id": "openai/gpt-5-mini",
@@ -49147,7 +49361,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -49173,7 +49386,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5-nano": {
 			"id": "openai/gpt-5-nano",
@@ -49211,7 +49425,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -49237,7 +49450,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5-pro": {
 			"id": "openai/gpt-5-pro",
@@ -49337,7 +49551,6 @@
 				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -49363,7 +49576,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.1-codex": {
 			"id": "openai/gpt-5.1-codex",
@@ -49895,7 +50109,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -49921,7 +50134,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.4-mini": {
 			"id": "openai/gpt-5.4-mini",
@@ -49959,7 +50173,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -49985,7 +50198,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.4-nano": {
 			"id": "openai/gpt-5.4-nano",
@@ -50023,7 +50237,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -50049,7 +50262,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.4-pro": {
 			"id": "openai/gpt-5.4-pro",
@@ -50085,7 +50299,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -50111,7 +50324,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.5": {
 			"id": "openai/gpt-5.5",
@@ -50150,7 +50364,6 @@
 				"revision": "5.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -50176,7 +50389,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.5-pro": {
 			"id": "openai/gpt-5.5-pro",
@@ -50213,7 +50427,6 @@
 				"revision": "5.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -50239,7 +50452,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6": {
 			"id": "openai/gpt-5.6",
@@ -50341,7 +50555,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -50367,7 +50580,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-sol": {
 			"id": "openai/gpt-5.6-sol",
@@ -50406,7 +50620,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -50432,7 +50645,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-terra": {
 			"id": "openai/gpt-5.6-terra",
@@ -50471,7 +50685,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -50497,7 +50710,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o1": {
 			"id": "openai/o1",
@@ -50664,7 +50878,6 @@
 				"family": "o-series"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -50690,7 +50903,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o3-mini": {
 			"id": "openai/o3-mini",
@@ -50729,7 +50943,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -50755,7 +50968,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o3-pro": {
 			"id": "openai/o3-pro",
@@ -50860,7 +51074,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -50886,7 +51099,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"workers-ai/@cf/deepseek-ai/deepseek-v4-flash-0731": {
 			"id": "workers-ai/@cf/deepseek-ai/deepseek-v4-flash-0731",
@@ -50920,7 +51134,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -50975,7 +51188,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"workers-ai/@cf/deepseek-ai/deepseek-v4-pro-0813": {
 			"id": "workers-ai/@cf/deepseek-ai/deepseek-v4-pro-0813",
@@ -51009,7 +51223,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -51064,7 +51277,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"workers-ai/@cf/google/gemma-4-26b-a4b-it": {
 			"id": "workers-ai/@cf/google/gemma-4-26b-a4b-it",
@@ -51099,7 +51313,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -51153,7 +51366,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"workers-ai/@cf/ibm-granite/granite-4.0-h-micro": {
 			"id": "workers-ai/@cf/ibm-granite/granite-4.0-h-micro",
@@ -51177,7 +51391,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -51231,7 +51444,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast": {
 			"id": "workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast",
@@ -51256,7 +51470,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -51310,7 +51523,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"workers-ai/@cf/meta/llama-4-scout-17b-16e-instruct": {
 			"id": "workers-ai/@cf/meta/llama-4-scout-17b-16e-instruct",
@@ -51336,7 +51550,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -51390,7 +51603,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"workers-ai/@cf/mistralai/mistral-small-3.1-24b-instruct": {
 			"id": "workers-ai/@cf/mistralai/mistral-small-3.1-24b-instruct",
@@ -51415,7 +51629,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -51469,7 +51682,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"workers-ai/@cf/moonshotai/kimi-k2.5": {
 			"id": "workers-ai/@cf/moonshotai/kimi-k2.5",
@@ -51571,7 +51785,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -51627,7 +51840,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"workers-ai/@cf/moonshotai/kimi-k2.7-code": {
 			"id": "workers-ai/@cf/moonshotai/kimi-k2.7-code",
@@ -51666,7 +51880,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -51721,7 +51934,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"workers-ai/@cf/nvidia/nemotron-3-120b-a12b": {
 			"id": "workers-ai/@cf/nvidia/nemotron-3-120b-a12b",
@@ -51755,7 +51969,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -51809,7 +52022,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"workers-ai/@cf/openai/gpt-oss-120b": {
 			"id": "workers-ai/@cf/openai/gpt-oss-120b",
@@ -51844,7 +52058,6 @@
 				"family": "120b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -51898,7 +52111,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"workers-ai/@cf/openai/gpt-oss-20b": {
 			"id": "workers-ai/@cf/openai/gpt-oss-20b",
@@ -51933,7 +52147,6 @@
 				"family": "20b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -51987,7 +52200,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"workers-ai/@cf/qwen/qwen3-30b-a3b-fp8": {
 			"id": "workers-ai/@cf/qwen/qwen3-30b-a3b-fp8",
@@ -52021,7 +52235,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -52075,7 +52288,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"workers-ai/@cf/qwen/qwen3.8-27b": {
 			"id": "workers-ai/@cf/qwen/qwen3.8-27b",
@@ -52113,7 +52327,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -52167,7 +52380,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"workers-ai/@cf/zai-org/glm-4.7-flash": {
 			"id": "workers-ai/@cf/zai-org/glm-4.7-flash",
@@ -52205,7 +52419,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -52259,7 +52472,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"workers-ai/@cf/zai-org/glm-5.2": {
 			"id": "workers-ai/@cf/zai-org/glm-5.2",
@@ -52297,7 +52511,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -52351,7 +52564,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"workers-ai/@cf/zai-org/glm-5.3": {
 			"id": "workers-ai/@cf/zai-org/glm-5.3",
@@ -52389,7 +52603,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -52443,7 +52656,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"workers-ai/@cf/zai-org/glm-5.3-flash": {
 			"id": "workers-ai/@cf/zai-org/glm-5.3-flash",
@@ -52483,7 +52697,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -52537,7 +52750,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xai/grok-4.20-0309-non-reasoning": {
 			"id": "xai/grok-4.20-0309-non-reasoning",
@@ -52565,7 +52779,6 @@
 				"revision": "4.20.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -52592,7 +52805,8 @@
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "xai"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xai/grok-4.20-0309-reasoning": {
 			"id": "xai/grok-4.20-0309-reasoning",
@@ -52631,7 +52845,6 @@
 				"revision": "4.20.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -52658,7 +52871,8 @@
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "xai"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xai/grok-4.3": {
 			"id": "xai/grok-4.3",
@@ -52697,7 +52911,6 @@
 				"revision": "4.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -52724,7 +52937,8 @@
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "xai"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xai/grok-4.5": {
 			"id": "xai/grok-4.5",
@@ -52763,7 +52977,6 @@
 				"revision": "4.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -52790,7 +53003,8 @@
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "xai"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xai/grok-4.6": {
 			"id": "xai/grok-4.6",
@@ -52829,7 +53043,6 @@
 				"revision": "4.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -52856,7 +53069,8 @@
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "xai"
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"commandcode": {
@@ -53738,7 +53952,6 @@
 				"family": "flash"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -53793,7 +54006,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.1-flash-lite": {
 			"id": "google/gemini-3.1-flash-lite",
@@ -54368,7 +54582,6 @@
 				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -54422,7 +54635,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.4": {
 			"id": "gpt-5.4",
@@ -54688,6 +54902,7 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
+			"contextPromotionTarget": "commandcode/gpt-5.4",
 			"supportsComputerUse": false
 		},
 		"gpt-5.6-luna": {
@@ -58590,7 +58805,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -58645,7 +58859,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V4-Flash": {
 			"id": "deepseek-ai/DeepSeek-V4-Flash",
@@ -58681,7 +58896,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -58736,7 +58950,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V4-Flash-0731": {
 			"id": "deepseek-ai/DeepSeek-V4-Flash-0731",
@@ -58770,7 +58985,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -58825,7 +59039,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V4-Pro": {
 			"id": "deepseek-ai/DeepSeek-V4-Pro",
@@ -58861,7 +59076,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -58916,7 +59130,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V4-Pro-0813": {
 			"id": "deepseek-ai/DeepSeek-V4-Pro-0813",
@@ -58950,7 +59165,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -59005,7 +59219,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemma-4-31B-it": {
 			"id": "google/gemma-4-31B-it",
@@ -59040,7 +59255,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -59094,7 +59308,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"ibm-granite/granite-4.1-8b": {
 			"id": "ibm-granite/granite-4.1-8b",
@@ -59120,7 +59335,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -59174,7 +59388,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"ibm-granite/granite-4.2-8b": {
 			"id": "ibm-granite/granite-4.2-8b",
@@ -59210,7 +59425,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -59264,7 +59478,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"JetBrains/Mellum2-12B-A2.5B-Instruct": {
 			"id": "JetBrains/Mellum2-12B-A2.5B-Instruct",
@@ -59288,7 +59503,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -59342,7 +59556,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta-llama/Llama-3.1-70B-Instruct": {
 			"id": "meta-llama/Llama-3.1-70B-Instruct",
@@ -59367,7 +59582,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -59421,7 +59635,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta-llama/Llama-3.1-8B-Instruct": {
 			"id": "meta-llama/Llama-3.1-8B-Instruct",
@@ -59446,7 +59661,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -59500,7 +59714,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta-llama/Llama-3.3-70B-Instruct": {
 			"id": "meta-llama/Llama-3.3-70B-Instruct",
@@ -59525,7 +59740,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -59579,7 +59793,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta-llama/Llama-4-Scout-17B-16E-Instruct": {
 			"id": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
@@ -59865,7 +60080,6 @@
 				"family": "m3"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -59919,7 +60133,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/Kimi-K2.5": {
 			"id": "moonshotai/Kimi-K2.5",
@@ -60051,7 +60266,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -60107,7 +60321,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/Kimi-K2.7-Code": {
 			"id": "moonshotai/Kimi-K2.7-Code",
@@ -60146,7 +60361,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -60201,7 +60415,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/Kimi-K3": {
 			"id": "moonshotai/Kimi-K3",
@@ -60427,7 +60642,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -60481,7 +60695,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B": {
 			"id": "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B",
@@ -60515,7 +60730,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -60569,7 +60783,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-oss-120b": {
 			"id": "openai/gpt-oss-120b",
@@ -60604,7 +60819,6 @@
 				"family": "120b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -60658,7 +60872,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-oss-20b": {
 			"id": "openai/gpt-oss-20b",
@@ -60693,7 +60908,6 @@
 				"family": "20b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -60747,7 +60961,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"OpenPipe/Qwen3-14B-Instruct": {
 			"id": "OpenPipe/Qwen3-14B-Instruct",
@@ -60774,7 +60989,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -60828,7 +61042,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-235B-A22B-Instruct-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
@@ -61023,7 +61238,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -61077,7 +61291,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-Coder-480B-A35B-Instruct": {
 			"id": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
@@ -61289,7 +61504,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -61343,7 +61557,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3.6-27B": {
 			"id": "Qwen/Qwen3.6-27B",
@@ -61381,7 +61596,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -61435,7 +61649,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3.6-35B-A3B": {
 			"id": "Qwen/Qwen3.6-35B-A3B",
@@ -61473,7 +61688,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -61527,7 +61741,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3.8-27B": {
 			"id": "Qwen/Qwen3.8-27B",
@@ -61565,7 +61780,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -61619,7 +61833,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-5-FP8": {
 			"id": "zai-org/GLM-5-FP8",
@@ -61829,7 +62044,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -61883,7 +62097,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"cursor": {
@@ -76141,6 +76356,14 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -76181,6 +76404,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"streamIdleTimeoutMs": 300000,
 				"stripDeepseekSpecialTokens": true,
 				"streamMarkupHealingPattern": "dsml",
 				"reasoningDeltasMayBeCumulative": false,
@@ -76195,7 +76419,6 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
-				"streamIdleTimeoutMs": 300000,
 				"whenThinking": {
 					"supportsStore": false,
 					"supportsDeveloperRole": false,
@@ -76258,15 +76481,7 @@
 					"supportsPromptCacheKey": false
 				}
 			},
-			"supportsComputerUse": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high",
-					"max"
-				]
-			}
+			"supportsComputerUse": false
 		},
 		"deepseek-v4-flash": {
 			"id": "deepseek-v4-flash",
@@ -76711,6 +76926,20 @@
 			"maxTokens": 384000,
 			"int": 53.2,
 			"tps": 60.2,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "deepseek",
+				"family": "pro"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -76828,20 +77057,6 @@
 					"supportsPromptCacheKey": false
 				}
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high",
-					"max"
-				]
-			},
-			"identity": {
-				"class": "deepseek",
-				"family": "pro"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "deepseek-v3",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsDeveloperRole": false,
@@ -76946,12 +77161,6 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"identity": {
-				"class": "glm",
-				"revision": "5.2.0"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "glm5",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -76965,6 +77174,12 @@
 					"minimal": "none"
 				}
 			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.2.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
 			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
@@ -77040,12 +77255,6 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"identity": {
-				"class": "kimi",
-				"family": "k3"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "kimi-k2",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -77059,6 +77268,12 @@
 				},
 				"requiresEffort": true
 			},
+			"identity": {
+				"class": "kimi",
+				"family": "k3"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
 			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
@@ -77905,6 +78120,8 @@
 				"class": "glm",
 				"revision": "5.1.0"
 			},
+			"int": 41,
+			"tps": 50.5,
 			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
@@ -78094,6 +78311,8 @@
 				"class": "glm",
 				"revision": "5.2.0"
 			},
+			"int": 52.6,
+			"tps": 69.1,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -78836,11 +79055,13 @@
 				"class": "kimi",
 				"family": "k2.6"
 			},
+			"int": 45.1,
+			"tps": 40.1,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
 				"supportsMultipleSystemMessages": true,
-				"supportsReasoningEffort": true,
+				"supportsReasoningEffort": false,
 				"supportsReasoningParams": true,
 				"supportsSamplingParams": true,
 				"supportsPenaltyAndStopParams": true,
@@ -78859,7 +79080,7 @@
 				"requiresMistralToolIds": false,
 				"thinkingFormat": "openai",
 				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
+				"omitReasoningEffort": true,
 				"includeEncryptedReasoning": true,
 				"filterReasoningHistory": false,
 				"reasoningContentField": "reasoning_content",
@@ -78892,7 +79113,10 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsReasoningEffort": false
+			}
 		},
 		"kimi-k2.7-code": {
 			"id": "kimi-k2.7-code",
@@ -79032,11 +79256,13 @@
 				"class": "kimi",
 				"family": "k2.7-code"
 			},
+			"int": 43,
+			"tps": 39,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
 				"supportsMultipleSystemMessages": true,
-				"supportsReasoningEffort": true,
+				"supportsReasoningEffort": false,
 				"supportsReasoningParams": true,
 				"supportsSamplingParams": true,
 				"supportsPenaltyAndStopParams": true,
@@ -79055,7 +79281,7 @@
 				"requiresMistralToolIds": false,
 				"thinkingFormat": "openai",
 				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
+				"omitReasoningEffort": true,
 				"includeEncryptedReasoning": true,
 				"filterReasoningHistory": false,
 				"reasoningContentField": "reasoning_content",
@@ -79087,7 +79313,10 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsReasoningEffort": false
+			}
 		},
 		"kimi-k3": {
 			"id": "kimi-k3",
@@ -80368,7 +80597,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -80394,7 +80622,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-haiku-4.5": {
 			"id": "claude-haiku-4.5",
@@ -80441,7 +80670,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -80467,7 +80695,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4.5": {
 			"id": "claude-opus-4.5",
@@ -80515,7 +80744,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -80541,7 +80769,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4.6": {
 			"id": "claude-opus-4.6",
@@ -80589,7 +80818,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -80615,7 +80843,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4.7": {
 			"id": "claude-opus-4.7",
@@ -80664,7 +80893,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -80690,7 +80918,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4.8": {
 			"id": "claude-opus-4.8",
@@ -80739,7 +80968,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -80765,7 +80993,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-5": {
 			"id": "claude-opus-5",
@@ -80814,7 +81043,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -80840,7 +81068,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4": {
 			"id": "claude-sonnet-4",
@@ -80886,7 +81115,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -80912,7 +81140,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4.5": {
 			"id": "claude-sonnet-4.5",
@@ -80958,7 +81187,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -80984,7 +81212,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4.6": {
 			"id": "claude-sonnet-4.6",
@@ -81030,7 +81259,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -81056,7 +81284,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-5": {
 			"id": "claude-sonnet-5",
@@ -81105,7 +81334,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -81131,7 +81359,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-pro": {
 			"id": "gemini-2.5-pro",
@@ -81462,6 +81691,20 @@
 				"Openai-Intent": "conversation-agent",
 				"X-GitHub-Api-Version": "2026-08-01"
 			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "gemini",
+				"family": "pro",
+				"revision": "3.1.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -81517,20 +81760,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "gemini",
-				"family": "pro",
-				"revision": "3.1.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -81567,6 +81796,22 @@
 				"Openai-Intent": "conversation-agent",
 				"X-GitHub-Api-Version": "2026-08-01"
 			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "gemini",
+				"family": "flash",
+				"revision": "3.5.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -81622,22 +81867,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "gemini",
-				"family": "flash",
-				"revision": "3.5.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -81674,6 +81903,22 @@
 				"Openai-Intent": "conversation-agent",
 				"X-GitHub-Api-Version": "2026-08-01"
 			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "gemini",
+				"family": "flash",
+				"revision": "3.6.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -81729,22 +81974,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "gemini",
-				"family": "flash",
-				"revision": "3.6.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -81781,6 +82010,22 @@
 				"Openai-Intent": "conversation-agent",
 				"X-GitHub-Api-Version": "2026-08-01"
 			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "gemini",
+				"family": "flash",
+				"revision": "3.7.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -81836,22 +82081,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "gemini",
-				"family": "flash",
-				"revision": "3.7.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -81888,6 +82117,12 @@
 				"Openai-Intent": "conversation-agent",
 				"X-GitHub-Api-Version": "2026-08-01"
 			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "4.1.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -81942,12 +82177,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "4.1.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -82133,6 +82362,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82190,7 +82420,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -82234,6 +82463,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82244,7 +82474,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.1": {
 			"id": "gpt-5.1",
@@ -82333,6 +82564,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82432,6 +82664,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82532,6 +82765,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82629,6 +82863,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82686,7 +82921,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -82730,6 +82964,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82740,7 +82975,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.2-codex": {
 			"id": "gpt-5.2-codex",
@@ -82785,7 +83021,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -82829,6 +83064,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82839,7 +83075,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.3-codex": {
 			"id": "gpt-5.3-codex",
@@ -82885,7 +83122,6 @@
 				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -82929,6 +83165,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82939,7 +83176,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.4": {
 			"id": "gpt-5.4",
@@ -82985,7 +83223,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -83029,6 +83266,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -83039,7 +83277,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.4-mini": {
 			"id": "gpt-5.4-mini",
@@ -83086,7 +83325,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -83130,6 +83368,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -83140,7 +83379,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.4-nano": {
 			"id": "gpt-5.4-nano",
@@ -83186,7 +83426,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -83230,6 +83469,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -83240,7 +83480,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.5": {
 			"id": "gpt-5.5",
@@ -83287,7 +83528,6 @@
 				"revision": "5.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -83331,6 +83571,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -83341,7 +83582,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.6-luna": {
 			"id": "gpt-5.6-luna",
@@ -83388,7 +83630,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -83432,6 +83673,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -83442,7 +83684,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.6-sol": {
 			"id": "gpt-5.6-sol",
@@ -83489,7 +83732,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -83533,6 +83775,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -83543,7 +83786,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.6-terra": {
 			"id": "gpt-5.6-terra",
@@ -83590,7 +83834,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -83634,6 +83877,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -83644,7 +83888,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"grok-4.5": {
 			"id": "grok-4.5",
@@ -83691,7 +83936,6 @@
 				"revision": "4.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -83736,6 +83980,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -83746,7 +83991,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"grok-4.6": {
 			"id": "grok-4.6",
@@ -83793,7 +84039,6 @@
 				"revision": "4.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -83838,6 +84083,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -83848,7 +84094,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"grok-code-fast-1": {
 			"id": "grok-code-fast-1",
@@ -83979,6 +84226,21 @@
 				"Openai-Intent": "conversation-agent",
 				"X-GitHub-Api-Version": "2026-08-01"
 			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "kimi",
+				"family": "k2.7-code"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -84034,21 +84296,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "kimi",
-				"family": "k2.7-code"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "kimi-k2",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -84085,6 +84332,25 @@
 				"Openai-Intent": "conversation-agent",
 				"X-GitHub-Api-Version": "2026-08-01"
 			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"effortMap": {
+					"max": "max"
+				},
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "kimi",
+				"family": "k3"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -84145,25 +84411,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high",
-					"max"
-				],
-				"defaultLevel": "max",
-				"effortMap": {
-					"max": "max"
-				},
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "kimi",
-				"family": "k3"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "kimi-k2",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -84211,7 +84458,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -84255,6 +84501,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -84265,7 +84512,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mai-code-1.1-flash": {
 			"id": "mai-code-1.1-flash",
@@ -84308,7 +84556,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -84352,6 +84599,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -84362,7 +84610,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"raptor-mini": {
 			"id": "raptor-mini",
@@ -84914,6 +85163,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -85004,6 +85254,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -85500,6 +85751,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -85590,6 +85842,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -85680,6 +85933,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -85750,8 +86004,6 @@
 					"max"
 				]
 			},
-			"int": 51.8,
-			"tps": 140,
 			"identity": {
 				"class": "deepseek",
 				"family": "flash"
@@ -85849,7 +86101,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -85861,7 +86112,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deep-research-preview-04-2026": {
 			"id": "deep-research-preview-04-2026",
@@ -85895,7 +86147,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -85907,7 +86158,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-1.5-flash": {
 			"id": "gemini-1.5-flash",
@@ -86142,7 +86394,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -86155,7 +86406,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-flash": {
 			"id": "gemini-2.5-flash",
@@ -86201,7 +86453,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -86214,7 +86465,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-flash-lite": {
 			"id": "gemini-2.5-flash-lite",
@@ -86260,7 +86512,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -86273,7 +86524,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-flash-lite-preview-06-17": {
 			"id": "gemini-2.5-flash-lite-preview-06-17",
@@ -86607,7 +86859,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -86620,7 +86871,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-pro-preview-05-06": {
 			"id": "gemini-2.5-pro-preview-05-06",
@@ -86773,7 +87025,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -86786,7 +87037,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3-pro-preview": {
 			"id": "gemini-3-pro-preview",
@@ -86871,7 +87123,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -86884,7 +87135,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.1-flash-lite-image": {
 			"id": "gemini-3.1-flash-lite-image",
@@ -86921,7 +87173,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -86934,7 +87185,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.1-flash-lite-preview": {
 			"id": "gemini-3.1-flash-lite-preview",
@@ -86973,7 +87225,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -86986,7 +87237,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.1-flash-live-preview": {
 			"id": "gemini-3.1-flash-live-preview",
@@ -87023,7 +87275,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -87036,7 +87287,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.1-pro-preview": {
 			"id": "gemini-3.1-pro-preview",
@@ -87073,7 +87325,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -87086,7 +87337,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.1-pro-preview-customtools": {
 			"id": "gemini-3.1-pro-preview-customtools",
@@ -87121,7 +87373,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -87134,7 +87385,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.5-flash": {
 			"id": "gemini-3.5-flash",
@@ -87173,7 +87425,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -87186,7 +87437,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.5-flash-lite": {
 			"id": "gemini-3.5-flash-lite",
@@ -87225,7 +87477,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -87238,7 +87489,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.6-flash": {
 			"id": "gemini-3.6-flash",
@@ -87277,7 +87529,6 @@
 				"revision": "3.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -87290,7 +87541,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.7-flash": {
 			"id": "gemini-3.7-flash",
@@ -87328,7 +87580,6 @@
 				"revision": "3.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -87341,7 +87592,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.8-flash": {
 			"id": "gemini-3.8-flash",
@@ -87380,7 +87632,6 @@
 				"revision": "3.8.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -87393,7 +87644,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-flash-latest": {
 			"id": "gemini-flash-latest",
@@ -87428,7 +87680,6 @@
 				"family": "flash"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -87441,7 +87692,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-flash-lite-latest": {
 			"id": "gemini-flash-lite-latest",
@@ -87476,7 +87728,6 @@
 				"family": "lite"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -87489,7 +87740,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-live-2.5-flash": {
 			"id": "gemini-live-2.5-flash",
@@ -87767,7 +88019,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -87779,7 +88030,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-26b-it": {
 			"id": "gemma-4-26b-it",
@@ -87907,7 +88159,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -87919,7 +88170,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-E2B-it": {
 			"id": "gemma-4-E2B-it",
@@ -88113,7 +88365,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": false,
@@ -88126,7 +88377,8 @@
 				"antigravityClaudeToolMode": true,
 				"stripImageInput": false,
 				"antigravityUsageLabel": "true"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-5": {
 			"id": "claude-sonnet-4-5",
@@ -88223,7 +88475,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": false,
@@ -88236,7 +88487,8 @@
 				"antigravityClaudeToolMode": true,
 				"stripImageInput": false,
 				"antigravityUsageLabel": "true"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-flash": {
 			"id": "gemini-2.5-flash",
@@ -88281,7 +88533,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -88295,7 +88546,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-flash-lite": {
 			"id": "gemini-2.5-flash-lite",
@@ -88333,7 +88585,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -88346,7 +88597,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-pro": {
 			"id": "gemini-2.5-pro",
@@ -88452,7 +88704,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -88466,7 +88717,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3-pro": {
 			"id": "gemini-3-pro",
@@ -88547,7 +88799,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -88561,7 +88812,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.1-flash-lite": {
 			"id": "gemini-3.1-flash-lite",
@@ -88598,7 +88850,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -88611,7 +88862,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.1-pro": {
 			"id": "gemini-3.1-pro",
@@ -88657,7 +88909,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -88670,7 +88921,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.5-flash": {
 			"id": "gemini-3.5-flash",
@@ -88724,7 +88976,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -88738,7 +88989,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.6-flash": {
 			"id": "gemini-3.6-flash",
@@ -88784,7 +89036,6 @@
 				"revision": "3.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -88798,7 +89049,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.7-flash": {
 			"id": "gemini-3.7-flash",
@@ -88844,7 +89096,6 @@
 				"revision": "3.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -88858,7 +89109,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.8-flash": {
 			"id": "gemini-3.8-flash",
@@ -88904,7 +89156,6 @@
 				"revision": "3.8.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -88918,7 +89169,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-oss-120b": {
 			"id": "gpt-oss-120b",
@@ -88955,7 +89207,6 @@
 				"family": "120b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -88967,7 +89218,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"tab_flash_lite_preview": {
 			"id": "tab_flash_lite_preview",
@@ -88991,7 +89243,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -89003,7 +89254,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"tab_jump_flash_lite_preview": {
 			"id": "tab_jump_flash_lite_preview",
@@ -89027,7 +89279,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -89039,7 +89290,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"google-gemini-cli": {
@@ -89436,7 +89688,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -89462,7 +89713,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-fable-5@default": {
 			"id": "claude-fable-5@default",
@@ -89501,7 +89753,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -89527,7 +89778,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-haiku-4-5@20251001": {
 			"id": "claude-haiku-4-5@20251001",
@@ -89565,7 +89817,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -89591,7 +89842,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-5@20251101": {
 			"id": "claude-opus-4-5@20251101",
@@ -89629,7 +89881,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -89655,7 +89906,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-6@default": {
 			"id": "claude-opus-4-6@default",
@@ -89692,7 +89944,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -89718,7 +89969,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-7@default": {
 			"id": "claude-opus-4-7@default",
@@ -89757,7 +90009,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -89783,7 +90034,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-8@default": {
 			"id": "claude-opus-4-8@default",
@@ -89822,7 +90074,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -89848,7 +90099,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-5@default": {
 			"id": "claude-opus-5@default",
@@ -89887,7 +90139,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -89913,7 +90164,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-5@20250929": {
 			"id": "claude-sonnet-4-5@20250929",
@@ -89951,7 +90203,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -89977,7 +90228,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-6@default": {
 			"id": "claude-sonnet-4-6@default",
@@ -90013,7 +90265,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -90039,7 +90290,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-5@default": {
 			"id": "claude-sonnet-5@default",
@@ -90078,7 +90330,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -90104,7 +90355,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-flash": {
 			"id": "gemini-2.5-flash",
@@ -90150,7 +90402,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -90163,7 +90414,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-flash-lite": {
 			"id": "gemini-2.5-flash-lite",
@@ -90209,7 +90461,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -90222,7 +90473,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-pro": {
 			"id": "gemini-2.5-pro",
@@ -90269,7 +90521,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -90282,7 +90533,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3-flash-preview": {
 			"id": "gemini-3-flash-preview",
@@ -90319,7 +90571,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -90332,7 +90583,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.1-flash-lite": {
 			"id": "gemini-3.1-flash-lite",
@@ -90369,7 +90621,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -90382,7 +90633,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.1-pro-preview": {
 			"id": "gemini-3.1-pro-preview",
@@ -90419,7 +90671,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -90432,7 +90683,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.1-pro-preview-customtools": {
 			"id": "gemini-3.1-pro-preview-customtools",
@@ -90467,7 +90719,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -90480,7 +90731,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.5-flash": {
 			"id": "gemini-3.5-flash",
@@ -90519,7 +90771,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -90532,7 +90783,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.5-flash-lite": {
 			"id": "gemini-3.5-flash-lite",
@@ -90571,7 +90823,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -90584,7 +90835,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.6-flash": {
 			"id": "gemini-3.6-flash",
@@ -90623,7 +90875,6 @@
 				"revision": "3.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -90636,7 +90887,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.7-flash": {
 			"id": "gemini-3.7-flash",
@@ -90674,7 +90926,6 @@
 				"revision": "3.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -90687,7 +90938,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.8-flash": {
 			"id": "gemini-3.8-flash",
@@ -90726,7 +90978,6 @@
 				"revision": "3.8.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -90739,7 +90990,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-flash-latest": {
 			"id": "gemini-flash-latest",
@@ -90774,7 +91026,6 @@
 				"family": "flash"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -90787,7 +91038,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-flash-lite-latest": {
 			"id": "gemini-flash-lite-latest",
@@ -90822,7 +91074,6 @@
 				"family": "lite"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -90835,7 +91086,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta/llama-4-maverick-17b-128e-instruct-maas": {
 			"id": "meta/llama-4-maverick-17b-128e-instruct-maas",
@@ -90861,7 +91113,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -90915,7 +91166,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-oss-120b-maas": {
 			"id": "openai/gpt-oss-120b-maas",
@@ -90948,7 +91200,6 @@
 				"family": "120b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -91002,7 +91253,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"groq": {
@@ -91371,7 +91623,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -91425,7 +91676,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"llama-3.3-70b-versatile": {
 			"id": "llama-3.3-70b-versatile",
@@ -91450,7 +91702,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -91504,7 +91755,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"llama3-70b-8192": {
 			"id": "llama3-70b-8192",
@@ -92098,7 +92350,6 @@
 				"family": "120b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -92152,7 +92403,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-oss-20b": {
 			"id": "openai/gpt-oss-20b",
@@ -92187,7 +92439,6 @@
 				"family": "20b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -92241,7 +92492,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-oss-safeguard-20b": {
 			"id": "openai/gpt-oss-safeguard-20b",
@@ -92273,7 +92525,6 @@
 				"class": "gpt-oss"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -92327,7 +92578,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen-qwq-32b": {
 			"id": "qwen-qwq-32b",
@@ -92532,7 +92784,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -92586,7 +92837,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.8-27b": {
 			"id": "qwen/qwen3.8-27b",
@@ -92624,7 +92876,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -92678,7 +92929,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"huggingface": {
@@ -92714,7 +92966,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -92769,7 +93020,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-R1-0528": {
 			"id": "deepseek-ai/DeepSeek-R1-0528",
@@ -92802,7 +93054,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -92857,7 +93108,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V3": {
 			"id": "deepseek-ai/DeepSeek-V3",
@@ -92884,7 +93136,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -92939,7 +93190,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V3-0324": {
 			"id": "deepseek-ai/DeepSeek-V3-0324",
@@ -92966,7 +93218,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -93021,7 +93272,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V3.1": {
 			"id": "deepseek-ai/DeepSeek-V3.1",
@@ -93055,7 +93307,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -93110,7 +93361,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V3.2": {
 			"id": "deepseek-ai/DeepSeek-V3.2",
@@ -93144,7 +93396,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -93199,7 +93450,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V4-Flash": {
 			"id": "deepseek-ai/DeepSeek-V4-Flash",
@@ -93235,7 +93487,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -93290,7 +93541,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V4-Flash-0731": {
 			"id": "deepseek-ai/DeepSeek-V4-Flash-0731",
@@ -93324,7 +93576,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -93379,7 +93630,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V4-Flash-Vision-Exp": {
 			"id": "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp",
@@ -93414,7 +93666,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -93469,7 +93720,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V4-Pro": {
 			"id": "deepseek-ai/DeepSeek-V4-Pro",
@@ -93505,7 +93757,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -93560,7 +93811,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V4-Pro-0813": {
 			"id": "deepseek-ai/DeepSeek-V4-Pro-0813",
@@ -93594,7 +93846,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -93649,7 +93900,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemma-4-26B-A4B-it": {
 			"id": "google/gemma-4-26B-A4B-it",
@@ -93684,7 +93936,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -93738,7 +93989,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemma-4-31B-it": {
 			"id": "google/gemma-4-31B-it",
@@ -93773,7 +94025,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -93827,7 +94078,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta-llama/Llama-3.1-8B-Instruct": {
 			"id": "meta-llama/Llama-3.1-8B-Instruct",
@@ -93852,7 +94104,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -93906,7 +94157,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta-llama/Llama-3.3-70B-Instruct": {
 			"id": "meta-llama/Llama-3.3-70B-Instruct",
@@ -93931,7 +94183,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -93985,7 +94236,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta-llama/Llama-3.3-70B-Instruct-Turbo": {
 			"id": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
@@ -94100,7 +94352,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -94154,7 +94405,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMaxAI/MiniMax-M2.1": {
 			"id": "MiniMaxAI/MiniMax-M2.1",
@@ -94190,7 +94442,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -94244,7 +94495,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMaxAI/MiniMax-M2.5": {
 			"id": "MiniMaxAI/MiniMax-M2.5",
@@ -94280,7 +94532,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -94334,7 +94585,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMaxAI/MiniMax-M2.7": {
 			"id": "MiniMaxAI/MiniMax-M2.7",
@@ -94370,7 +94622,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -94424,7 +94675,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMaxAI/MiniMax-M3": {
 			"id": "MiniMaxAI/MiniMax-M3",
@@ -94462,7 +94714,6 @@
 				"family": "m3"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -94516,7 +94767,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/Kimi-K2-Instruct": {
 			"id": "moonshotai/Kimi-K2-Instruct",
@@ -94542,7 +94794,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -94597,7 +94848,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/Kimi-K2-Instruct-0905": {
 			"id": "moonshotai/Kimi-K2-Instruct-0905",
@@ -94623,7 +94875,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -94678,7 +94929,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/Kimi-K2-Thinking": {
 			"id": "moonshotai/Kimi-K2-Thinking",
@@ -94719,7 +94971,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -94774,7 +95025,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/Kimi-K2.5": {
 			"id": "moonshotai/Kimi-K2.5",
@@ -94812,7 +95064,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -94867,7 +95118,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/Kimi-K2.6": {
 			"id": "moonshotai/Kimi-K2.6",
@@ -94906,7 +95158,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -94962,7 +95213,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/Kimi-K2.7-Code": {
 			"id": "moonshotai/Kimi-K2.7-Code",
@@ -95001,7 +95253,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -95056,7 +95307,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/Kimi-K3": {
 			"id": "moonshotai/Kimi-K3",
@@ -95098,7 +95350,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -95158,7 +95409,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-oss-120b": {
 			"id": "openai/gpt-oss-120b",
@@ -95193,7 +95445,6 @@
 				"family": "120b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -95247,7 +95498,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-oss-20b": {
 			"id": "openai/gpt-oss-20b",
@@ -95282,7 +95534,6 @@
 				"family": "20b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -95336,7 +95587,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen2.5-Coder-32B-Instruct": {
 			"id": "Qwen/Qwen2.5-Coder-32B-Instruct",
@@ -95362,7 +95614,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -95416,7 +95667,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-235B-A22B": {
 			"id": "Qwen/Qwen3-235B-A22B",
@@ -95450,7 +95702,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -95504,7 +95755,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-235B-A22B-Instruct-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
@@ -95531,7 +95783,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -95585,7 +95836,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-235B-A22B-Thinking-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Thinking-2507",
@@ -95620,7 +95872,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -95674,7 +95925,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-30B-A3B": {
 			"id": "Qwen/Qwen3-30B-A3B",
@@ -95708,7 +95960,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -95762,7 +96013,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-32B": {
 			"id": "Qwen/Qwen3-32B",
@@ -95796,7 +96048,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -95850,7 +96101,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-Coder-30B-A3B-Instruct": {
 			"id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -95878,7 +96130,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -95932,7 +96183,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-Coder-480B-A35B-Instruct": {
 			"id": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
@@ -95960,7 +96212,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -96014,7 +96265,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-Coder-Next": {
 			"id": "Qwen/Qwen3-Coder-Next",
@@ -96042,7 +96294,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -96096,7 +96347,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-Next-80B-A3B-Instruct": {
 			"id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -96124,7 +96376,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -96178,7 +96429,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-Next-80B-A3B-Thinking": {
 			"id": "Qwen/Qwen3-Next-80B-A3B-Thinking",
@@ -96206,7 +96458,6 @@
 				"logicalId": "Qwen/Qwen3-Next-80B-A3B"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -96260,7 +96511,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-VL-235B-A22B-Instruct": {
 			"id": "Qwen/Qwen3-VL-235B-A22B-Instruct",
@@ -96289,7 +96541,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -96343,7 +96594,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-VL-235B-A22B-Thinking": {
 			"id": "Qwen/Qwen3-VL-235B-A22B-Thinking",
@@ -96382,7 +96634,6 @@
 				"logicalId": "Qwen/Qwen3-VL-235B-A22B"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -96436,7 +96687,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3.5-122B-A10B": {
 			"id": "Qwen/Qwen3.5-122B-A10B",
@@ -96474,7 +96726,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -96528,7 +96779,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3.5-27B": {
 			"id": "Qwen/Qwen3.5-27B",
@@ -96566,7 +96818,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -96620,7 +96871,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3.5-35B-A3B": {
 			"id": "Qwen/Qwen3.5-35B-A3B",
@@ -96658,7 +96910,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -96712,7 +96963,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3.5-397B-A17B": {
 			"id": "Qwen/Qwen3.5-397B-A17B",
@@ -96750,7 +97002,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -96804,7 +97055,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3.5-9B": {
 			"id": "Qwen/Qwen3.5-9B",
@@ -96842,7 +97094,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -96896,7 +97147,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3.6-27B": {
 			"id": "Qwen/Qwen3.6-27B",
@@ -96934,7 +97186,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -96988,7 +97239,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3.6-35B-A3B": {
 			"id": "Qwen/Qwen3.6-35B-A3B",
@@ -97026,7 +97278,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -97080,7 +97331,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3.8-2.4T-A95B": {
 			"id": "Qwen/Qwen3.8-2.4T-A95B",
@@ -97117,7 +97369,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -97171,7 +97422,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3.8-27B": {
 			"id": "Qwen/Qwen3.8-27B",
@@ -97209,7 +97461,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -97263,7 +97514,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"stepfun-ai/Step-3.5-Flash": {
 			"id": "stepfun-ai/Step-3.5-Flash",
@@ -97300,7 +97552,6 @@
 				"family": "step"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -97354,7 +97605,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"stepfun-ai/Step-3.7-Flash": {
 			"id": "stepfun-ai/Step-3.7-Flash",
@@ -97392,7 +97644,6 @@
 				"family": "step"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -97446,7 +97697,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"tencent/Hy3": {
 			"id": "tencent/Hy3",
@@ -97482,7 +97734,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -97536,7 +97787,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"thinkingmachines/Inkling": {
 			"id": "thinkingmachines/Inkling",
@@ -97573,7 +97825,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -97627,7 +97878,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"thinkingmachines/Inkling-Small": {
 			"id": "thinkingmachines/Inkling-Small",
@@ -97664,7 +97916,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -97718,7 +97969,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"XiaomiMiMo/MiMo-V2-Flash": {
 			"id": "XiaomiMiMo/MiMo-V2-Flash",
@@ -97752,7 +98004,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -97809,7 +98060,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"XiaomiMiMo/MiMo-V2.5": {
 			"id": "XiaomiMiMo/MiMo-V2.5",
@@ -97842,7 +98094,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -97899,7 +98150,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"XiaomiMiMo/MiMo-V2.5-Pro": {
 			"id": "XiaomiMiMo/MiMo-V2.5-Pro",
@@ -97934,7 +98186,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -97991,7 +98242,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-4.5": {
 			"id": "zai-org/GLM-4.5",
@@ -98027,7 +98279,6 @@
 				"revision": "4.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -98081,7 +98332,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-4.5-Air": {
 			"id": "zai-org/GLM-4.5-Air",
@@ -98119,7 +98371,6 @@
 				"revision": "4.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -98173,7 +98424,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-4.5V": {
 			"id": "zai-org/GLM-4.5V",
@@ -98211,7 +98463,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -98265,7 +98516,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-4.6": {
 			"id": "zai-org/GLM-4.6",
@@ -98302,7 +98554,6 @@
 				"revision": "4.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -98356,7 +98607,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-4.6V-Flash": {
 			"id": "zai-org/GLM-4.6V-Flash",
@@ -98393,7 +98645,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -98447,7 +98698,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-4.7": {
 			"id": "zai-org/GLM-4.7",
@@ -98484,7 +98736,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -98538,7 +98789,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-4.7-Flash": {
 			"id": "zai-org/GLM-4.7-Flash",
@@ -98576,7 +98828,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -98630,7 +98881,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-5": {
 			"id": "zai-org/GLM-5",
@@ -98668,7 +98920,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -98722,7 +98973,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-5.1": {
 			"id": "zai-org/GLM-5.1",
@@ -98760,7 +99012,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -98814,7 +99065,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-5.2": {
 			"id": "zai-org/GLM-5.2",
@@ -98852,7 +99104,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -98906,7 +99157,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-5.3": {
 			"id": "zai-org/GLM-5.3",
@@ -98944,7 +99196,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -98998,7 +99249,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-5.3-Flash": {
 			"id": "zai-org/GLM-5.3-Flash",
@@ -99038,7 +99290,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -99092,7 +99343,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"kilo": {
@@ -99131,7 +99383,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -99185,7 +99436,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"~anthropic/claude-haiku-latest": {
 			"id": "~anthropic/claude-haiku-latest",
@@ -99222,7 +99474,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -99276,7 +99527,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"~anthropic/claude-opus-latest": {
 			"id": "~anthropic/claude-opus-latest",
@@ -99313,7 +99565,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -99367,7 +99618,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"~anthropic/claude-sonnet-latest": {
 			"id": "~anthropic/claude-sonnet-latest",
@@ -99404,7 +99656,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -99458,7 +99709,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"~deepseek/deepseek-v4-flash-latest": {
 			"id": "~deepseek/deepseek-v4-flash-latest",
@@ -99492,7 +99744,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -99547,7 +99798,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"~google/gemini-flash-latest": {
 			"id": "~google/gemini-flash-latest",
@@ -99583,7 +99835,6 @@
 				"family": "flash"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -99638,7 +99889,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"~google/gemini-pro-latest": {
 			"id": "~google/gemini-pro-latest",
@@ -99674,7 +99926,6 @@
 				"family": "pro"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -99729,7 +99980,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"~moonshotai/kimi-latest": {
 			"id": "~moonshotai/kimi-latest",
@@ -99765,7 +100017,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -99820,7 +100071,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"~openai/gpt-latest": {
 			"id": "~openai/gpt-latest",
@@ -99856,7 +100108,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -99910,7 +100161,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"~openai/gpt-mini-latest": {
 			"id": "~openai/gpt-mini-latest",
@@ -99946,7 +100198,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -100000,7 +100251,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"~x-ai/grok-latest": {
 			"id": "~x-ai/grok-latest",
@@ -100036,7 +100288,6 @@
 				"family": "grok"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -100091,7 +100342,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"~z-ai/glm-flash-latest": {
 			"id": "~z-ai/glm-flash-latest",
@@ -100127,7 +100379,6 @@
 				"family": "flash"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -100181,7 +100432,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"~z-ai/glm-latest": {
 			"id": "~z-ai/glm-latest",
@@ -100215,7 +100467,6 @@
 				"class": "glm"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -100269,7 +100520,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"ai21/jamba-large-1.7": {
 			"id": "ai21/jamba-large-1.7",
@@ -100541,7 +100793,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -100595,7 +100846,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"aion-labs/aion-3.0": {
 			"id": "aion-labs/aion-3.0",
@@ -100629,7 +100881,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -100683,7 +100934,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"aion-labs/aion-3.0-mini": {
 			"id": "aion-labs/aion-3.0-mini",
@@ -100717,7 +100969,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -100771,7 +101022,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"aion-labs/aion-rp-llama-3.1-8b": {
 			"id": "aion-labs/aion-rp-llama-3.1-8b",
@@ -101674,7 +101926,6 @@
 				"family": "nova"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -101728,7 +101979,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"amazon/nova-lite-v1": {
 			"id": "amazon/nova-lite-v1",
@@ -101754,7 +102006,6 @@
 				"family": "nova"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -101808,7 +102059,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"amazon/nova-micro-v1": {
 			"id": "amazon/nova-micro-v1",
@@ -101833,7 +102085,6 @@
 				"family": "nova"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -101887,7 +102138,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"amazon/nova-premier-v1": {
 			"id": "amazon/nova-premier-v1",
@@ -101913,7 +102165,6 @@
 				"family": "nova"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -101967,7 +102218,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"amazon/nova-pro-v1": {
 			"id": "amazon/nova-pro-v1",
@@ -101993,7 +102245,6 @@
 				"family": "nova"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -102047,7 +102298,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthracite-org/magnum-v4-72b": {
 			"id": "anthracite-org/magnum-v4-72b",
@@ -102154,7 +102406,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -102208,7 +102459,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-3.5-haiku": {
 			"id": "anthropic/claude-3.5-haiku",
@@ -102589,7 +102841,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -102643,7 +102894,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-fable-5.1": {
 			"id": "anthropic/claude-fable-5.1",
@@ -102684,7 +102936,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -102738,7 +102989,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-haiku-4.5": {
 			"id": "anthropic/claude-haiku-4.5",
@@ -102776,7 +103028,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -102830,7 +103081,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4": {
 			"id": "anthropic/claude-opus-4",
@@ -102868,7 +103120,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -102922,7 +103173,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.1": {
 			"id": "anthropic/claude-opus-4.1",
@@ -102960,7 +103212,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -103014,7 +103265,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.5": {
 			"id": "anthropic/claude-opus-4.5",
@@ -103054,7 +103306,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -103108,7 +103359,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.6": {
 			"id": "anthropic/claude-opus-4.6",
@@ -103148,7 +103400,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -103202,7 +103453,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.6-fast": {
 			"id": "anthropic/claude-opus-4.6-fast",
@@ -103335,7 +103587,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -103389,7 +103640,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.7-fast": {
 			"id": "anthropic/claude-opus-4.7-fast",
@@ -103521,7 +103773,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -103575,7 +103826,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.8-fast": {
 			"id": "anthropic/claude-opus-4.8-fast",
@@ -103707,7 +103959,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -103761,7 +104012,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-5-fast": {
 			"id": "anthropic/claude-opus-5-fast",
@@ -103891,7 +104143,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -103945,7 +104196,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-sonnet-4.5": {
 			"id": "anthropic/claude-sonnet-4.5",
@@ -103983,7 +104235,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -104037,7 +104288,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-sonnet-4.6": {
 			"id": "anthropic/claude-sonnet-4.6",
@@ -104077,7 +104329,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -104131,7 +104382,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-sonnet-5": {
 			"id": "anthropic/claude-sonnet-5",
@@ -104171,7 +104423,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -104225,7 +104476,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"arcee-ai/coder-large": {
 			"id": "arcee-ai/coder-large",
@@ -104659,7 +104911,6 @@
 				"logicalId": "arcee-ai/trinity-large"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -104713,7 +104964,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"arcee-ai/trinity-large-thinking:free": {
 			"id": "arcee-ai/trinity-large-thinking:free",
@@ -105650,7 +105902,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -105704,7 +105955,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"bytedance-seed/seed-1.6-flash": {
 			"id": "bytedance-seed/seed-1.6-flash",
@@ -105739,7 +105991,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -105793,7 +106044,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"bytedance-seed/seed-2-1-turbo": {
 			"id": "bytedance-seed/seed-2-1-turbo",
@@ -105828,7 +106080,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -105882,7 +106133,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"bytedance-seed/seed-2.0-code": {
 			"id": "bytedance-seed/seed-2.0-code",
@@ -105917,7 +106169,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -105971,7 +106222,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"bytedance-seed/seed-2.0-lite": {
 			"id": "bytedance-seed/seed-2.0-lite",
@@ -106006,7 +106258,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -106060,7 +106311,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"bytedance-seed/seed-2.0-mini": {
 			"id": "bytedance-seed/seed-2.0-mini",
@@ -106095,7 +106347,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -106149,7 +106400,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"bytedance/ui-tars-1.5-7b": {
 			"id": "bytedance/ui-tars-1.5-7b",
@@ -106409,7 +106661,6 @@
 				"family": "command"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -106463,7 +106714,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"cohere/command-r-plus-08-2024": {
 			"id": "cohere/command-r-plus-08-2024",
@@ -106488,7 +106740,6 @@
 				"family": "command"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -106542,7 +106793,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"cohere/command-r7b-12-2024": {
 			"id": "cohere/command-r7b-12-2024",
@@ -106655,7 +106907,6 @@
 				"class": "cohere"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -106709,7 +106960,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"corethink:free": {
 			"id": "corethink:free",
@@ -106891,7 +107143,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -106946,7 +107197,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-chat-v3-0324": {
 			"id": "deepseek/deepseek-chat-v3-0324",
@@ -106971,7 +107223,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -107026,7 +107277,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-chat-v3.1": {
 			"id": "deepseek/deepseek-chat-v3.1",
@@ -107058,7 +107310,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -107113,7 +107364,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-r1": {
 			"id": "deepseek/deepseek-r1",
@@ -107147,7 +107399,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -107202,7 +107453,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-r1-0528": {
 			"id": "deepseek/deepseek-r1-0528",
@@ -107235,7 +107487,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -107290,7 +107541,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-r1-distill-llama-70b": {
 			"id": "deepseek/deepseek-r1-distill-llama-70b",
@@ -107484,7 +107736,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -107539,7 +107790,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v3.1-terminus:exacto": {
 			"id": "deepseek/deepseek-v3.1-terminus:exacto",
@@ -107655,7 +107907,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -107710,7 +107961,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v3.2-exp": {
 			"id": "deepseek/deepseek-v3.2-exp",
@@ -107743,7 +107995,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -107798,7 +108049,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v3.2-speciale": {
 			"id": "deepseek/deepseek-v3.2-speciale",
@@ -107916,7 +108168,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -107971,7 +108222,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-flash-0731": {
 			"id": "deepseek/deepseek-v4-flash-0731",
@@ -108005,7 +108257,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -108060,7 +108311,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-flash-vision-exp": {
 			"id": "deepseek/deepseek-v4-flash-vision-exp",
@@ -108095,7 +108347,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -108150,7 +108401,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-flash:discounted": {
 			"id": "deepseek/deepseek-v4-flash:discounted",
@@ -108357,7 +108609,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -108412,7 +108663,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-pro-0813": {
 			"id": "deepseek/deepseek-v4-pro-0813",
@@ -108446,7 +108698,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -108501,7 +108752,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-pro:discounted": {
 			"id": "deepseek/deepseek-v4-pro:discounted",
@@ -108625,7 +108877,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -108679,7 +108930,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"eleutherai/llemma_7b": {
 			"id": "eleutherai/llemma_7b",
@@ -109138,7 +109390,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -109193,7 +109444,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-2.5-flash-image": {
 			"id": "google/gemini-2.5-flash-image",
@@ -109312,7 +109564,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -109367,7 +109618,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-2.5-flash-lite-preview-09-2025": {
 			"id": "google/gemini-2.5-flash-lite-preview-09-2025",
@@ -109498,7 +109750,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -109553,7 +109804,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-2.5-pro-preview": {
 			"id": "google/gemini-2.5-pro-preview",
@@ -109590,7 +109842,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -109645,7 +109896,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-2.5-pro-preview-05-06": {
 			"id": "google/gemini-2.5-pro-preview-05-06",
@@ -109682,7 +109934,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -109737,7 +109988,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3-flash-preview": {
 			"id": "google/gemini-3-flash-preview",
@@ -109774,7 +110026,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -109829,7 +110080,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3-pro-image": {
 			"id": "google/gemini-3-pro-image",
@@ -109864,7 +110116,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -109919,7 +110170,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3-pro-image-preview": {
 			"id": "google/gemini-3-pro-image-preview",
@@ -110299,7 +110551,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -110354,7 +110605,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.1-flash-lite-image": {
 			"id": "google/gemini-3.1-flash-lite-image",
@@ -110474,7 +110726,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -110529,7 +110780,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.1-pro-preview": {
 			"id": "google/gemini-3.1-pro-preview",
@@ -110566,7 +110818,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -110621,7 +110872,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.1-pro-preview-customtools": {
 			"id": "google/gemini-3.1-pro-preview-customtools",
@@ -110656,7 +110908,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -110711,7 +110962,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.5-flash": {
 			"id": "google/gemini-3.5-flash",
@@ -110750,7 +111002,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -110805,7 +111056,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.5-flash-lite": {
 			"id": "google/gemini-3.5-flash-lite",
@@ -110844,7 +111096,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -110899,7 +111150,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.6-flash": {
 			"id": "google/gemini-3.6-flash",
@@ -110938,7 +111190,6 @@
 				"revision": "3.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -110993,7 +111244,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.7-flash": {
 			"id": "google/gemini-3.7-flash",
@@ -111032,7 +111284,6 @@
 				"revision": "3.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -111087,7 +111338,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.8-flash": {
 			"id": "google/gemini-3.8-flash",
@@ -111126,7 +111378,6 @@
 				"revision": "3.8.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -111181,7 +111432,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemma-2-27b-it": {
 			"id": "google/gemma-2-27b-it",
@@ -111363,7 +111615,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -111417,7 +111668,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemma-3-27b-it": {
 			"id": "google/gemma-3-27b-it",
@@ -111442,7 +111694,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -111496,7 +111747,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemma-3-4b-it": {
 			"id": "google/gemma-3-4b-it",
@@ -111689,7 +111941,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -111743,7 +111994,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
@@ -111778,7 +112030,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -111832,7 +112083,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/lyria-3-clip-preview": {
 			"id": "google/lyria-3-clip-preview",
@@ -112170,7 +112422,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -112224,7 +112475,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"ibm-granite/granite-4.2-8b": {
 			"id": "ibm-granite/granite-4.2-8b",
@@ -112260,7 +112512,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -112314,7 +112565,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"inception/mercury": {
 			"id": "inception/mercury",
@@ -112429,7 +112681,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -112483,7 +112734,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"inception/mercury-2.5-preview": {
 			"id": "inception/mercury-2.5-preview",
@@ -112517,7 +112769,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -112571,7 +112822,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"inception/mercury-coder": {
 			"id": "inception/mercury-coder",
@@ -113000,7 +113252,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -113054,7 +113305,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"inclusionai/ling-3.0-flash-fin": {
 			"id": "inclusionai/ling-3.0-flash-fin",
@@ -113088,7 +113340,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -113142,7 +113393,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"inclusionai/ling-3.0-flash-fin:free": {
 			"id": "inclusionai/ling-3.0-flash-fin:free",
@@ -113176,7 +113428,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -113230,7 +113481,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"inclusionai/ling-3.0-flash:free": {
 			"id": "inclusionai/ling-3.0-flash:free",
@@ -113760,7 +114012,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -113814,7 +114065,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kilo-auto/efficient": {
 			"id": "kilo-auto/efficient",
@@ -113849,7 +114101,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -113903,7 +114154,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kilo-auto/free": {
 			"id": "kilo-auto/free",
@@ -113937,7 +114189,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -113991,7 +114242,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kilo-auto/frontier": {
 			"id": "kilo-auto/frontier",
@@ -114026,7 +114278,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -114080,7 +114331,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kilo-auto/small": {
 			"id": "kilo-auto/small",
@@ -114115,7 +114367,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -114169,7 +114420,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kilo/auto": {
 			"id": "kilo/auto",
@@ -114588,7 +114840,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -114642,7 +114893,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kwaipilot/kat-coder-pro-v2.5": {
 			"id": "kwaipilot/kat-coder-pro-v2.5",
@@ -114666,7 +114918,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -114720,7 +114971,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kwaipilot/kat-coder-pro-v2.5:free": {
 			"id": "kwaipilot/kat-coder-pro-v2.5:free",
@@ -114991,7 +115243,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -115045,7 +115296,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"liquid/lfm2-8b-a1b": {
 			"id": "liquid/lfm2-8b-a1b",
@@ -115238,7 +115490,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -115292,7 +115543,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meituan/longcat-2.0-free": {
 			"id": "meituan/longcat-2.0-free",
@@ -115804,7 +116056,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -115858,7 +116109,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta-llama/llama-3.1-8b-instruct": {
 			"id": "meta-llama/llama-3.1-8b-instruct",
@@ -115883,7 +116135,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -115937,7 +116188,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta-llama/llama-3.2-11b-vision-instruct": {
 			"id": "meta-llama/llama-3.2-11b-vision-instruct",
@@ -116200,7 +116452,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -116254,7 +116505,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta-llama/llama-4-maverick": {
 			"id": "meta-llama/llama-4-maverick",
@@ -116282,7 +116534,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -116336,7 +116587,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta-llama/llama-4-scout": {
 			"id": "meta-llama/llama-4-scout",
@@ -116364,7 +116616,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -116418,7 +116669,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta-llama/llama-guard-2-8b": {
 			"id": "meta-llama/llama-guard-2-8b",
@@ -116772,7 +117024,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -116826,7 +117077,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta/muse-spark-1.1": {
 			"id": "meta/muse-spark-1.1",
@@ -116865,7 +117117,6 @@
 				"revision": "1.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -116919,7 +117170,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta/muse-spark-1.2": {
 			"id": "meta/muse-spark-1.2",
@@ -116958,7 +117210,6 @@
 				"revision": "1.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -117012,7 +117263,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta/muse-spark-1.2-contributor": {
 			"id": "meta/muse-spark-1.2-contributor",
@@ -117049,7 +117301,6 @@
 				"revision": "1.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -117103,7 +117354,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta/muse-spark-1.3": {
 			"id": "meta/muse-spark-1.3",
@@ -117141,7 +117393,6 @@
 				"revision": "1.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -117195,7 +117446,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta/muse-spark-1.3-contributor": {
 			"id": "meta/muse-spark-1.3-contributor",
@@ -117232,7 +117484,6 @@
 				"revision": "1.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -117286,7 +117537,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"microsoft/phi-4": {
 			"id": "microsoft/phi-4",
@@ -117634,7 +117886,6 @@
 				"family": "m1"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -117688,7 +117939,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m2": {
 			"id": "minimax/minimax-m2",
@@ -117724,7 +117976,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -117778,7 +118029,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m2-her": {
 			"id": "minimax/minimax-m2-her",
@@ -117893,7 +118145,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -117947,7 +118198,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m2.5": {
 			"id": "minimax/minimax-m2.5",
@@ -117983,7 +118235,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -118037,7 +118288,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m2.5:free": {
 			"id": "minimax/minimax-m2.5:free",
@@ -118153,7 +118405,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -118207,7 +118458,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m2.7:free": {
 			"id": "minimax/minimax-m2.7:free",
@@ -118241,7 +118493,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -118295,7 +118546,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
@@ -118333,7 +118585,6 @@
 				"family": "m3"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -118387,7 +118638,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m3:discounted": {
 			"id": "minimax/minimax-m3:discounted",
@@ -118503,7 +118755,6 @@
 				"family": "m3"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -118557,7 +118808,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/codestral-2508": {
 			"id": "mistralai/codestral-2508",
@@ -118581,7 +118833,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -118635,7 +118886,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/devstral-2512": {
 			"id": "mistralai/devstral-2512",
@@ -118659,7 +118911,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -118713,7 +118964,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/devstral-medium": {
 			"id": "mistralai/devstral-medium",
@@ -118898,7 +119150,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -118952,7 +119203,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/ministral-3b-2512": {
 			"id": "mistralai/ministral-3b-2512",
@@ -118977,7 +119229,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -119031,7 +119282,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/ministral-8b": {
 			"id": "mistralai/ministral-8b",
@@ -119134,7 +119386,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -119188,7 +119439,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-7b-instruct": {
 			"id": "mistralai/mistral-7b-instruct",
@@ -119454,7 +119706,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -119508,7 +119759,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-large-2407": {
 			"id": "mistralai/mistral-large-2407",
@@ -119534,7 +119786,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -119588,7 +119839,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-large-2411": {
 			"id": "mistralai/mistral-large-2411",
@@ -119694,7 +119946,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -119748,7 +119999,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-medium-3": {
 			"id": "mistralai/mistral-medium-3",
@@ -119776,7 +120028,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -119830,7 +120081,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-medium-3-5": {
 			"id": "mistralai/mistral-medium-3-5",
@@ -119868,7 +120120,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -119922,7 +120173,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-medium-3.1": {
 			"id": "mistralai/mistral-medium-3.1",
@@ -119950,7 +120202,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -120004,7 +120255,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-nemo": {
 			"id": "mistralai/mistral-nemo",
@@ -120029,7 +120281,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -120083,7 +120334,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-saba": {
 			"id": "mistralai/mistral-saba",
@@ -120109,7 +120361,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -120163,7 +120414,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-small-24b-instruct-2501": {
 			"id": "mistralai/mistral-small-24b-instruct-2501",
@@ -120278,7 +120530,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -120332,7 +120583,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-small-3.1-24b-instruct": {
 			"id": "mistralai/mistral-small-3.1-24b-instruct",
@@ -120437,7 +120689,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -120491,7 +120742,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-small-creative": {
 			"id": "mistralai/mistral-small-creative",
@@ -120596,7 +120848,6 @@
 				"family": "mixtral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -120650,7 +120901,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mixtral-8x7b-instruct": {
 			"id": "mistralai/mixtral-8x7b-instruct",
@@ -120835,7 +121087,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -120889,7 +121140,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2": {
 			"id": "moonshotai/kimi-k2",
@@ -120917,7 +121169,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -120972,7 +121223,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2-0905": {
 			"id": "moonshotai/kimi-k2-0905",
@@ -121000,7 +121252,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -121055,7 +121306,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2-0905:exacto": {
 			"id": "moonshotai/kimi-k2-0905:exacto",
@@ -121176,7 +121428,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -121231,7 +121482,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2.5": {
 			"id": "moonshotai/kimi-k2.5",
@@ -121269,7 +121521,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -121324,7 +121575,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2.5:free": {
 			"id": "moonshotai/kimi-k2.5:free",
@@ -121445,7 +121697,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -121501,7 +121752,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2.6:free": {
 			"id": "moonshotai/kimi-k2.6:free",
@@ -121622,7 +121874,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -121677,7 +121928,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k3": {
 			"id": "moonshotai/kimi-k3",
@@ -121719,7 +121971,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -121779,7 +122030,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"morph-warp-grep-v2": {
 			"id": "morph-warp-grep-v2",
@@ -122290,7 +122542,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -122344,7 +122595,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nex-agi/nex-n2-pro": {
 			"id": "nex-agi/nex-n2-pro",
@@ -122381,7 +122633,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -122435,7 +122686,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nex-agi/nex-n2-pro:free": {
 			"id": "nex-agi/nex-n2-pro:free",
@@ -123201,7 +123453,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -123255,7 +123506,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": {
 			"id": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
@@ -123291,7 +123543,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -123345,7 +123596,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3-super-120b-a12b": {
 			"id": "nvidia/nemotron-3-super-120b-a12b",
@@ -123379,7 +123631,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -123433,7 +123684,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3-super-120b-a12b:free": {
 			"id": "nvidia/nemotron-3-super-120b-a12b:free",
@@ -123467,7 +123719,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -123521,7 +123772,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3-ultra-550b-a55b": {
 			"id": "nvidia/nemotron-3-ultra-550b-a55b",
@@ -123555,7 +123807,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -123609,7 +123860,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3-ultra-550b-a55b:free": {
 			"id": "nvidia/nemotron-3-ultra-550b-a55b:free",
@@ -123643,7 +123895,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -123697,7 +123948,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3.5-content-safety:free": {
 			"id": "nvidia/nemotron-3.5-content-safety:free",
@@ -123811,7 +124063,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -123865,7 +124116,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3.5-lightning:free": {
 			"id": "nvidia/nemotron-3.5-lightning:free",
@@ -123899,7 +124151,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -123953,7 +124204,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-nano-12b-v2-vl": {
 			"id": "nvidia/nemotron-nano-12b-v2-vl",
@@ -124158,7 +124410,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -124212,7 +124463,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-3.5-turbo-0613": {
 			"id": "openai/gpt-3.5-turbo-0613",
@@ -124238,7 +124490,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -124292,7 +124543,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-3.5-turbo-16k": {
 			"id": "openai/gpt-3.5-turbo-16k",
@@ -124318,7 +124570,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -124372,7 +124623,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-3.5-turbo-instruct": {
 			"id": "openai/gpt-3.5-turbo-instruct",
@@ -124479,7 +124731,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -124533,7 +124784,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4-0314": {
 			"id": "openai/gpt-4-0314",
@@ -124724,7 +124976,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -124778,7 +125029,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4-turbo-preview": {
 			"id": "openai/gpt-4-turbo-preview",
@@ -124804,7 +125056,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -124858,7 +125109,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4.1": {
 			"id": "openai/gpt-4.1",
@@ -124887,7 +125139,6 @@
 				"revision": "4.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -124941,7 +125192,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4.1-mini": {
 			"id": "openai/gpt-4.1-mini",
@@ -124970,7 +125222,6 @@
 				"revision": "4.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -125024,7 +125275,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4.1-nano": {
 			"id": "openai/gpt-4.1-nano",
@@ -125053,7 +125305,6 @@
 				"revision": "4.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -125107,7 +125358,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4o": {
 			"id": "openai/gpt-4o",
@@ -125135,7 +125387,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -125189,7 +125440,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4o-2024-05-13": {
 			"id": "openai/gpt-4o-2024-05-13",
@@ -125217,7 +125469,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -125271,7 +125522,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4o-2024-08-06": {
 			"id": "openai/gpt-4o-2024-08-06",
@@ -125299,7 +125551,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -125353,7 +125604,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4o-2024-11-20": {
 			"id": "openai/gpt-4o-2024-11-20",
@@ -125379,7 +125631,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -125433,7 +125684,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4o-audio-preview": {
 			"id": "openai/gpt-4o-audio-preview",
@@ -125541,7 +125793,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -125595,7 +125846,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4o-mini-2024-07-18": {
 			"id": "openai/gpt-4o-mini-2024-07-18",
@@ -125621,7 +125873,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -125675,7 +125926,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4o-mini-search-preview": {
 			"id": "openai/gpt-4o-mini-search-preview",
@@ -125953,7 +126205,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -126007,7 +126258,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5-chat": {
 			"id": "openai/gpt-5-chat",
@@ -126398,7 +126650,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -126452,7 +126703,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5-nano": {
 			"id": "openai/gpt-5-nano",
@@ -126490,7 +126742,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -126544,7 +126795,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5-pro": {
 			"id": "openai/gpt-5-pro",
@@ -126580,7 +126832,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -126634,7 +126885,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.1": {
 			"id": "openai/gpt-5.1",
@@ -126672,7 +126924,6 @@
 				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -126726,7 +126977,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.1-chat": {
 			"id": "openai/gpt-5.1-chat",
@@ -126845,7 +127097,6 @@
 				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -126899,7 +127150,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.1-codex-max": {
 			"id": "openai/gpt-5.1-codex-max",
@@ -126937,7 +127189,6 @@
 				"logicalId": "openai/gpt-5.1-codex"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -126991,7 +127242,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.1-codex-mini": {
 			"id": "openai/gpt-5.1-codex-mini",
@@ -127026,7 +127278,6 @@
 				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -127080,7 +127331,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.2": {
 			"id": "openai/gpt-5.2",
@@ -127118,7 +127370,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -127172,7 +127423,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.2-chat": {
 			"id": "openai/gpt-5.2-chat",
@@ -127199,7 +127451,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -127253,7 +127504,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.2-codex": {
 			"id": "openai/gpt-5.2-codex",
@@ -127290,7 +127542,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -127344,7 +127595,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.2-pro": {
 			"id": "openai/gpt-5.2-pro",
@@ -127380,7 +127632,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -127434,7 +127685,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.3-chat": {
 			"id": "openai/gpt-5.3-chat",
@@ -127553,7 +127805,6 @@
 				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -127607,7 +127858,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.4": {
 			"id": "openai/gpt-5.4",
@@ -127645,7 +127897,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -127699,7 +127950,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.4-image-2": {
 			"id": "openai/gpt-5.4-image-2",
@@ -127817,7 +128069,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -127871,7 +128122,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.4-nano": {
 			"id": "openai/gpt-5.4-nano",
@@ -127909,7 +128161,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -127963,7 +128214,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.4-pro": {
 			"id": "openai/gpt-5.4-pro",
@@ -127999,7 +128251,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -128053,7 +128304,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.5": {
 			"id": "openai/gpt-5.5",
@@ -128092,7 +128344,6 @@
 				"revision": "5.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -128146,7 +128397,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.5-pro": {
 			"id": "openai/gpt-5.5-pro",
@@ -128183,7 +128435,6 @@
 				"revision": "5.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -128237,7 +128488,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-luna": {
 			"id": "openai/gpt-5.6-luna",
@@ -128276,7 +128528,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -128330,7 +128581,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-luna-pro": {
 			"id": "openai/gpt-5.6-luna-pro",
@@ -128367,7 +128619,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -128421,7 +128672,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-sol": {
 			"id": "openai/gpt-5.6-sol",
@@ -128460,7 +128712,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -128514,7 +128765,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-sol-discounted": {
 			"id": "openai/gpt-5.6-sol-discounted",
@@ -128551,7 +128803,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -128605,7 +128856,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-sol-pro": {
 			"id": "openai/gpt-5.6-sol-pro",
@@ -128642,7 +128894,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -128696,7 +128947,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-terra": {
 			"id": "openai/gpt-5.6-terra",
@@ -128735,7 +128987,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -128789,7 +129040,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-terra-pro": {
 			"id": "openai/gpt-5.6-terra-pro",
@@ -128826,7 +129078,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -128880,7 +129131,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-audio": {
 			"id": "openai/gpt-audio",
@@ -128905,7 +129157,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -128959,7 +129210,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-audio-mini": {
 			"id": "openai/gpt-audio-mini",
@@ -128984,7 +129236,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -129038,7 +129289,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-chat-latest": {
 			"id": "openai/gpt-chat-latest",
@@ -129064,7 +129316,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -129118,7 +129369,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-oss-120b": {
 			"id": "openai/gpt-oss-120b",
@@ -129153,7 +129405,6 @@
 				"family": "120b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -129207,7 +129458,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-oss-120b:exacto": {
 			"id": "openai/gpt-oss-120b:exacto",
@@ -129322,7 +129574,6 @@
 				"family": "20b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -129376,7 +129627,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-oss-safeguard-20b": {
 			"id": "openai/gpt-oss-safeguard-20b",
@@ -129408,7 +129660,6 @@
 				"class": "gpt-oss"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -129462,7 +129713,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o1": {
 			"id": "openai/o1",
@@ -129500,7 +129752,6 @@
 				"family": "o-series"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -129554,7 +129805,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o1-pro": {
 			"id": "openai/o1-pro",
@@ -129685,7 +129937,6 @@
 				"family": "o-series"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -129739,7 +129990,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o3-deep-research": {
 			"id": "openai/o3-deep-research",
@@ -129871,7 +130123,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -129925,7 +130176,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o3-mini-high": {
 			"id": "openai/o3-mini-high",
@@ -129966,7 +130218,6 @@
 				"logicalId": "openai/o3-mini"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -130020,7 +130271,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o3-pro": {
 			"id": "openai/o3-pro",
@@ -130059,7 +130311,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -130113,7 +130364,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o4-mini": {
 			"id": "openai/o4-mini",
@@ -130153,7 +130405,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -130207,7 +130458,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o4-mini-deep-research": {
 			"id": "openai/o4-mini-deep-research",
@@ -130342,7 +130594,6 @@
 				"logicalId": "openai/o4-mini"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -130396,7 +130647,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"opengvlab/internvl3-78b": {
 			"id": "opengvlab/internvl3-78b",
@@ -130510,7 +130762,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -130564,7 +130815,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openrouter/auto-beta": {
 			"id": "openrouter/auto-beta",
@@ -130834,7 +131086,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -130888,7 +131139,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openrouter/fusion": {
 			"id": "openrouter/fusion",
@@ -131912,7 +132164,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -131966,7 +132217,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"poolside/laguna-s-2.1:free": {
 			"id": "poolside/laguna-s-2.1:free",
@@ -132000,7 +132252,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -132054,7 +132305,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"poolside/laguna-xs-2.1": {
 			"id": "poolside/laguna-xs-2.1",
@@ -132088,7 +132340,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -132142,7 +132393,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"poolside/laguna-xs-2.1:free": {
 			"id": "poolside/laguna-xs-2.1:free",
@@ -132176,7 +132428,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -132230,7 +132481,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"poolside/laguna-xs.2": {
 			"id": "poolside/laguna-xs.2",
@@ -132522,7 +132774,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -132576,7 +132827,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen-2.5-7b-instruct": {
 			"id": "qwen/qwen-2.5-7b-instruct",
@@ -132601,7 +132853,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -132655,7 +132906,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen-2.5-coder-32b-instruct": {
 			"id": "qwen/qwen-2.5-coder-32b-instruct",
@@ -132917,7 +133169,6 @@
 				"class": "qwen"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -132971,7 +133222,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen-plus-2025-07-28": {
 			"id": "qwen/qwen-plus-2025-07-28",
@@ -132995,7 +133247,6 @@
 				"class": "qwen"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -133049,7 +133300,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen-plus-2025-07-28:thinking": {
 			"id": "qwen/qwen-plus-2025-07-28:thinking",
@@ -133646,7 +133898,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -133700,7 +133951,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-235b-a22b": {
 			"id": "qwen/qwen3-235b-a22b",
@@ -133734,7 +133986,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -133788,7 +134039,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-235b-a22b-2507": {
 			"id": "qwen/qwen3-235b-a22b-2507",
@@ -133813,7 +134065,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -133867,7 +134118,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-235b-a22b-thinking-2507": {
 			"id": "qwen/qwen3-235b-a22b-thinking-2507",
@@ -133902,7 +134154,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -133956,7 +134207,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-30b-a3b": {
 			"id": "qwen/qwen3-30b-a3b",
@@ -133990,7 +134242,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -134044,7 +134295,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-30b-a3b-instruct-2507": {
 			"id": "qwen/qwen3-30b-a3b-instruct-2507",
@@ -134069,7 +134321,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -134123,7 +134374,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-30b-a3b-thinking-2507": {
 			"id": "qwen/qwen3-30b-a3b-thinking-2507",
@@ -134158,7 +134410,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -134212,7 +134463,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-32b": {
 			"id": "qwen/qwen3-32b",
@@ -134246,7 +134498,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -134300,7 +134551,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-8b": {
 			"id": "qwen/qwen3-8b",
@@ -134334,7 +134586,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -134388,7 +134639,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-coder": {
 			"id": "qwen/qwen3-coder",
@@ -134414,7 +134666,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -134468,7 +134719,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-coder-30b-a3b-instruct": {
 			"id": "qwen/qwen3-coder-30b-a3b-instruct",
@@ -134496,7 +134748,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -134550,7 +134801,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-coder-flash": {
 			"id": "qwen/qwen3-coder-flash",
@@ -134576,7 +134828,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -134630,7 +134881,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-coder-next": {
 			"id": "qwen/qwen3-coder-next",
@@ -134658,7 +134910,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -134712,7 +134963,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-coder-plus": {
 			"id": "qwen/qwen3-coder-plus",
@@ -134738,7 +134990,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -134792,7 +135043,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-coder:exacto": {
 			"id": "qwen/qwen3-coder:exacto",
@@ -134900,7 +135152,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -134954,7 +135205,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-max-thinking": {
 			"id": "qwen/qwen3-max-thinking",
@@ -134992,7 +135244,6 @@
 				"logicalId": "qwen/qwen3-max"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -135046,7 +135297,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-next-80b-a3b-instruct": {
 			"id": "qwen/qwen3-next-80b-a3b-instruct",
@@ -135074,7 +135326,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -135128,7 +135379,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-next-80b-a3b-thinking": {
 			"id": "qwen/qwen3-next-80b-a3b-thinking",
@@ -135166,7 +135418,6 @@
 				"logicalId": "qwen/qwen3-next-80b-a3b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -135220,7 +135471,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-vl-235b-a22b-instruct": {
 			"id": "qwen/qwen3-vl-235b-a22b-instruct",
@@ -135249,7 +135501,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -135303,7 +135554,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-vl-235b-a22b-thinking": {
 			"id": "qwen/qwen3-vl-235b-a22b-thinking",
@@ -135342,7 +135594,6 @@
 				"logicalId": "qwen/qwen3-vl-235b-a22b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -135396,7 +135647,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-vl-30b-a3b-instruct": {
 			"id": "qwen/qwen3-vl-30b-a3b-instruct",
@@ -135425,7 +135677,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -135479,7 +135730,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-vl-30b-a3b-thinking": {
 			"id": "qwen/qwen3-vl-30b-a3b-thinking",
@@ -135518,7 +135770,6 @@
 				"logicalId": "qwen/qwen3-vl-30b-a3b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -135572,7 +135823,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-vl-32b-instruct": {
 			"id": "qwen/qwen3-vl-32b-instruct",
@@ -135601,7 +135853,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -135655,7 +135906,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-vl-8b-instruct": {
 			"id": "qwen/qwen3-vl-8b-instruct",
@@ -135684,7 +135936,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -135738,7 +135989,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-vl-8b-thinking": {
 			"id": "qwen/qwen3-vl-8b-thinking",
@@ -135777,7 +136029,6 @@
 				"logicalId": "qwen/qwen3-vl-8b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -135831,7 +136082,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.5-122b-a10b": {
 			"id": "qwen/qwen3.5-122b-a10b",
@@ -135869,7 +136121,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -135923,7 +136174,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.5-27b": {
 			"id": "qwen/qwen3.5-27b",
@@ -135961,7 +136213,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -136015,7 +136266,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.5-35b-a3b": {
 			"id": "qwen/qwen3.5-35b-a3b",
@@ -136053,7 +136305,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -136107,7 +136358,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.5-397b-a17b": {
 			"id": "qwen/qwen3.5-397b-a17b",
@@ -136145,7 +136397,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -136199,7 +136450,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.5-9b": {
 			"id": "qwen/qwen3.5-9b",
@@ -136237,7 +136489,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -136291,7 +136542,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.5-flash-02-23": {
 			"id": "qwen/qwen3.5-flash-02-23",
@@ -136327,7 +136579,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -136381,7 +136632,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.5-plus-02-15": {
 			"id": "qwen/qwen3.5-plus-02-15",
@@ -136417,7 +136669,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -136471,7 +136722,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.5-plus-20260420": {
 			"id": "qwen/qwen3.5-plus-20260420",
@@ -136507,7 +136759,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -136561,7 +136812,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.6-27b": {
 			"id": "qwen/qwen3.6-27b",
@@ -136599,7 +136851,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -136653,7 +136904,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.6-35b-a3b": {
 			"id": "qwen/qwen3.6-35b-a3b",
@@ -136691,7 +136943,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -136745,7 +136996,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.6-flash": {
 			"id": "qwen/qwen3.6-flash",
@@ -136781,7 +137033,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -136835,7 +137086,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.6-max-preview": {
 			"id": "qwen/qwen3.6-max-preview",
@@ -136870,7 +137122,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -136924,7 +137175,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.6-plus": {
 			"id": "qwen/qwen3.6-plus",
@@ -136962,7 +137214,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -137016,7 +137267,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.6-plus-preview:free": {
 			"id": "qwen/qwen3.6-plus-preview:free",
@@ -137214,7 +137466,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -137268,7 +137519,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.7-max": {
 			"id": "qwen/qwen3.7-max",
@@ -137305,7 +137557,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -137359,7 +137610,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.7-plus": {
 			"id": "qwen/qwen3.7-plus",
@@ -137397,7 +137649,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -137451,7 +137702,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.7-plus:free": {
 			"id": "qwen/qwen3.7-plus:free",
@@ -137569,7 +137821,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -137623,7 +137874,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.8-27b": {
 			"id": "qwen/qwen3.8-27b",
@@ -137661,7 +137913,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -137715,7 +137966,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.8-flash": {
 			"id": "qwen/qwen3.8-flash",
@@ -137751,7 +138003,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -137805,7 +138056,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.8-max": {
 			"id": "qwen/qwen3.8-max",
@@ -137843,7 +138095,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -137897,7 +138148,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwq-32b": {
 			"id": "qwen/qwq-32b",
@@ -138160,7 +138412,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -138214,7 +138465,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"rekaai/reka-flash-3": {
 			"id": "rekaai/reka-flash-3",
@@ -138394,7 +138646,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -138448,7 +138699,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"sakana/fugu-ultra": {
 			"id": "sakana/fugu-ultra",
@@ -138483,7 +138735,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -138537,7 +138788,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"sakana/sakana-namazu": {
 			"id": "sakana/sakana-namazu",
@@ -138572,7 +138824,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -138626,7 +138877,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"sao10k/l3-euryale-70b": {
 			"id": "sao10k/l3-euryale-70b",
@@ -138886,7 +139138,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -138940,7 +139191,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"sao10k/l3.3-euryale-70b": {
 			"id": "sao10k/l3.3-euryale-70b",
@@ -139058,7 +139310,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -139112,7 +139363,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"stealth/claude-opus-4.7": {
 			"id": "stealth/claude-opus-4.7",
@@ -139152,7 +139404,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -139206,7 +139457,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"stealth/claude-opus-4.8": {
 			"id": "stealth/claude-opus-4.8",
@@ -139246,7 +139498,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -139300,7 +139551,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"stealth/claude-sonnet-4.6": {
 			"id": "stealth/claude-sonnet-4.6",
@@ -139340,7 +139592,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -139394,7 +139645,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"stealth/gpt-5.6-sol": {
 			"id": "stealth/gpt-5.6-sol",
@@ -139613,7 +139865,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -139667,7 +139918,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"stepfun/step-3.5-flash": {
 			"id": "stepfun/step-3.5-flash",
@@ -139704,7 +139956,6 @@
 				"family": "step"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -139758,7 +140009,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"stepfun/step-3.5-flash:free": {
 			"id": "stepfun/step-3.5-flash:free",
@@ -139876,7 +140128,6 @@
 				"family": "step"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -139930,7 +140181,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"stepfun/step-3.7-flash:free": {
 			"id": "stepfun/step-3.7-flash:free",
@@ -139966,7 +140218,6 @@
 				"family": "step"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -140020,7 +140271,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"switchpoint/router": {
 			"id": "switchpoint/router",
@@ -140447,7 +140699,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -140501,7 +140752,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"tencent/hy3-preview": {
 			"id": "tencent/hy3-preview",
@@ -140536,7 +140788,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -140590,7 +140841,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"tencent/hy3-preview:free": {
 			"id": "tencent/hy3-preview:free",
@@ -140791,7 +141043,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -140845,7 +141096,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"thedrummer/cydonia-24b-v4.1": {
 			"id": "thedrummer/cydonia-24b-v4.1",
@@ -141103,7 +141355,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -141157,7 +141408,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"thinkingmachines/inkling": {
 			"id": "thinkingmachines/inkling",
@@ -141194,7 +141446,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -141248,7 +141499,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"thinkingmachines/inkling-small": {
 			"id": "thinkingmachines/inkling-small",
@@ -141285,7 +141537,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -141339,7 +141590,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"thinkingmachines/inkling-small:free": {
 			"id": "thinkingmachines/inkling-small:free",
@@ -141374,7 +141626,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -141428,7 +141679,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"thinkingmachines/inkling:free": {
 			"id": "thinkingmachines/inkling:free",
@@ -141463,7 +141715,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -141517,7 +141768,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"tngtech/deepseek-r1t2-chimera": {
 			"id": "tngtech/deepseek-r1t2-chimera",
@@ -141713,7 +141965,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -141767,7 +142018,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"upstage/solar-pro4": {
 			"id": "upstage/solar-pro4",
@@ -141803,7 +142055,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -141857,7 +142108,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"writer/palmyra-x5": {
 			"id": "writer/palmyra-x5",
@@ -142581,7 +142833,6 @@
 				"revision": "4.20.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -142636,7 +142887,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"x-ai/grok-4.20-beta": {
 			"id": "x-ai/grok-4.20-beta",
@@ -142931,7 +143183,6 @@
 				"revision": "4.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -142986,7 +143237,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"x-ai/grok-4.5": {
 			"id": "x-ai/grok-4.5",
@@ -143025,7 +143277,6 @@
 				"revision": "4.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -143080,7 +143331,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"x-ai/grok-4.6": {
 			"id": "x-ai/grok-4.6",
@@ -143119,7 +143371,6 @@
 				"revision": "4.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -143174,7 +143425,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"x-ai/grok-build-0.1": {
 			"id": "x-ai/grok-build-0.1",
@@ -143211,7 +143463,6 @@
 				"revision": "0.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -143266,7 +143517,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"x-ai/grok-code-fast-1": {
 			"id": "x-ai/grok-code-fast-1",
@@ -143917,7 +144169,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -143974,7 +144225,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xiaomi/mimo-v2.5-pro": {
 			"id": "xiaomi/mimo-v2.5-pro",
@@ -144009,7 +144261,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -144066,7 +144317,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4-32b": {
 			"id": "z-ai/glm-4-32b",
@@ -144182,7 +144434,6 @@
 				"revision": "4.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -144236,7 +144487,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.5-air": {
 			"id": "z-ai/glm-4.5-air",
@@ -144274,7 +144526,6 @@
 				"revision": "4.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -144328,7 +144579,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.5v": {
 			"id": "z-ai/glm-4.5v",
@@ -144366,7 +144618,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -144420,7 +144671,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.6": {
 			"id": "z-ai/glm-4.6",
@@ -144457,7 +144709,6 @@
 				"revision": "4.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -144511,7 +144762,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.6:exacto": {
 			"id": "z-ai/glm-4.6:exacto",
@@ -144629,7 +144881,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -144683,7 +144934,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.7": {
 			"id": "z-ai/glm-4.7",
@@ -144720,7 +144972,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -144774,7 +145025,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.7-flash": {
 			"id": "z-ai/glm-4.7-flash",
@@ -144812,7 +145064,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -144866,7 +145117,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5": {
 			"id": "z-ai/glm-5",
@@ -144904,7 +145156,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -144958,7 +145209,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5-turbo": {
 			"id": "z-ai/glm-5-turbo",
@@ -144996,7 +145248,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -145050,7 +145301,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5.1": {
 			"id": "z-ai/glm-5.1",
@@ -145088,7 +145340,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -145142,7 +145393,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5.2": {
 			"id": "z-ai/glm-5.2",
@@ -145180,7 +145432,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -145234,7 +145485,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5.2:free": {
 			"id": "z-ai/glm-5.2:free",
@@ -145353,7 +145605,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -145407,7 +145658,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5.3-flash": {
 			"id": "z-ai/glm-5.3-flash",
@@ -145447,7 +145699,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -145501,7 +145752,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5v-turbo": {
 			"id": "z-ai/glm-5v-turbo",
@@ -145538,7 +145790,6 @@
 				"family": "vision"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -145592,7 +145843,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"kimi-code": {
@@ -146778,7 +147030,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -146804,7 +147055,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMax-M2.1": {
 			"id": "MiniMax-M2.1",
@@ -146845,7 +147097,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -146871,7 +147122,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMax-M2.5": {
 			"id": "MiniMax-M2.5",
@@ -146912,7 +147164,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -146938,7 +147189,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMax-M2.5-highspeed": {
 			"id": "MiniMax-M2.5-highspeed",
@@ -146977,7 +147229,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -147003,7 +147254,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMax-M2.5-lightning": {
 			"id": "MiniMax-M2.5-lightning",
@@ -147109,7 +147361,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -147135,7 +147386,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMax-M2.7-highspeed": {
 			"id": "MiniMax-M2.7-highspeed",
@@ -147174,7 +147426,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -147200,7 +147451,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMax-M3": {
 			"id": "MiniMax-M3",
@@ -147241,7 +147493,6 @@
 				"family": "m3"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -147267,7 +147518,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"minimax-cn": {
@@ -147310,7 +147562,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -147336,7 +147587,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMax-M2.1": {
 			"id": "MiniMax-M2.1",
@@ -147377,7 +147629,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -147403,7 +147654,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMax-M2.5": {
 			"id": "MiniMax-M2.5",
@@ -147444,7 +147696,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -147470,7 +147721,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMax-M2.5-highspeed": {
 			"id": "MiniMax-M2.5-highspeed",
@@ -147509,7 +147761,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -147535,7 +147786,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMax-M2.5-lightning": {
 			"id": "MiniMax-M2.5-lightning",
@@ -147641,7 +147893,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -147667,7 +147918,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMax-M2.7-highspeed": {
 			"id": "MiniMax-M2.7-highspeed",
@@ -147706,7 +147958,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -147732,7 +147983,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMax-M3": {
 			"id": "MiniMax-M3",
@@ -147773,7 +148025,6 @@
 				"family": "m3"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -147799,7 +148050,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"minimax-code": {
@@ -147823,6 +148075,20 @@
 			"maxTokens": 131072,
 			"int": 28.9,
 			"tps": 97.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "minimax",
+				"family": "m2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -147877,20 +148143,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "minimax",
-				"family": "m2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -147919,6 +148171,20 @@
 			"maxTokens": 131072,
 			"int": 32.1,
 			"tps": 96.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "minimax",
+				"family": "m2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -147973,20 +148239,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "minimax",
-				"family": "m2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -148109,6 +148361,20 @@
 			"maxTokens": 131072,
 			"int": 34.5,
 			"tps": 97,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "minimax",
+				"family": "m2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -148163,20 +148429,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "minimax",
-				"family": "m2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -148203,6 +148455,20 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "minimax",
+				"family": "m2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -148257,20 +148523,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "minimax",
-				"family": "m2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -148393,6 +148645,20 @@
 			"maxTokens": 131072,
 			"int": 38.9,
 			"tps": 76.8,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "minimax",
+				"family": "m2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -148447,20 +148713,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "minimax",
-				"family": "m2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -148487,6 +148739,20 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "minimax",
+				"family": "m2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -148541,20 +148807,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "minimax",
-				"family": "m2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -148584,6 +148836,20 @@
 			"maxTokens": 128000,
 			"int": 45.4,
 			"tps": 89.4,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "minimax",
+				"family": "m3"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -148638,20 +148904,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "minimax",
-				"family": "m3"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -148682,6 +148934,20 @@
 			"maxTokens": 131072,
 			"int": 28.9,
 			"tps": 97.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "minimax",
+				"family": "m2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -148736,20 +149002,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "minimax",
-				"family": "m2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -148778,6 +149030,20 @@
 			"maxTokens": 131072,
 			"int": 32.1,
 			"tps": 96.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "minimax",
+				"family": "m2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -148832,20 +149098,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "minimax",
-				"family": "m2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -148968,6 +149220,20 @@
 			"maxTokens": 131072,
 			"int": 34.5,
 			"tps": 97,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "minimax",
+				"family": "m2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -149022,20 +149288,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "minimax",
-				"family": "m2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -149062,6 +149314,20 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "minimax",
+				"family": "m2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -149116,20 +149382,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "minimax",
-				"family": "m2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -149252,6 +149504,20 @@
 			"maxTokens": 131072,
 			"int": 38.9,
 			"tps": 76.8,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "minimax",
+				"family": "m2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -149306,20 +149572,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "minimax",
-				"family": "m2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -149346,6 +149598,20 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "minimax",
+				"family": "m2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -149400,20 +149666,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "minimax",
-				"family": "m2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -149443,6 +149695,20 @@
 			"maxTokens": 128000,
 			"int": 45.4,
 			"tps": 89.4,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "minimax",
+				"family": "m3"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -149497,20 +149763,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "minimax",
-				"family": "m3"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -149543,7 +149795,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -149597,7 +149848,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"devstral-2512": {
 			"id": "devstral-2512",
@@ -149621,7 +149873,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -149675,7 +149926,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"devstral-latest": {
 			"id": "devstral-latest",
@@ -149699,7 +149951,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -149753,7 +150004,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"devstral-medium-2507": {
 			"id": "devstral-medium-2507",
@@ -149777,7 +150029,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -149831,7 +150082,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"devstral-medium-latest": {
 			"id": "devstral-medium-latest",
@@ -149855,7 +150107,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -149909,7 +150160,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"devstral-small-2505": {
 			"id": "devstral-small-2505",
@@ -149934,7 +150186,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -149988,7 +150239,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"devstral-small-2507": {
 			"id": "devstral-small-2507",
@@ -150012,7 +150264,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -150066,7 +150317,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"labs-devstral-small-2512": {
 			"id": "labs-devstral-small-2512",
@@ -150091,7 +150343,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -150145,7 +150396,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"magistral-medium-latest": {
 			"id": "magistral-medium-latest",
@@ -150179,7 +150431,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -150233,7 +150484,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"magistral-small": {
 			"id": "magistral-small",
@@ -150268,7 +150520,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -150322,7 +150573,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"ministral-3b-latest": {
 			"id": "ministral-3b-latest",
@@ -150346,7 +150598,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -150400,7 +150651,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"ministral-8b-latest": {
 			"id": "ministral-8b-latest",
@@ -150424,7 +150676,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -150478,7 +150729,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral-large-2411": {
 			"id": "mistral-large-2411",
@@ -150503,7 +150755,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -150557,7 +150808,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral-large-2512": {
 			"id": "mistral-large-2512",
@@ -150583,7 +150835,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -150637,7 +150888,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral-large-latest": {
 			"id": "mistral-large-latest",
@@ -150663,7 +150915,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -150717,7 +150968,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral-medium-2505": {
 			"id": "mistral-medium-2505",
@@ -150743,7 +150995,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -150797,7 +151048,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral-medium-2508": {
 			"id": "mistral-medium-2508",
@@ -150823,7 +151075,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -150877,7 +151128,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral-medium-2604": {
 			"id": "mistral-medium-2604",
@@ -150913,7 +151165,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -150967,7 +151218,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral-medium-latest": {
 			"id": "mistral-medium-latest",
@@ -151003,7 +151255,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -151057,7 +151308,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral-nemo": {
 			"id": "mistral-nemo",
@@ -151082,7 +151334,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -151136,7 +151387,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral-small-2506": {
 			"id": "mistral-small-2506",
@@ -151162,7 +151414,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -151216,7 +151467,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral-small-2603": {
 			"id": "mistral-small-2603",
@@ -151252,7 +151504,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -151306,7 +151557,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral-small-latest": {
 			"id": "mistral-small-latest",
@@ -151342,7 +151594,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -151396,7 +151647,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"open-mistral-7b": {
 			"id": "open-mistral-7b",
@@ -151420,7 +151672,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -151474,7 +151725,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"open-mistral-nemo": {
 			"id": "open-mistral-nemo",
@@ -151498,7 +151750,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -151552,7 +151803,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"open-mixtral-8x22b": {
 			"id": "open-mixtral-8x22b",
@@ -151576,7 +151828,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -151630,7 +151881,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"open-mixtral-8x7b": {
 			"id": "open-mixtral-8x7b",
@@ -151654,7 +151906,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -151708,7 +151959,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"pixtral-12b": {
 			"id": "pixtral-12b",
@@ -151733,7 +151985,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -151787,7 +152038,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"pixtral-large-latest": {
 			"id": "pixtral-large-latest",
@@ -151812,7 +152064,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -151866,7 +152117,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"voxtral-small-latest": {
 			"id": "voxtral-small-latest",
@@ -151890,7 +152142,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -151944,7 +152195,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-glm-5-2": {
 			"id": "zai-glm-5-2",
@@ -151980,7 +152232,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -152034,7 +152285,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"moonshot": {
@@ -152062,7 +152314,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -152117,7 +152368,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2-0905-preview": {
 			"id": "kimi-k2-0905-preview",
@@ -152143,7 +152395,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -152198,7 +152449,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2-thinking": {
 			"id": "kimi-k2-thinking",
@@ -152238,7 +152490,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -152293,7 +152544,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2-thinking-turbo": {
 			"id": "kimi-k2-thinking-turbo",
@@ -152329,7 +152581,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -152384,7 +152635,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2-turbo-preview": {
 			"id": "kimi-k2-turbo-preview",
@@ -152410,7 +152662,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -152465,7 +152716,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2.5": {
 			"id": "kimi-k2.5",
@@ -152502,7 +152754,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -152557,7 +152808,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2.6": {
 			"id": "kimi-k2.6",
@@ -152595,7 +152847,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -152652,7 +152903,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2.7-code": {
 			"id": "kimi-k2.7-code",
@@ -152690,7 +152942,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -152746,7 +152997,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2.7-code-highspeed": {
 			"id": "kimi-k2.7-code-highspeed",
@@ -152782,7 +153034,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -152838,7 +153089,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k3": {
 			"id": "kimi-k3",
@@ -152880,7 +153132,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -152941,7 +153192,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshot-v1-128k": {
 			"id": "moonshot-v1-128k",
@@ -153689,8 +153941,6 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"int": 46.8,
-			"tps": 260,
 			"identity": {
 				"class": "meta",
 				"family": "muse-spark",
@@ -153706,7 +153956,7 @@
 		},
 		"muse-spark-1.2-contributor": {
 			"id": "muse-spark-1.2-contributor",
-			"name": "Muse Spark 1.2 Contributor",
+			"name": "Muse Spark 1.2 (C)",
 			"api": "openai-responses",
 			"provider": "muse-code",
 			"baseUrl": "https://api.meta.ai/v1",
@@ -153886,8 +154136,6 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"int": 53,
-			"tps": 190.1,
 			"identity": {
 				"class": "meta",
 				"family": "muse-spark",
@@ -153903,7 +154151,7 @@
 		},
 		"muse-spark-1.3-contributor": {
 			"id": "muse-spark-1.3-contributor",
-			"name": "Muse Spark 1.3 Contributor",
+			"name": "Muse Spark 1.3 (C)",
 			"api": "openai-responses",
 			"provider": "muse-code",
 			"baseUrl": "https://api.meta.ai/v1",
@@ -154345,7 +154593,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -154399,7 +154646,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"abliteration-ai/abliterated-model-large-v2": {
 			"id": "abliteration-ai/abliterated-model-large-v2",
@@ -154433,7 +154681,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -154487,7 +154734,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"aion-labs/aion-1.0": {
 			"id": "aion-labs/aion-1.0",
@@ -154669,7 +154917,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -154723,7 +154970,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"aion-labs/aion-2.5": {
 			"id": "aion-labs/aion-2.5",
@@ -154836,7 +155084,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -154890,7 +155137,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"aion-labs/aion-3.0-mini": {
 			"id": "aion-labs/aion-3.0-mini",
@@ -154924,7 +155172,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -154978,7 +155225,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"aion-labs/aion-rp-llama-3.1-8b": {
 			"id": "aion-labs/aion-rp-llama-3.1-8b",
@@ -155002,7 +155250,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -155056,7 +155303,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Alibaba-NLP/Tongyi-DeepResearch-30B-A3B": {
 			"id": "Alibaba-NLP/Tongyi-DeepResearch-30B-A3B",
@@ -155164,7 +155412,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -155218,7 +155465,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"alibaba/qwen3.6-27b:thinking": {
 			"id": "alibaba/qwen3.6-27b:thinking",
@@ -155254,7 +155502,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -155308,7 +155555,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"alibaba/qwen3.6-flash": {
 			"id": "alibaba/qwen3.6-flash",
@@ -155425,7 +155673,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -155479,7 +155726,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"alibaba/qwen3.8-max-0902": {
 			"id": "alibaba/qwen3.8-max-0902",
@@ -155515,7 +155763,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -155569,7 +155816,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"allenai/molmo-2-8b": {
 			"id": "allenai/molmo-2-8b",
@@ -156416,7 +156664,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -156470,7 +156717,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-fable-5.1": {
 			"id": "anthropic/claude-fable-5.1",
@@ -156511,7 +156759,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -156565,7 +156812,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-fable-latest": {
 			"id": "anthropic/claude-fable-latest",
@@ -156602,7 +156850,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -156656,7 +156903,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-haiku-latest": {
 			"id": "anthropic/claude-haiku-latest",
@@ -156693,7 +156941,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -156747,7 +156994,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.6": {
 			"id": "anthropic/claude-opus-4.6",
@@ -156787,7 +157035,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -156841,7 +157088,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.6:thinking": {
 			"id": "anthropic/claude-opus-4.6:thinking",
@@ -156879,7 +157127,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -156933,7 +157180,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.6:thinking:low": {
 			"id": "anthropic/claude-opus-4.6:thinking:low",
@@ -156971,7 +157219,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -157025,7 +157272,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.6:thinking:max": {
 			"id": "anthropic/claude-opus-4.6:thinking:max",
@@ -157063,7 +157311,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -157117,7 +157364,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.6:thinking:medium": {
 			"id": "anthropic/claude-opus-4.6:thinking:medium",
@@ -157155,7 +157403,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -157209,7 +157456,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.7": {
 			"id": "anthropic/claude-opus-4.7",
@@ -157249,7 +157497,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -157303,7 +157550,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.7:thinking": {
 			"id": "anthropic/claude-opus-4.7:thinking",
@@ -157341,7 +157589,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -157395,7 +157642,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.8": {
 			"id": "anthropic/claude-opus-4.8",
@@ -157435,7 +157683,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -157489,7 +157736,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.8:thinking": {
 			"id": "anthropic/claude-opus-4.8:thinking",
@@ -157527,7 +157775,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -157581,7 +157828,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-5": {
 			"id": "anthropic/claude-opus-5",
@@ -157621,7 +157869,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -157675,7 +157922,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-latest": {
 			"id": "anthropic/claude-opus-latest",
@@ -157712,7 +157960,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -157766,7 +158013,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-sonnet-4.6": {
 			"id": "anthropic/claude-sonnet-4.6",
@@ -157806,7 +158054,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -157860,7 +158107,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-sonnet-4.6:thinking": {
 			"id": "anthropic/claude-sonnet-4.6:thinking",
@@ -157898,7 +158146,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -157952,7 +158199,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-sonnet-5": {
 			"id": "anthropic/claude-sonnet-5",
@@ -157982,7 +158230,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -158036,7 +158283,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-sonnet-5:thinking": {
 			"id": "anthropic/claude-sonnet-5:thinking",
@@ -158074,7 +158322,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -158128,7 +158375,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-sonnet-latest": {
 			"id": "anthropic/claude-sonnet-latest",
@@ -158165,7 +158413,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -158219,7 +158466,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"arcee-ai/trinity-large": {
 			"id": "arcee-ai/trinity-large",
@@ -158587,7 +158835,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -158641,7 +158888,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"auto-model-basic": {
 			"id": "auto-model-basic",
@@ -158665,7 +158913,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -158719,7 +158966,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"auto-model-premium": {
 			"id": "auto-model-premium",
@@ -158743,7 +158991,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -158797,7 +159044,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"auto-model-standard": {
 			"id": "auto-model-standard",
@@ -158821,7 +159069,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -158875,7 +159122,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"azure-gpt-4-turbo": {
 			"id": "azure-gpt-4-turbo",
@@ -158979,7 +159227,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -159033,7 +159280,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"azure-gpt-4o-mini": {
 			"id": "azure-gpt-4o-mini",
@@ -159058,7 +159306,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -159112,7 +159359,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"azure-o1": {
 			"id": "azure-o1",
@@ -159704,7 +159952,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -159759,7 +160006,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"brave": {
 			"id": "brave",
@@ -160031,7 +160279,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -160085,7 +160332,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"bytedance-seed/seed-2.0-code": {
 			"id": "bytedance-seed/seed-2.0-code",
@@ -160120,7 +160368,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -160174,7 +160421,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"bytedance-seed/seed-2.0-lite": {
 			"id": "bytedance-seed/seed-2.0-lite",
@@ -161545,7 +161793,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -161599,7 +161846,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-1-20250805": {
 			"id": "claude-opus-4-1-20250805",
@@ -161627,7 +161875,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -161681,7 +161928,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-1-thinking": {
 			"id": "claude-opus-4-1-thinking",
@@ -161722,7 +161970,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -161776,7 +162023,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-1-thinking:1024": {
 			"id": "claude-opus-4-1-thinking:1024",
@@ -161815,7 +162063,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -161869,7 +162116,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-1-thinking:32000": {
 			"id": "claude-opus-4-1-thinking:32000",
@@ -162001,7 +162249,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -162055,7 +162302,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-1-thinking:8192": {
 			"id": "claude-opus-4-1-thinking:8192",
@@ -162094,7 +162342,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -162148,7 +162395,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-20250514": {
 			"id": "claude-opus-4-20250514",
@@ -162176,7 +162424,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -162230,7 +162477,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-5-20251101": {
 			"id": "claude-opus-4-5-20251101",
@@ -162268,7 +162516,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -162322,7 +162569,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-5-20251101:thinking": {
 			"id": "claude-opus-4-5-20251101:thinking",
@@ -162360,7 +162608,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -162414,7 +162661,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-thinking": {
 			"id": "claude-opus-4-thinking",
@@ -162455,7 +162703,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -162509,7 +162756,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-thinking:1024": {
 			"id": "claude-opus-4-thinking:1024",
@@ -162548,7 +162796,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -162602,7 +162849,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-thinking:32000": {
 			"id": "claude-opus-4-thinking:32000",
@@ -162734,7 +162982,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -162788,7 +163035,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-thinking:8192": {
 			"id": "claude-opus-4-thinking:8192",
@@ -162827,7 +163075,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -162881,7 +163128,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-20250514": {
 			"id": "claude-sonnet-4-20250514",
@@ -162909,7 +163157,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -162963,7 +163210,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-5-20250929": {
 			"id": "claude-sonnet-4-5-20250929",
@@ -163009,7 +163257,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -163063,7 +163310,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-thinking": {
 			"id": "claude-sonnet-4-thinking",
@@ -163104,7 +163352,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -163158,7 +163405,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-thinking:1024": {
 			"id": "claude-sonnet-4-thinking:1024",
@@ -163197,7 +163445,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -163251,7 +163498,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-thinking:32768": {
 			"id": "claude-sonnet-4-thinking:32768",
@@ -163290,7 +163538,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -163344,7 +163591,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-thinking:64000": {
 			"id": "claude-sonnet-4-thinking:64000",
@@ -163383,7 +163631,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -163437,7 +163684,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-thinking:8192": {
 			"id": "claude-sonnet-4-thinking:8192",
@@ -163476,7 +163724,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -163530,7 +163777,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claw-high": {
 			"id": "claw-high",
@@ -163566,7 +163814,6 @@
 				"logicalId": "claw"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -163620,7 +163867,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claw-low": {
 			"id": "claw-low",
@@ -163656,7 +163904,6 @@
 				"logicalId": "claw"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -163710,7 +163957,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claw-medium": {
 			"id": "claw-medium",
@@ -163746,7 +163994,6 @@
 				"logicalId": "claw"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -163800,7 +164047,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"cognitivecomputations/dolphin-2.9.2-qwen2-72b": {
 			"id": "cognitivecomputations/dolphin-2.9.2-qwen2-72b",
@@ -164302,7 +164550,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -164356,7 +164603,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"crofai/greg-2-ultra": {
 			"id": "crofai/greg-2-ultra",
@@ -164380,7 +164628,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -164434,7 +164681,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"CrucibleLab/L3.3-70B-Loki-V2.0": {
 			"id": "CrucibleLab/L3.3-70B-Loki-V2.0",
@@ -164783,7 +165031,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -164838,7 +165085,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V3.1": {
 			"id": "deepseek-ai/DeepSeek-V3.1",
@@ -164865,7 +165113,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -164920,7 +165167,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V3.1-Terminus": {
 			"id": "deepseek-ai/DeepSeek-V3.1-Terminus",
@@ -164947,7 +165195,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -165002,7 +165249,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V3.1-Terminus:thinking": {
 			"id": "deepseek-ai/DeepSeek-V3.1-Terminus:thinking",
@@ -165028,7 +165276,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -165083,7 +165330,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V3.1:thinking": {
 			"id": "deepseek-ai/DeepSeek-V3.1:thinking",
@@ -165109,7 +165357,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -165164,7 +165411,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/deepseek-v3.2-exp": {
 			"id": "deepseek-ai/deepseek-v3.2-exp",
@@ -165286,7 +165534,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -165341,7 +165588,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-chat-cheaper": {
 			"id": "deepseek-chat-cheaper",
@@ -165366,7 +165614,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -165421,7 +165668,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-math-v2": {
 			"id": "deepseek-math-v2",
@@ -165536,7 +165784,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -165591,7 +165838,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-r1-sambanova": {
 			"id": "deepseek-r1-sambanova",
@@ -165864,7 +166112,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -165919,7 +166166,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-latest": {
 			"id": "deepseek/deepseek-latest",
@@ -165951,7 +166199,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -166006,7 +166253,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-prover-v2-671b": {
 			"id": "deepseek/deepseek-prover-v2-671b",
@@ -166114,7 +166362,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -166169,7 +166416,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v3.2-speciale": {
 			"id": "deepseek/deepseek-v3.2-speciale",
@@ -166284,7 +166532,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -166339,7 +166586,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-flash": {
 			"id": "deepseek/deepseek-v4-flash",
@@ -166375,7 +166623,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -166430,7 +166677,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-flash-0731": {
 			"id": "deepseek/deepseek-v4-flash-0731",
@@ -166464,7 +166712,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -166519,7 +166766,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-flash-0731-cheaper": {
 			"id": "deepseek/deepseek-v4-flash-0731-cheaper",
@@ -166733,7 +166981,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -166788,7 +167035,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-flash-latest": {
 			"id": "deepseek/deepseek-v4-flash-latest",
@@ -166822,7 +167070,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -166877,7 +167124,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-flash:thinking": {
 			"id": "deepseek/deepseek-v4-flash:thinking",
@@ -166911,7 +167159,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -166966,7 +167213,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-pro": {
 			"id": "deepseek/deepseek-v4-pro",
@@ -167002,7 +167250,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -167057,7 +167304,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-pro-0813": {
 			"id": "deepseek/deepseek-v4-pro-0813",
@@ -167091,7 +167339,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -167146,7 +167393,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-pro-0813:thinking": {
 			"id": "deepseek/deepseek-v4-pro-0813:thinking",
@@ -167180,7 +167428,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -167235,7 +167482,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-pro-cheaper": {
 			"id": "deepseek/deepseek-v4-pro-cheaper",
@@ -167449,7 +167697,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -167504,7 +167751,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"dmind/dmind-1": {
 			"id": "dmind/dmind-1",
@@ -167776,7 +168024,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -167830,7 +168077,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"dots-studio/dots-3-note-preview:free": {
 			"id": "dots-studio/dots-3-note-preview:free",
@@ -171268,7 +171516,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -171323,7 +171570,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-flash-lite": {
 			"id": "gemini-2.5-flash-lite",
@@ -171361,7 +171609,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -171416,7 +171663,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-flash-lite-preview-06-17": {
 			"id": "gemini-2.5-flash-lite-preview-06-17",
@@ -171552,7 +171800,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -171607,7 +171854,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-flash-nothinking": {
 			"id": "gemini-2.5-flash-nothinking",
@@ -171917,7 +172165,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -171972,7 +172219,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-pro": {
 			"id": "gemini-2.5-pro",
@@ -172011,7 +172259,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -172066,7 +172313,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-pro-exp-03-25": {
 			"id": "gemini-2.5-pro-exp-03-25",
@@ -173170,7 +173418,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -173224,7 +173471,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-26b-a4b-it-chimerax": {
 			"id": "gemma-4-26b-a4b-it-chimerax",
@@ -173259,7 +173507,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -173313,7 +173560,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-26b-a4b-it-darksoul": {
 			"id": "gemma-4-26b-a4b-it-darksoul",
@@ -173348,7 +173596,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -173402,7 +173649,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-26b-a4b-it-luminous": {
 			"id": "gemma-4-26b-a4b-it-luminous",
@@ -173427,7 +173675,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -173481,7 +173728,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-26b-a4b-it-moonlight": {
 			"id": "gemma-4-26b-a4b-it-moonlight",
@@ -173516,7 +173764,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -173570,7 +173817,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-26b-a4b-it-musica": {
 			"id": "gemma-4-26b-a4b-it-musica",
@@ -173605,7 +173853,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -173659,7 +173906,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-26b-a4b-it-opusdistill": {
 			"id": "gemma-4-26b-a4b-it-opusdistill",
@@ -173694,7 +173942,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -173748,7 +173995,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-26b-a4b-it-shadowsiren": {
 			"id": "gemma-4-26b-a4b-it-shadowsiren",
@@ -173783,7 +174031,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -173837,7 +174084,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Gemma-4-26B-A4B-MeroMero": {
 			"id": "Gemma-4-26B-A4B-MeroMero",
@@ -173872,7 +174120,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -173926,7 +174173,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Gemma-4-26B-A4B-MeroMero:thinking": {
 			"id": "Gemma-4-26B-A4B-MeroMero:thinking",
@@ -173961,7 +174209,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -174015,7 +174262,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-26b-a4b-uncensored": {
 			"id": "gemma-4-26b-a4b-uncensored",
@@ -174050,7 +174298,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -174104,7 +174351,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-26b-a4b-uncensored:thinking": {
 			"id": "gemma-4-26b-a4b-uncensored:thinking",
@@ -174139,7 +174387,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -174193,7 +174440,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Gemma-4-31B-Agares-v1": {
 			"id": "Gemma-4-31B-Agares-v1",
@@ -174468,7 +174716,6 @@
 				"revision": "4.6.0"
 			},
 			"requiresGlyphTokenization": true,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -174522,7 +174769,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Gemma-4-31B-Cognitive-Unshackled": {
 			"id": "Gemma-4-31B-Cognitive-Unshackled",
@@ -174557,7 +174805,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -174611,7 +174858,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Gemma-4-31B-Dark-Gemistry": {
 			"id": "Gemma-4-31B-Dark-Gemistry",
@@ -174725,7 +174973,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -174779,7 +175026,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-31B-Fabled": {
 			"id": "gemma-4-31B-Fabled",
@@ -175130,7 +175378,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -175184,7 +175431,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Gemma-4-31B-Gembrain": {
 			"id": "Gemma-4-31B-Gembrain",
@@ -176009,7 +176257,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -176063,7 +176310,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-31b-it-fabled": {
 			"id": "gemma-4-31b-it-fabled",
@@ -176098,7 +176346,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -176152,7 +176399,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-31b-it-garnet": {
 			"id": "gemma-4-31b-it-garnet",
@@ -176187,7 +176435,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -176241,7 +176488,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-31b-it-gembrain": {
 			"id": "gemma-4-31b-it-gembrain",
@@ -176276,7 +176524,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -176330,7 +176577,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-31b-it-gemsicle": {
 			"id": "gemma-4-31b-it-gemsicle",
@@ -176365,7 +176613,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -176419,7 +176666,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-31b-it-isometry": {
 			"id": "gemma-4-31b-it-isometry",
@@ -176454,7 +176702,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -176508,7 +176755,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-31b-it-novelist": {
 			"id": "gemma-4-31b-it-novelist",
@@ -176543,7 +176791,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -176597,7 +176844,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-31B-K1-v5": {
 			"id": "gemma-4-31B-K1-v5",
@@ -177264,7 +177512,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -177318,7 +177565,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Gemma-4-31B-MeroMero-v2:thinking": {
 			"id": "Gemma-4-31B-MeroMero-v2:thinking",
@@ -177353,7 +177601,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -177407,7 +177654,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Gemma-4-31B-Musica-v1": {
 			"id": "Gemma-4-31B-Musica-v1",
@@ -177679,7 +177927,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -177733,7 +177980,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Gemma-4-31B-SDFT-Heretic-RP": {
 			"id": "Gemma-4-31B-SDFT-Heretic-RP",
@@ -177995,7 +178243,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -178049,7 +178296,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemma-4-e4b-it": {
 			"id": "gemma-4-e4b-it",
@@ -178074,7 +178322,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -178128,7 +178375,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-4": {
 			"id": "glm-4",
@@ -179536,7 +179784,6 @@
 				"revision": "4.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -179590,7 +179837,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-4.7-flash-heretic": {
 			"id": "glm-4.7-flash-heretic",
@@ -179697,7 +179945,6 @@
 				"revision": "1.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -179751,7 +179998,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-z1-airx": {
 			"id": "glm-z1-airx",
@@ -179777,7 +180025,6 @@
 				"revision": "1.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -179831,7 +180078,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-zero-preview": {
 			"id": "glm-zero-preview",
@@ -179947,7 +180195,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -180002,7 +180249,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.1-flash-lite": {
 			"id": "google/gemini-3.1-flash-lite",
@@ -180039,7 +180287,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -180094,7 +180341,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.1-flash-lite-preview": {
 			"id": "google/gemini-3.1-flash-lite-preview",
@@ -180216,7 +180464,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -180271,7 +180518,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.1-pro-preview-customtools": {
 			"id": "google/gemini-3.1-pro-preview-customtools",
@@ -180306,7 +180554,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -180361,7 +180608,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.1-pro-preview-high": {
 			"id": "google/gemini-3.1-pro-preview-high",
@@ -180400,7 +180648,6 @@
 				"logicalId": "google/gemini-3.1-pro-preview"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -180455,7 +180702,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.1-pro-preview-low": {
 			"id": "google/gemini-3.1-pro-preview-low",
@@ -180494,7 +180742,6 @@
 				"logicalId": "google/gemini-3.1-pro-preview"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -180549,7 +180796,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.5-flash": {
 			"id": "google/gemini-3.5-flash",
@@ -180588,7 +180836,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -180643,7 +180890,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.5-flash-lite": {
 			"id": "google/gemini-3.5-flash-lite",
@@ -180682,7 +180930,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -180737,7 +180984,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.6-flash": {
 			"id": "google/gemini-3.6-flash",
@@ -180776,7 +181024,6 @@
 				"revision": "3.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -180831,7 +181078,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.7-flash": {
 			"id": "google/gemini-3.7-flash",
@@ -180870,7 +181118,6 @@
 				"revision": "3.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -180925,7 +181172,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.8-flash": {
 			"id": "google/gemini-3.8-flash",
@@ -180964,7 +181212,6 @@
 				"revision": "3.8.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -181019,7 +181266,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-flash-1.5": {
 			"id": "google/gemini-flash-1.5",
@@ -181137,7 +181385,6 @@
 				"family": "flash"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -181192,7 +181439,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-flash-lite-latest": {
 			"id": "google/gemini-flash-lite-latest",
@@ -181228,7 +181476,6 @@
 				"family": "lite"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -181283,7 +181530,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-pro-latest": {
 			"id": "google/gemini-pro-latest",
@@ -181319,7 +181567,6 @@
 				"family": "pro"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -181374,7 +181621,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemma-4-26b-a4b-it": {
 			"id": "google/gemma-4-26b-a4b-it",
@@ -181409,7 +181657,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -181463,7 +181710,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemma-4-26b-a4b-it-chimerax": {
 			"id": "google/gemma-4-26b-a4b-it-chimerax",
@@ -182111,7 +182359,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -182165,7 +182412,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemma-4-26b-a4b-uncensored": {
 			"id": "google/gemma-4-26b-a4b-uncensored",
@@ -182378,7 +182626,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -182432,7 +182679,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemma-4-31b-it-darkidol": {
 			"id": "google/gemma-4-31b-it-darkidol",
@@ -183080,7 +183328,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -183134,7 +183381,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"grok-3-beta": {
 			"id": "grok-3-beta",
@@ -183577,7 +183825,6 @@
 				"logicalId": "hermes"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -183631,7 +183878,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"hermes-low": {
 			"id": "hermes-low",
@@ -183667,7 +183915,6 @@
 				"logicalId": "hermes"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -183721,7 +183968,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"hermes-medium": {
 			"id": "hermes-medium",
@@ -183757,7 +184005,6 @@
 				"logicalId": "hermes"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -183811,7 +184058,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"holo3-35b-a3b": {
 			"id": "holo3-35b-a3b",
@@ -183846,7 +184094,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -183900,7 +184147,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"holo3-35b-a3b:thinking": {
 			"id": "holo3-35b-a3b:thinking",
@@ -183935,7 +184183,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -183989,7 +184236,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"huihui-ai/DeepSeek-R1-Distill-Llama-70B-abliterated": {
 			"id": "huihui-ai/DeepSeek-R1-Distill-Llama-70B-abliterated",
@@ -184574,7 +184822,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -184628,7 +184875,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"ibm-granite/granite-4.2-8b": {
 			"id": "ibm-granite/granite-4.2-8b",
@@ -184664,7 +184912,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -184718,7 +184965,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"inception/mercury-2.5-preview": {
 			"id": "inception/mercury-2.5-preview",
@@ -184752,7 +185000,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -184806,7 +185053,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"inclusionai/ling-2.6-1t": {
 			"id": "inclusionai/ling-2.6-1t",
@@ -184988,7 +185236,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -185042,7 +185289,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"inclusionai/ling-3.0-flash:thinking": {
 			"id": "inclusionai/ling-3.0-flash:thinking",
@@ -185076,7 +185324,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -185130,7 +185377,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"inclusionai/ling-3.0-tiny": {
 			"id": "inclusionai/ling-3.0-tiny",
@@ -186447,7 +186695,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -186502,7 +186749,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-thinking-preview": {
 			"id": "kimi-thinking-preview",
@@ -187414,7 +187662,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -187468,7 +187715,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Llama-3.3-70B-Anthrobomination": {
 			"id": "Llama-3.3-70B-Anthrobomination",
@@ -191013,7 +191261,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -191067,7 +191314,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"longcat-2.0:thinking": {
 			"id": "longcat-2.0:thinking",
@@ -191101,7 +191349,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -191155,7 +191402,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Magistral-Small-2506": {
 			"id": "Magistral-Small-2506",
@@ -191744,7 +191992,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -191798,7 +192045,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mercury-coder-small": {
 			"id": "mercury-coder-small",
@@ -192141,7 +192389,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -192195,7 +192442,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta-llama/llama-4-maverick": {
 			"id": "meta-llama/llama-4-maverick",
@@ -192223,7 +192471,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -192277,7 +192524,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta-llama/llama-4-scout": {
 			"id": "meta-llama/llama-4-scout",
@@ -192305,7 +192553,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -192359,7 +192606,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta/muse-glimmer-30b": {
 			"id": "meta/muse-glimmer-30b",
@@ -192394,7 +192642,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -192448,7 +192695,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta/muse-spark-1.1": {
 			"id": "meta/muse-spark-1.1",
@@ -192581,7 +192829,6 @@
 				"revision": "1.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -192635,7 +192882,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta/muse-spark-1.2-contributor": {
 			"id": "meta/muse-spark-1.2-contributor",
@@ -192672,7 +192920,6 @@
 				"revision": "1.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -192726,7 +192973,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta/muse-spark-1.3": {
 			"id": "meta/muse-spark-1.3",
@@ -192764,7 +193012,6 @@
 				"revision": "1.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -192818,7 +193065,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta/muse-spark-1.3-contributor": {
 			"id": "meta/muse-spark-1.3-contributor",
@@ -192855,7 +193103,6 @@
 				"revision": "1.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -192909,7 +193156,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"microsoft/MAI-DS-R1-FP8": {
 			"id": "microsoft/MAI-DS-R1-FP8",
@@ -193352,7 +193600,6 @@
 				"class": "minimax"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -193406,7 +193653,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m2-her": {
 			"id": "minimax/minimax-m2-her",
@@ -193522,7 +193770,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -193576,7 +193823,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m2.5": {
 			"id": "minimax/minimax-m2.5",
@@ -193612,7 +193860,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -193666,7 +193913,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m2.7": {
 			"id": "minimax/minimax-m2.7",
@@ -193702,7 +193950,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -193756,7 +194003,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m2.7-turbo": {
 			"id": "minimax/minimax-m2.7-turbo",
@@ -193790,7 +194038,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -193844,7 +194091,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
@@ -193872,7 +194120,6 @@
 				"family": "m3"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -193926,7 +194173,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m3:thinking": {
 			"id": "minimax/minimax-m3:thinking",
@@ -193962,7 +194210,6 @@
 				"family": "m3"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -194016,7 +194263,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMaxAI/MiniMax-M1-80k": {
 			"id": "MiniMaxAI/MiniMax-M1-80k",
@@ -194358,7 +194606,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -194412,7 +194659,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral-code-latest": {
 			"id": "mistral-code-latest",
@@ -194437,7 +194685,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -194491,7 +194738,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Mistral-Nemo-12B-Instruct-2407": {
 			"id": "Mistral-Nemo-12B-Instruct-2407",
@@ -194689,7 +194937,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -194743,7 +194990,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral/mistral-medium-3.5:thinking": {
 			"id": "mistral/mistral-medium-3.5:thinking",
@@ -194779,7 +195027,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -194833,7 +195080,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral/mistral-vibe-cli-latest": {
 			"id": "mistral/mistral-vibe-cli-latest",
@@ -196085,7 +196333,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -196139,7 +196386,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-small-4-119b-2603:thinking": {
 			"id": "mistralai/mistral-small-4-119b-2603:thinking",
@@ -196175,7 +196423,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -196229,7 +196476,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-small-creative": {
 			"id": "mistralai/mistral-small-creative",
@@ -196735,7 +196983,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -196790,7 +197037,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2-instruct-0711": {
 			"id": "moonshotai/kimi-k2-instruct-0711",
@@ -196816,7 +197064,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -196871,7 +197118,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/Kimi-K2-Instruct-0905": {
 			"id": "moonshotai/Kimi-K2-Instruct-0905",
@@ -196897,7 +197145,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -196952,7 +197199,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2-thinking": {
 			"id": "moonshotai/kimi-k2-thinking",
@@ -196993,7 +197241,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -197048,7 +197295,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2-thinking-original": {
 			"id": "moonshotai/kimi-k2-thinking-original",
@@ -197240,7 +197488,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -197295,7 +197542,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2.5:thinking": {
 			"id": "moonshotai/kimi-k2.5:thinking",
@@ -197332,7 +197580,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -197387,7 +197634,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2.6": {
 			"id": "moonshotai/kimi-k2.6",
@@ -197416,7 +197664,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -197471,7 +197718,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2.6:thinking": {
 			"id": "moonshotai/kimi-k2.6:thinking",
@@ -197508,7 +197756,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -197564,7 +197811,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2.7-code": {
 			"id": "moonshotai/kimi-k2.7-code",
@@ -197603,7 +197851,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -197658,7 +197905,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2.7-code-highspeed": {
 			"id": "moonshotai/kimi-k2.7-code-highspeed",
@@ -197695,7 +197943,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -197750,7 +197997,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k3": {
 			"id": "moonshotai/kimi-k3",
@@ -197792,7 +198040,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -197852,7 +198099,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-latest": {
 			"id": "moonshotai/kimi-latest",
@@ -197888,7 +198136,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -197943,7 +198190,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nano-gpt-help": {
 			"id": "nano-gpt-help",
@@ -198056,7 +198304,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -198110,7 +198357,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nanogpt/coding-router:high": {
 			"id": "nanogpt/coding-router:high",
@@ -198144,7 +198392,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -198198,7 +198445,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nanogpt/coding-router:low": {
 			"id": "nanogpt/coding-router:low",
@@ -198232,7 +198480,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -198286,7 +198533,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nanogpt/coding-router:max": {
 			"id": "nanogpt/coding-router:max",
@@ -198320,7 +198568,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -198374,7 +198621,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nanogpt/coding-router:medium": {
 			"id": "nanogpt/coding-router:medium",
@@ -198408,7 +198656,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -198462,7 +198709,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"NeverSleep/Llama-3-Lumimaid-70B-v0.1": {
 			"id": "NeverSleep/Llama-3-Lumimaid-70B-v0.1",
@@ -198738,7 +198986,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -198792,7 +199039,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nex-agi/nex-n2-pro": {
 			"id": "nex-agi/nex-n2-pro",
@@ -198829,7 +199077,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -198883,7 +199130,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nothingiisreal/L3.1-70B-Celeste-V0.1-BF16": {
 			"id": "nothingiisreal/L3.1-70B-Celeste-V0.1-BF16",
@@ -199146,7 +199394,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -199200,7 +199447,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nousresearch/hermes-4-405b": {
 			"id": "nousresearch/hermes-4-405b",
@@ -199825,7 +200073,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -199879,7 +200126,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3-super-120b-a12b": {
 			"id": "nvidia/nemotron-3-super-120b-a12b",
@@ -200091,7 +200339,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -200145,7 +200392,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3-ultra-550b-a55b:thinking": {
 			"id": "nvidia/nemotron-3-ultra-550b-a55b:thinking",
@@ -200179,7 +200427,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -200233,7 +200480,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3.5-lightning": {
 			"id": "nvidia/nemotron-3.5-lightning",
@@ -200269,7 +200517,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -200323,7 +200570,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3.5-lightning:thinking": {
 			"id": "nvidia/nemotron-3.5-lightning:thinking",
@@ -200357,7 +200605,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -200411,7 +200658,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-TEE": {
 			"id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-TEE",
@@ -200936,7 +201184,6 @@
 				"revision": "4.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -200990,7 +201237,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4.1-mini": {
 			"id": "openai/gpt-4.1-mini",
@@ -201186,7 +201434,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -201240,7 +201487,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4o-2024-08-06": {
 			"id": "openai/gpt-4o-2024-08-06",
@@ -201268,7 +201516,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -201322,7 +201569,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4o-2024-11-20": {
 			"id": "openai/gpt-4o-2024-11-20",
@@ -201348,7 +201596,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -201402,7 +201649,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4o-mini": {
 			"id": "openai/gpt-4o-mini",
@@ -201683,7 +201931,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -201737,7 +201984,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5-chat-latest": {
 			"id": "openai/gpt-5-chat-latest",
@@ -202224,7 +202472,6 @@
 				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -202278,7 +202525,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.1-2025-11-13": {
 			"id": "openai/gpt-5.1-2025-11-13",
@@ -202313,7 +202561,6 @@
 				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -202367,7 +202614,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.1-chat": {
 			"id": "openai/gpt-5.1-chat",
@@ -202660,7 +202908,6 @@
 				"logicalId": "openai/gpt-5.1-codex"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -202714,7 +202961,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.1-codex-mini": {
 			"id": "openai/gpt-5.1-codex-mini",
@@ -202842,7 +203090,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -202896,7 +203143,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.2-chat": {
 			"id": "openai/gpt-5.2-chat",
@@ -203015,7 +203263,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -203069,7 +203316,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.2-pro": {
 			"id": "openai/gpt-5.2-pro",
@@ -203279,7 +203527,6 @@
 				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -203333,7 +203580,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.4": {
 			"id": "openai/gpt-5.4",
@@ -203371,7 +203619,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -203425,7 +203672,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.4-mini": {
 			"id": "openai/gpt-5.4-mini",
@@ -203463,7 +203711,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -203517,7 +203764,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.4-nano": {
 			"id": "openai/gpt-5.4-nano",
@@ -203555,7 +203803,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -203609,7 +203856,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.4-pro": {
 			"id": "openai/gpt-5.4-pro",
@@ -203739,7 +203987,6 @@
 				"revision": "5.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -203793,7 +204040,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-luna": {
 			"id": "openai/gpt-5.6-luna",
@@ -203832,7 +204080,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -203886,7 +204133,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-luna-pro": {
 			"id": "openai/gpt-5.6-luna-pro",
@@ -203923,7 +204171,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -203977,7 +204224,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-sol": {
 			"id": "openai/gpt-5.6-sol",
@@ -204016,7 +204264,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -204070,7 +204317,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-sol-pro": {
 			"id": "openai/gpt-5.6-sol-pro",
@@ -204107,7 +204355,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -204161,7 +204408,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-terra": {
 			"id": "openai/gpt-5.6-terra",
@@ -204200,7 +204448,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -204254,7 +204501,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-terra-pro": {
 			"id": "openai/gpt-5.6-terra-pro",
@@ -204291,7 +204539,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -204345,7 +204592,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-chat-latest": {
 			"id": "openai/gpt-chat-latest",
@@ -204381,7 +204629,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -204435,7 +204682,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-latest": {
 			"id": "openai/gpt-latest",
@@ -204471,7 +204719,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -204525,7 +204772,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-oss-120b": {
 			"id": "openai/gpt-oss-120b",
@@ -204560,7 +204808,6 @@
 				"family": "120b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -204614,7 +204861,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-oss-20b": {
 			"id": "openai/gpt-oss-20b",
@@ -204649,7 +204897,6 @@
 				"family": "20b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -204703,7 +204950,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-oss-safeguard-20b": {
 			"id": "openai/gpt-oss-safeguard-20b",
@@ -205283,7 +205531,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -205337,7 +205584,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o3-mini-high": {
 			"id": "openai/o3-mini-high",
@@ -205378,7 +205626,6 @@
 				"logicalId": "openai/o3-mini"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -205432,7 +205679,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o3-mini-low": {
 			"id": "openai/o3-mini-low",
@@ -205473,7 +205721,6 @@
 				"logicalId": "openai/o3-mini"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -205527,7 +205774,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o3-pro-2025-06-10": {
 			"id": "openai/o3-pro-2025-06-10",
@@ -205564,7 +205812,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -205618,7 +205865,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o4-mini": {
 			"id": "openai/o4-mini",
@@ -205657,7 +205905,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -205711,7 +205958,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o4-mini-deep-research": {
 			"id": "openai/o4-mini-deep-research",
@@ -205845,7 +206093,6 @@
 				"logicalId": "openai/o4-mini"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -205899,7 +206146,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"ornith-ai/ornith-1.5-35b-a3b": {
 			"id": "ornith-ai/ornith-1.5-35b-a3b",
@@ -205934,7 +206182,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -205988,7 +206235,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"ornith-ai/ornith-1.5-35b-a3b:thinking": {
 			"id": "ornith-ai/ornith-1.5-35b-a3b:thinking",
@@ -206023,7 +206271,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -206077,7 +206324,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"ornith-ai/ornith-1.5-397b": {
 			"id": "ornith-ai/ornith-1.5-397b",
@@ -206290,7 +206538,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -206344,7 +206591,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"ornith-ai/ornith-1.5-9b:thinking": {
 			"id": "ornith-ai/ornith-1.5-9b:thinking",
@@ -206379,7 +206627,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -206433,7 +206680,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"owl": {
 			"id": "owl",
@@ -207099,7 +207347,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -207153,7 +207400,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"poolside/laguna-m.1": {
 			"id": "poolside/laguna-m.1",
@@ -207276,7 +207524,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -207330,7 +207577,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"poolside/laguna-s-2.1:thinking": {
 			"id": "poolside/laguna-s-2.1:thinking",
@@ -207364,7 +207612,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -207418,7 +207665,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"poolside/laguna-xs.2": {
 			"id": "poolside/laguna-xs.2",
@@ -207615,7 +207863,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -207669,7 +207916,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen-long": {
 			"id": "qwen-long",
@@ -208010,7 +208258,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -208064,7 +208311,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen2.5-Coder-32B-Instruct": {
 			"id": "Qwen/Qwen2.5-Coder-32B-Instruct",
@@ -208259,7 +208507,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -208313,7 +208560,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-235B-A22B": {
 			"id": "Qwen/Qwen3-235B-A22B",
@@ -208429,7 +208677,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -208483,7 +208730,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-235B-A22B-Instruct-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
@@ -208750,7 +208998,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -208804,7 +209051,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-235B-A22B-Thinking-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Thinking-2507",
@@ -209008,7 +209256,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -209062,7 +209309,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-8B": {
 			"id": "Qwen/Qwen3-8B",
@@ -209168,7 +209416,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -209222,7 +209469,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-coder-flash": {
 			"id": "qwen/qwen3-coder-flash",
@@ -209331,7 +209579,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -209385,7 +209632,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-coder-plus": {
 			"id": "qwen/qwen3-coder-plus",
@@ -209576,7 +209824,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -209630,7 +209877,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-Next-80B-A3B-Instruct": {
 			"id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -209935,7 +210183,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -209989,7 +210236,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.5-9b": {
 			"id": "qwen/qwen3.5-9b",
@@ -210027,7 +210275,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -210081,7 +210328,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.5-plus": {
 			"id": "qwen/qwen3.5-plus",
@@ -210208,7 +210456,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -210262,7 +210509,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3.6-35B-A3B": {
 			"id": "Qwen/Qwen3.6-35B-A3B",
@@ -210391,7 +210639,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -210445,7 +210692,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.6-35b-a3b-uncensored:thinking": {
 			"id": "qwen/qwen3.6-35b-a3b-uncensored:thinking",
@@ -210481,7 +210729,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -210535,7 +210782,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/Qwen3.6-35B-A3B:thinking": {
 			"id": "qwen/Qwen3.6-35B-A3B:thinking",
@@ -210571,7 +210819,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -210625,7 +210872,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.8-2.4t-a95b": {
 			"id": "qwen/qwen3.8-2.4t-a95b",
@@ -210654,7 +210902,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -210708,7 +210955,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.8-27b-fable": {
 			"id": "qwen/qwen3.8-27b-fable",
@@ -210744,7 +210992,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -210798,7 +211045,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.8-27b-obliterated": {
 			"id": "qwen/qwen3.8-27b-obliterated",
@@ -210834,7 +211082,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -210888,7 +211135,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.8-27b-obliterated:thinking": {
 			"id": "qwen/qwen3.8-27b-obliterated:thinking",
@@ -210924,7 +211172,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -210978,7 +211225,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.8-27b-uncensored": {
 			"id": "qwen/qwen3.8-27b-uncensored",
@@ -211014,7 +211262,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -211068,7 +211315,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.8-27b-uncensored:thinking": {
 			"id": "qwen/qwen3.8-27b-uncensored:thinking",
@@ -211104,7 +211352,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -211158,7 +211405,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwq-32b-preview": {
 			"id": "qwen/qwq-32b-preview",
@@ -211507,7 +211755,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -211561,7 +211808,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3-max-2026-01-23": {
 			"id": "qwen3-max-2026-01-23",
@@ -211842,7 +212090,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -211896,7 +212143,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.5-122b-a10b": {
 			"id": "qwen3.5-122b-a10b",
@@ -211924,7 +212172,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -211978,7 +212225,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.5-122b-a10b:thinking": {
 			"id": "qwen3.5-122b-a10b:thinking",
@@ -212013,7 +212261,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -212067,7 +212314,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.5-27b": {
 			"id": "qwen3.5-27b",
@@ -212096,7 +212344,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -212150,7 +212397,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen3.5-27B-Anko": {
 			"id": "Qwen3.5-27B-Anko",
@@ -212753,7 +213001,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -212807,7 +213054,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen3.5-27B-BlueStar-v3-Derestricted-Lite": {
 			"id": "Qwen3.5-27B-BlueStar-v3-Derestricted-Lite",
@@ -215032,7 +215280,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -215086,7 +215333,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen3.5-27B-Queen-Derestricted-Lite": {
 			"id": "Qwen3.5-27B-Queen-Derestricted-Lite",
@@ -215851,7 +216099,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -215905,7 +216152,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.5-2b": {
 			"id": "qwen3.5-2b",
@@ -215942,7 +216190,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -215996,7 +216243,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.5-35b-a3b": {
 			"id": "qwen3.5-35b-a3b",
@@ -216025,7 +216273,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -216079,7 +216326,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.5-35b-a3b:thinking": {
 			"id": "qwen3.5-35b-a3b:thinking",
@@ -216115,7 +216363,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -216169,7 +216416,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.5-4b": {
 			"id": "qwen3.5-4b",
@@ -216207,7 +216455,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -216261,7 +216508,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.5-flash": {
 			"id": "qwen3.5-flash",
@@ -216630,7 +216878,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -216684,7 +216931,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.7-flash:thinking": {
 			"id": "qwen3.7-flash:thinking",
@@ -216720,7 +216968,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -216774,7 +217021,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.7-max": {
 			"id": "qwen3.7-max",
@@ -216811,7 +217059,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -216865,7 +217112,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.7-max:thinking": {
 			"id": "qwen3.7-max:thinking",
@@ -216900,7 +217148,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -216954,7 +217201,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.7-plus": {
 			"id": "qwen3.7-plus",
@@ -216992,7 +217240,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -217046,7 +217293,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.7-plus:thinking": {
 			"id": "qwen3.7-plus:thinking",
@@ -217082,7 +217330,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -217136,7 +217383,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.8-27b": {
 			"id": "qwen3.8-27b",
@@ -217174,7 +217422,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -217228,7 +217475,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.8-27b:thinking": {
 			"id": "qwen3.8-27b:thinking",
@@ -217264,7 +217512,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -217318,7 +217565,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.8-max": {
 			"id": "qwen3.8-max",
@@ -217347,7 +217595,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -217401,7 +217648,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.8-max-preview": {
 			"id": "qwen3.8-max-preview",
@@ -217527,7 +217775,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -217581,7 +217828,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwq-32b": {
 			"id": "qwq-32b",
@@ -218011,7 +218259,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -218065,7 +218312,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"sakana/fugu-ultra-v1.1": {
 			"id": "sakana/fugu-ultra-v1.1",
@@ -218100,7 +218348,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -218154,7 +218401,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Salesforce/Llama-xLAM-2-70b-fc-r": {
 			"id": "Salesforce/Llama-xLAM-2-70b-fc-r",
@@ -218585,7 +218833,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -218639,7 +218886,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"sarvam-30b": {
 			"id": "sarvam-30b",
@@ -220708,7 +220956,6 @@
 				"family": "step"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -220762,7 +221009,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"study_gpt-chatgpt-4o-latest": {
 			"id": "study_gpt-chatgpt-4o-latest",
@@ -221123,7 +221371,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -221178,7 +221425,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"TEE/deepseek-v4-pro": {
 			"id": "TEE/deepseek-v4-pro",
@@ -221641,7 +221889,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -221695,7 +221942,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"TEE/gemma-4-31b-it": {
 			"id": "TEE/gemma-4-31b-it",
@@ -221729,7 +221977,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -221783,7 +222030,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"TEE/gemma4-31b": {
 			"id": "TEE/gemma4-31b",
@@ -221808,7 +222056,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -221862,7 +222109,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"TEE/gemma4-31b:thinking": {
 			"id": "TEE/gemma4-31b:thinking",
@@ -221897,7 +222145,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -221951,7 +222198,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"TEE/glm-4.6": {
 			"id": "TEE/glm-4.6",
@@ -222418,7 +222666,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -222472,7 +222719,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"TEE/glm-5.2": {
 			"id": "TEE/glm-5.2",
@@ -222510,7 +222758,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -222564,7 +222811,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"TEE/glm-5.2:thinking": {
 			"id": "TEE/glm-5.2:thinking",
@@ -222600,7 +222848,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -222654,7 +222901,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"TEE/glm-5.3": {
 			"id": "TEE/glm-5.3",
@@ -222692,7 +222940,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -222746,7 +222993,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"TEE/glm-5.3-flash": {
 			"id": "TEE/glm-5.3-flash",
@@ -222786,7 +223034,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -222840,7 +223087,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"TEE/gpt-oss-120b": {
 			"id": "TEE/gpt-oss-120b",
@@ -223213,7 +223461,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -223268,7 +223515,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"TEE/kimi-k2.7-code": {
 			"id": "TEE/kimi-k2.7-code",
@@ -223307,7 +223555,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -223362,7 +223609,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"TEE/kimi-k3": {
 			"id": "TEE/kimi-k3",
@@ -223404,7 +223652,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -223464,7 +223711,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"TEE/llama3-3-70b": {
 			"id": "TEE/llama3-3-70b",
@@ -223831,7 +224079,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -223885,7 +224132,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"TEE/qwen2.5-vl-72b-instruct": {
 			"id": "TEE/qwen2.5-vl-72b-instruct",
@@ -224656,7 +224904,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -224710,7 +224957,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"TEE/qwen3.8-27b": {
 			"id": "TEE/qwen3.8-27b",
@@ -224748,7 +224996,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -224802,7 +225049,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"tencent/Hunyuan-MT-7B": {
 			"id": "tencent/Hunyuan-MT-7B",
@@ -224917,7 +225165,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -224971,7 +225218,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"tencent/hy3-preview": {
 			"id": "tencent/hy3-preview",
@@ -225095,7 +225343,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -225149,7 +225396,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"TheDrummer/Anubis-70B-v1": {
 			"id": "TheDrummer/Anubis-70B-v1",
@@ -226045,7 +226293,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -226099,7 +226346,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"thinkingmachines/Inkling-Small": {
 			"id": "thinkingmachines/Inkling-Small",
@@ -226126,7 +226374,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -226180,7 +226427,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"thinkingmachines/Inkling-Small:thinking": {
 			"id": "thinkingmachines/Inkling-Small:thinking",
@@ -226215,7 +226463,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -226269,7 +226516,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"thinkingmachines/inkling:thinking": {
 			"id": "thinkingmachines/inkling:thinking",
@@ -226304,7 +226552,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -226358,7 +226605,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"THUDM/GLM-4-32B-0414": {
 			"id": "THUDM/GLM-4-32B-0414",
@@ -227679,7 +227927,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -227733,7 +227980,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"upstage/solar-pro4:thinking": {
 			"id": "upstage/solar-pro4:thinking",
@@ -227767,7 +228015,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -227821,7 +228068,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"v0-1.0-md": {
 			"id": "v0-1.0-md",
@@ -228610,7 +228858,6 @@
 				"revision": "4.20.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -228665,7 +228912,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"x-ai/grok-4.20-beta-non-reasoning": {
 			"id": "x-ai/grok-4.20-beta-non-reasoning",
@@ -228866,7 +229114,6 @@
 				"revision": "4.20.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -228921,7 +229168,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"x-ai/grok-4.20-multi-agent-beta": {
 			"id": "x-ai/grok-4.20-multi-agent-beta",
@@ -229042,7 +229290,6 @@
 				"revision": "4.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -229097,7 +229344,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"x-ai/grok-4.5": {
 			"id": "x-ai/grok-4.5",
@@ -229136,7 +229384,6 @@
 				"revision": "4.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -229191,7 +229438,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"x-ai/grok-4.6": {
 			"id": "x-ai/grok-4.6",
@@ -229230,7 +229478,6 @@
 				"revision": "4.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -229285,7 +229532,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"x-ai/grok-build-0.1": {
 			"id": "x-ai/grok-build-0.1",
@@ -229322,7 +229570,6 @@
 				"revision": "0.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -229377,7 +229624,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"x-ai/grok-code-fast-1": {
 			"id": "x-ai/grok-code-fast-1",
@@ -229505,7 +229753,6 @@
 				"family": "grok"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -229560,7 +229807,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xiaomi/mimo-v2-flash": {
 			"id": "xiaomi/mimo-v2-flash",
@@ -229978,7 +230226,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -230035,7 +230282,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xiaomi/mimo-v2.5-pro": {
 			"id": "xiaomi/mimo-v2.5-pro",
@@ -230070,7 +230318,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -230127,7 +230374,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xiaomi/mimo-v2.5-pro-crof": {
 			"id": "xiaomi/mimo-v2.5-pro-crof",
@@ -230160,7 +230408,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -230217,7 +230464,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xiaomi/mimo-v2.5-pro-crof:thinking": {
 			"id": "xiaomi/mimo-v2.5-pro-crof:thinking",
@@ -230250,7 +230498,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -230307,7 +230554,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xiaomi/mimo-v2.5-pro-ultraspeed": {
 			"id": "xiaomi/mimo-v2.5-pro-ultraspeed",
@@ -230423,7 +230671,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -230480,7 +230727,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xiaomi/mimo-v2.5:thinking": {
 			"id": "xiaomi/mimo-v2.5:thinking",
@@ -230514,7 +230762,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -230571,7 +230818,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"yi-large": {
 			"id": "yi-large",
@@ -230926,7 +231174,6 @@
 				"revision": "4.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -230980,7 +231227,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/GLM-4.5-Air:thinking": {
 			"id": "z-ai/GLM-4.5-Air:thinking",
@@ -231016,7 +231264,6 @@
 				"revision": "4.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -231070,7 +231317,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.5v": {
 			"id": "z-ai/glm-4.5v",
@@ -231200,7 +231448,6 @@
 				"revision": "4.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -231254,7 +231501,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.6-original": {
 			"id": "z-ai/glm-4.6-original",
@@ -231289,7 +231537,6 @@
 				"revision": "4.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -231343,7 +231590,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/GLM-4.6-turbo": {
 			"id": "z-ai/GLM-4.6-turbo",
@@ -231468,7 +231716,6 @@
 				"revision": "4.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -231522,7 +231769,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.6v": {
 			"id": "z-ai/glm-4.6v",
@@ -231810,7 +232058,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -231864,7 +232111,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.7-flash": {
 			"id": "z-ai/glm-4.7-flash",
@@ -231902,7 +232150,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -231956,7 +232203,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.7-flash-original": {
 			"id": "z-ai/glm-4.7-flash-original",
@@ -231992,7 +232240,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -232046,7 +232293,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.7-flash-original:thinking": {
 			"id": "z-ai/glm-4.7-flash-original:thinking",
@@ -232082,7 +232330,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -232136,7 +232383,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.7-flash:thinking": {
 			"id": "z-ai/glm-4.7-flash:thinking",
@@ -232172,7 +232420,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -232226,7 +232473,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.7-original": {
 			"id": "z-ai/glm-4.7-original",
@@ -232261,7 +232509,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -232315,7 +232562,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.7-original:thinking": {
 			"id": "z-ai/glm-4.7-original:thinking",
@@ -232350,7 +232598,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -232404,7 +232651,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.7:thinking": {
 			"id": "z-ai/glm-4.7:thinking",
@@ -232439,7 +232687,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -232493,7 +232740,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5": {
 			"id": "z-ai/glm-5",
@@ -232531,7 +232779,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -232585,7 +232832,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5-original": {
 			"id": "z-ai/glm-5-original",
@@ -232621,7 +232869,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -232675,7 +232922,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5-original:thinking": {
 			"id": "z-ai/glm-5-original:thinking",
@@ -232711,7 +232959,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -232765,7 +233012,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5-turbo": {
 			"id": "z-ai/glm-5-turbo",
@@ -232793,7 +233041,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -232847,7 +233094,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5:thinking": {
 			"id": "z-ai/glm-5:thinking",
@@ -232883,7 +233131,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -232937,7 +233184,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5.1": {
 			"id": "z-ai/glm-5.1",
@@ -232975,7 +233223,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -233029,7 +233276,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5.1:thinking": {
 			"id": "z-ai/glm-5.1:thinking",
@@ -233065,7 +233313,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -233119,7 +233366,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5.2": {
 			"id": "z-ai/glm-5.2",
@@ -233157,7 +233405,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -233211,7 +233458,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5.2:thinking": {
 			"id": "z-ai/glm-5.2:thinking",
@@ -233247,7 +233495,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -233301,7 +233548,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5.3": {
 			"id": "z-ai/glm-5.3",
@@ -233339,7 +233587,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -233393,7 +233640,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5.3-flash": {
 			"id": "z-ai/glm-5.3-flash",
@@ -233433,7 +233681,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -233487,7 +233734,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5.3-flash-uncensored": {
 			"id": "z-ai/glm-5.3-flash-uncensored",
@@ -233525,7 +233773,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -233579,7 +233826,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5.3:thinking": {
 			"id": "z-ai/glm-5.3:thinking",
@@ -233615,7 +233863,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -233669,7 +233916,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5v-turbo": {
 			"id": "z-ai/glm-5v-turbo",
@@ -233696,7 +233944,6 @@
 				"family": "vision"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -233750,7 +233997,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5v-turbo:thinking": {
 			"id": "z-ai/glm-5v-turbo:thinking",
@@ -233786,7 +234034,6 @@
 				"family": "vision"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -233840,7 +234087,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-latest": {
 			"id": "z-ai/glm-latest",
@@ -233874,7 +234122,6 @@
 				"class": "glm"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -233928,7 +234175,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/glm-4.5": {
 			"id": "zai-org/glm-4.5",
@@ -246766,7 +247014,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -246820,7 +247067,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"adept/fuyu-8b": {
 			"id": "adept/fuyu-8b",
@@ -247237,7 +247485,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -247291,7 +247538,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"databricks/dbrx-instruct": {
 			"id": "databricks/dbrx-instruct",
@@ -247837,7 +248085,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -247892,7 +248139,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/deepseek-v4-flash-0731": {
 			"id": "deepseek-ai/deepseek-v4-flash-0731",
@@ -247926,7 +248174,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -247981,7 +248228,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/deepseek-v4-pro": {
 			"id": "deepseek-ai/deepseek-v4-pro",
@@ -248017,7 +248265,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -248072,7 +248319,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/deepseek-v4-pro-0813": {
 			"id": "deepseek-ai/deepseek-v4-pro-0813",
@@ -248106,7 +248354,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -248161,7 +248408,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/codegemma-1.1-7b": {
 			"id": "google/codegemma-1.1-7b",
@@ -248497,7 +248745,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -248551,7 +248798,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemma-2b": {
 			"id": "google/gemma-2b",
@@ -248654,7 +248902,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -248708,7 +248955,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemma-3-1b-it": {
 			"id": "google/gemma-3-1b-it",
@@ -248891,7 +249139,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -248945,7 +249192,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemma-3n-e2b-it": {
 			"id": "google/gemma-3n-e2b-it",
@@ -248970,7 +249218,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -249024,7 +249271,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemma-3n-e4b-it": {
 			"id": "google/gemma-3n-e4b-it",
@@ -249049,7 +249297,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -249103,7 +249350,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
@@ -249138,7 +249386,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -249192,7 +249439,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/recurrentgemma-2b": {
 			"id": "google/recurrentgemma-2b",
@@ -249764,7 +250012,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -249818,7 +250065,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta/llama-3.1-8b-instruct": {
 			"id": "meta/llama-3.1-8b-instruct",
@@ -249843,7 +250091,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -249897,7 +250144,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta/llama-3.2-11b-vision-instruct": {
 			"id": "meta/llama-3.2-11b-vision-instruct",
@@ -249923,7 +250171,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -249977,7 +250224,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta/llama-3.2-1b-instruct": {
 			"id": "meta/llama-3.2-1b-instruct",
@@ -250002,7 +250250,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -250056,7 +250303,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta/llama-3.2-3b-instruct": {
 			"id": "meta/llama-3.2-3b-instruct",
@@ -250161,7 +250409,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -250215,7 +250462,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta/llama-3.3-70b-instruct": {
 			"id": "meta/llama-3.3-70b-instruct",
@@ -250240,7 +250488,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -250294,7 +250541,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta/llama-4-maverick-17b-128e-instruct": {
 			"id": "meta/llama-4-maverick-17b-128e-instruct",
@@ -250320,7 +250568,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -250374,7 +250621,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta/llama-4-scout-17b-16e-instruct": {
 			"id": "meta/llama-4-scout-17b-16e-instruct",
@@ -250805,7 +251053,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -250859,7 +251106,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"microsoft/kosmos-2": {
 			"id": "microsoft/kosmos-2",
@@ -251513,7 +251761,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -251567,7 +251814,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"microsoft/phi-4-multimodal-instruct": {
 			"id": "microsoft/phi-4-multimodal-instruct",
@@ -251945,7 +252193,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -251999,7 +252246,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimaxai/minimax-m3": {
 			"id": "minimaxai/minimax-m3",
@@ -252037,7 +252285,6 @@
 				"family": "m3"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -252091,7 +252338,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/codestral-22b-instruct-v0.1": {
 			"id": "mistralai/codestral-22b-instruct-v0.1",
@@ -252282,7 +252530,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -252336,7 +252583,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-7b-instruct-v0.3": {
 			"id": "mistralai/mistral-7b-instruct-v0.3",
@@ -252361,7 +252609,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -252415,7 +252662,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-7b-instruct-v03": {
 			"id": "mistralai/mistral-7b-instruct-v03",
@@ -252679,7 +252927,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -252733,7 +252980,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-medium-3.5-128b": {
 			"id": "mistralai/mistral-medium-3.5-128b",
@@ -252769,7 +253017,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -252823,7 +253070,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-nemotron": {
 			"id": "mistralai/mistral-nemotron",
@@ -252848,7 +253096,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -252902,7 +253149,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-small-3.1-24b-instruct-2503": {
 			"id": "mistralai/mistral-small-3.1-24b-instruct-2503",
@@ -253017,7 +253265,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -253071,7 +253318,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mixtral-8x22b-instruct": {
 			"id": "mistralai/mixtral-8x22b-instruct",
@@ -253096,7 +253344,6 @@
 				"family": "mixtral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -253150,7 +253397,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mixtral-8x22b-v0.1": {
 			"id": "mistralai/mixtral-8x22b-v0.1",
@@ -253255,7 +253503,6 @@
 				"family": "mixtral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -253309,7 +253556,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mixtral-8x7b-instruct-v0.1": {
 			"id": "mistralai/mixtral-8x7b-instruct-v0.1",
@@ -253495,7 +253743,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -253550,7 +253797,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2-thinking": {
 			"id": "moonshotai/kimi-k2-thinking",
@@ -253778,7 +254026,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -253834,7 +254081,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k3": {
 			"id": "moonshotai/kimi-k3",
@@ -253876,7 +254124,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -253936,7 +254183,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nv-mistralai/mistral-nemo-12b-instruct": {
 			"id": "nv-mistralai/mistral-nemo-12b-instruct",
@@ -254128,7 +254376,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -254182,7 +254429,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/embed-qa-4": {
 			"id": "nvidia/embed-qa-4",
@@ -254856,7 +255104,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -254910,7 +255157,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/llama-3.1-nemotron-nano-8b-v1": {
 			"id": "nvidia/llama-3.1-nemotron-nano-8b-v1",
@@ -254945,7 +255193,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -254999,7 +255246,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/llama-3.1-nemotron-nano-vl-8b-v1": {
 			"id": "nvidia/llama-3.1-nemotron-nano-vl-8b-v1",
@@ -255035,7 +255283,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -255089,7 +255336,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/llama-3.1-nemotron-safety-guard-8b-v3": {
 			"id": "nvidia/llama-3.1-nemotron-safety-guard-8b-v3",
@@ -255205,7 +255453,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -255259,7 +255506,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/llama-3.2-nemoretriever-1b-vlm-embed-v1": {
 			"id": "nvidia/llama-3.2-nemoretriever-1b-vlm-embed-v1",
@@ -255452,7 +255700,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -255506,7 +255753,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/llama-3.3-nemotron-super-49b-v1.5": {
 			"id": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
@@ -255541,7 +255789,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -255595,7 +255842,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/llama-nemotron-embed-1b-v2": {
 			"id": "nvidia/llama-nemotron-embed-1b-v2",
@@ -256101,7 +256349,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -256155,7 +256402,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3-nano-omni-30b-a3b-reasoning": {
 			"id": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
@@ -256193,7 +256441,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -256247,7 +256494,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3-super-120b-a12b": {
 			"id": "nvidia/nemotron-3-super-120b-a12b",
@@ -256281,7 +256529,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -256335,7 +256582,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3-ultra-550b-a55b": {
 			"id": "nvidia/nemotron-3-ultra-550b-a55b",
@@ -256369,7 +256617,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -256423,7 +256670,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3.5-content-safety": {
 			"id": "nvidia/nemotron-3.5-content-safety",
@@ -256535,7 +256783,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -256589,7 +256836,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-4-340b-instruct": {
 			"id": "nvidia/nemotron-4-340b-instruct",
@@ -256847,7 +257095,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -256901,7 +257148,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-nano-12b-v2-vl": {
 			"id": "nvidia/nemotron-nano-12b-v2-vl",
@@ -256936,7 +257184,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -256990,7 +257237,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-nano-3-30b-a3b": {
 			"id": "nvidia/nemotron-nano-3-30b-a3b",
@@ -257170,7 +257418,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -257224,7 +257471,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/neva-22b": {
 			"id": "nvidia/neva-22b",
@@ -257728,7 +257976,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -257782,7 +258029,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/riva-translate-4b-instruct": {
 			"id": "nvidia/riva-translate-4b-instruct",
@@ -258051,7 +258299,6 @@
 				"family": "120b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -258105,7 +258352,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-oss-20b": {
 			"id": "openai/gpt-oss-20b",
@@ -258140,7 +258388,6 @@
 				"family": "20b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -258194,7 +258441,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"poolside/laguna-xs-2.1": {
 			"id": "poolside/laguna-xs-2.1",
@@ -258228,7 +258476,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -258282,7 +258529,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen2.5-coder-32b-instruct": {
 			"id": "qwen/qwen2.5-coder-32b-instruct",
@@ -258308,7 +258556,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -258362,7 +258609,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen2.5-coder-7b-instruct": {
 			"id": "qwen/qwen2.5-coder-7b-instruct",
@@ -258557,7 +258805,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -258611,7 +258858,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-next-80b-a3b-instruct": {
 			"id": "qwen/qwen3-next-80b-a3b-instruct",
@@ -258639,7 +258887,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -258693,7 +258940,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-next-80b-a3b-thinking": {
 			"id": "qwen/qwen3-next-80b-a3b-thinking",
@@ -258823,7 +259071,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -258877,7 +259124,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.5-397b-a17b": {
 			"id": "qwen/qwen3.5-397b-a17b",
@@ -258915,7 +259163,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -258969,7 +259216,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"sarvamai/sarvam-m": {
 			"id": "sarvamai/sarvam-m",
@@ -258994,7 +259242,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -259048,7 +259295,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"snowflake/arctic-embed-l": {
 			"id": "snowflake/arctic-embed-l",
@@ -259163,7 +259411,6 @@
 				"family": "step"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -259217,7 +259464,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"stepfun-ai/step-3.7-flash": {
 			"id": "stepfun-ai/step-3.7-flash",
@@ -259255,7 +259503,6 @@
 				"family": "step"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -259309,7 +259556,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"stockmark/stockmark-2-100b-instruct": {
 			"id": "stockmark/stockmark-2-100b-instruct",
@@ -259424,7 +259672,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -259478,7 +259725,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"upstage/solar-10_7b-instruct": {
 			"id": "upstage/solar-10_7b-instruct",
@@ -259580,7 +259828,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -259634,7 +259881,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"writer/palmyra-creative-122b": {
 			"id": "writer/palmyra-creative-122b",
@@ -260076,7 +260324,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -260130,7 +260377,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm4.7": {
 			"id": "z-ai/glm4.7",
@@ -262180,6 +262428,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262278,6 +262527,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262369,6 +262619,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262406,7 +262657,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -262450,6 +262700,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262459,7 +262710,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-4-turbo": {
 			"id": "gpt-4-turbo",
@@ -262488,7 +262740,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -262532,6 +262783,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262541,7 +262793,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-4.1": {
 			"id": "gpt-4.1",
@@ -262570,7 +262823,6 @@
 				"revision": "4.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -262614,6 +262866,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262623,7 +262876,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-4.1-mini": {
 			"id": "gpt-4.1-mini",
@@ -262652,7 +262906,6 @@
 				"revision": "4.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -262696,6 +262949,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262705,7 +262959,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-4.1-nano": {
 			"id": "gpt-4.1-nano",
@@ -262734,7 +262989,6 @@
 				"revision": "4.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -262778,6 +263032,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262787,7 +263042,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-4o": {
 			"id": "gpt-4o",
@@ -262815,7 +263071,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -262859,6 +263114,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262868,7 +263124,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-4o-2024-05-13": {
 			"id": "gpt-4o-2024-05-13",
@@ -262896,7 +263153,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -262940,6 +263196,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262949,7 +263206,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-4o-2024-08-06": {
 			"id": "gpt-4o-2024-08-06",
@@ -262977,7 +263235,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -263021,6 +263278,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263030,7 +263288,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-4o-2024-11-20": {
 			"id": "gpt-4o-2024-11-20",
@@ -263056,7 +263315,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -263100,6 +263358,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263109,7 +263368,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-4o-mini": {
 			"id": "gpt-4o-mini",
@@ -263137,7 +263397,6 @@
 				"family": "gpt"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -263181,6 +263440,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263190,7 +263450,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5": {
 			"id": "gpt-5",
@@ -263228,7 +263489,7 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -263272,6 +263533,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263282,7 +263544,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5-chat-latest": {
 			"id": "gpt-5-chat-latest",
@@ -263353,6 +263615,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263444,6 +263707,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263492,7 +263756,7 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -263536,6 +263800,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263546,7 +263811,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5-nano": {
 			"id": "gpt-5-nano",
@@ -263584,7 +263849,7 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -263628,6 +263893,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263638,7 +263904,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5-pro": {
 			"id": "gpt-5-pro",
@@ -263674,7 +263940,7 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -263718,6 +263984,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263728,7 +263995,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.1": {
 			"id": "gpt-5.1",
@@ -263766,7 +264033,7 @@
 				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -263810,6 +264077,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263820,7 +264088,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.1-chat-latest": {
 			"id": "gpt-5.1-chat-latest",
@@ -263900,6 +264168,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263991,6 +264260,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264083,6 +264353,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264172,6 +264443,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264220,7 +264492,7 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -264264,6 +264536,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264274,7 +264547,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.2-chat-latest": {
 			"id": "gpt-5.2-chat-latest",
@@ -264310,7 +264583,7 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -264354,6 +264627,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264364,7 +264638,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.2-codex": {
 			"id": "gpt-5.2-codex",
@@ -264445,6 +264719,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264491,7 +264766,7 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -264535,6 +264810,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264545,7 +264821,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.3-chat-latest": {
 			"id": "gpt-5.3-chat-latest",
@@ -264572,7 +264848,7 @@
 				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -264616,6 +264892,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264626,7 +264903,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.3-codex": {
 			"id": "gpt-5.3-codex",
@@ -264664,7 +264941,7 @@
 				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -264708,6 +264985,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264718,7 +264996,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.3-codex-spark": {
 			"id": "gpt-5.3-codex-spark",
@@ -264755,7 +265033,7 @@
 				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -264799,6 +265077,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264809,7 +265088,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.4": {
 			"id": "gpt-5.4",
@@ -264847,7 +265126,7 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -264891,6 +265170,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264901,7 +265181,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": true
 		},
 		"gpt-5.4-mini": {
 			"id": "gpt-5.4-mini",
@@ -264939,7 +265219,7 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -264983,6 +265263,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264993,7 +265274,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": true
 		},
 		"gpt-5.4-nano": {
 			"id": "gpt-5.4-nano",
@@ -265031,7 +265312,7 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -265075,6 +265356,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265085,7 +265367,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": true
 		},
 		"gpt-5.4-pro": {
 			"id": "gpt-5.4-pro",
@@ -265121,7 +265403,7 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -265165,6 +265447,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265175,7 +265458,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": true
 		},
 		"gpt-5.5": {
 			"id": "gpt-5.5",
@@ -265214,7 +265497,7 @@
 				"revision": "5.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -265258,6 +265541,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265268,7 +265552,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": true
 		},
 		"gpt-5.5-pro": {
 			"id": "gpt-5.5-pro",
@@ -265305,7 +265589,7 @@
 				"revision": "5.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -265349,6 +265633,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265359,7 +265644,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": true
 		},
 		"gpt-5.6": {
 			"id": "gpt-5.6",
@@ -265403,7 +265688,7 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -265448,6 +265733,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265458,7 +265744,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": true
 		},
 		"gpt-5.6-cyber": {
 			"id": "gpt-5.6-cyber",
@@ -265540,6 +265826,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265596,7 +265883,7 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -265641,6 +265928,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265651,7 +265939,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": true
 		},
 		"gpt-5.6-luna-pro": {
 			"id": "gpt-5.6-luna-pro",
@@ -265681,8 +265969,6 @@
 			"maxTokens": 128000,
 			"int": 52.3,
 			"tps": 123.3,
-			"requestModelId": "gpt-5.6-luna",
-			"reasoningMode": "pro",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -265699,7 +265985,7 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -265744,6 +266030,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265754,7 +266041,9 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"requestModelId": "gpt-5.6-luna",
+			"reasoningMode": "pro",
+			"supportsComputerUse": true
 		},
 		"gpt-5.6-sol": {
 			"id": "gpt-5.6-sol",
@@ -265800,7 +266089,7 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -265845,6 +266134,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265855,7 +266145,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": true
 		},
 		"gpt-5.6-sol-pro": {
 			"id": "gpt-5.6-sol-pro",
@@ -265885,8 +266175,6 @@
 			"maxTokens": 128000,
 			"int": 60.9,
 			"tps": 76.5,
-			"requestModelId": "gpt-5.6-sol",
-			"reasoningMode": "pro",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -265903,7 +266191,7 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -265948,6 +266236,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265958,7 +266247,9 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"requestModelId": "gpt-5.6-sol",
+			"reasoningMode": "pro",
+			"supportsComputerUse": true
 		},
 		"gpt-5.6-terra": {
 			"id": "gpt-5.6-terra",
@@ -266004,7 +266295,7 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -266049,6 +266340,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -266059,7 +266351,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": true
 		},
 		"gpt-5.6-terra-pro": {
 			"id": "gpt-5.6-terra-pro",
@@ -266089,8 +266381,6 @@
 			"maxTokens": 128000,
 			"int": 56.6,
 			"tps": 103.2,
-			"requestModelId": "gpt-5.6-terra",
-			"reasoningMode": "pro",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -266107,7 +266397,7 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": true,
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -266152,6 +266442,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -266162,7 +266453,9 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
 			},
-			"applyPatchToolType": "freeform"
+			"requestModelId": "gpt-5.6-terra",
+			"reasoningMode": "pro",
+			"supportsComputerUse": true
 		},
 		"gpt-realtime-2.1": {
 			"id": "gpt-realtime-2.1",
@@ -266199,7 +266492,6 @@
 				"revision": "2.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -266243,6 +266535,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -266252,7 +266545,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"o1": {
 			"id": "o1",
@@ -266290,7 +266584,6 @@
 				"family": "o-series"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -266334,6 +266627,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -266343,7 +266637,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"o1-pro": {
 			"id": "o1-pro",
@@ -266382,7 +266677,6 @@
 				"revision": "1.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -266426,6 +266720,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -266435,7 +266730,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"o3": {
 			"id": "o3",
@@ -266474,7 +266770,6 @@
 				"family": "o-series"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -266518,6 +266813,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -266527,7 +266823,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"o3-deep-research": {
 			"id": "o3-deep-research",
@@ -266608,6 +266905,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -266657,7 +266955,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -266701,6 +266998,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -266710,7 +267008,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"o3-pro": {
 			"id": "o3-pro",
@@ -266749,7 +267048,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -266793,6 +267091,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -266802,7 +267101,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"o4-mini": {
 			"id": "o4-mini",
@@ -266842,7 +267142,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -266886,6 +267185,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -266895,7 +267195,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"o4-mini-deep-research": {
 			"id": "o4-mini-deep-research",
@@ -266976,6 +267277,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -267031,7 +267333,11 @@
 				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -267075,6 +267381,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -267086,11 +267393,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.4": {
 			"id": "gpt-5.4",
@@ -267135,7 +267438,11 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -267179,6 +267486,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -267190,11 +267498,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.4-mini": {
 			"id": "gpt-5.4-mini",
@@ -267239,7 +267543,11 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -267283,6 +267591,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -267294,11 +267603,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.5": {
 			"id": "gpt-5.5",
@@ -267344,7 +267649,11 @@
 				"revision": "5.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2.5
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -267388,6 +267697,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -267399,11 +267709,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2.5
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.6-luna": {
 			"id": "gpt-5.6-luna",
@@ -267458,7 +267764,11 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -267502,6 +267812,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -267513,11 +267824,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.6-sol": {
 			"id": "gpt-5.6-sol",
@@ -267572,7 +267879,11 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -267616,6 +267927,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -267627,11 +267939,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.6-terra": {
 			"id": "gpt-5.6-terra",
@@ -267686,7 +267994,11 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -267730,6 +268042,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -267741,11 +268054,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-6-astra": {
 			"id": "gpt-6-astra",
@@ -267791,7 +268100,11 @@
 				"revision": "6.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2.5
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -267835,6 +268148,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -267846,11 +268160,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2.5
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-daybreak-blue-latest": {
 			"id": "gpt-daybreak-blue-latest",
@@ -267896,7 +268206,11 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -267940,6 +268254,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -267951,11 +268266,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		}
 	},
 	"opencode-go": {
@@ -267993,7 +268304,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -268038,6 +268348,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -268048,7 +268359,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-v4-flash-vision-exp": {
 			"id": "deepseek-v4-flash-vision-exp",
@@ -268083,7 +268395,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -268193,7 +268504,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-v4-pro": {
 			"id": "deepseek-v4-pro",
@@ -268229,7 +268541,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -268339,7 +268650,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-5": {
 			"id": "glm-5",
@@ -268525,7 +268837,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -268635,7 +268946,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-5.2": {
 			"id": "glm-5.2",
@@ -268673,7 +268985,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -268783,7 +269094,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-5.3": {
 			"id": "glm-5.3",
@@ -268821,7 +269133,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -268931,7 +269242,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-5.3-flash": {
 			"id": "glm-5.3-flash",
@@ -268971,7 +269283,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -269081,7 +269392,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.6-luna": {
 			"id": "gpt-5.6-luna",
@@ -269120,7 +269432,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -269164,6 +269475,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -269174,7 +269486,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"grok-4.5": {
 			"id": "grok-4.5",
@@ -269257,6 +269570,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -269307,7 +269621,6 @@
 				"revision": "4.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -269352,6 +269665,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -269362,7 +269676,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"hy3": {
 			"id": "hy3",
@@ -269398,7 +269713,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -269506,7 +269820,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"hy4-preview": {
 			"id": "hy4-preview",
@@ -269540,7 +269855,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -269648,7 +269962,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2.5": {
 			"id": "kimi-k2.5",
@@ -269835,7 +270150,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -269947,7 +270261,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2.7-code": {
 			"id": "kimi-k2.7-code",
@@ -269986,7 +270301,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -270096,7 +270410,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k3": {
 			"id": "kimi-k3",
@@ -270138,7 +270453,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -270258,7 +270572,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"longcat-2.0": {
 			"id": "longcat-2.0",
@@ -270294,7 +270609,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -270402,7 +270716,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mimo-v2-omni": {
 			"id": "mimo-v2-omni",
@@ -270739,7 +271054,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -270853,7 +271167,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mimo-v2.5-pro": {
 			"id": "mimo-v2.5-pro",
@@ -270888,7 +271203,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -271002,7 +271316,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax-m2.5": {
 			"id": "minimax-m2.5",
@@ -271105,7 +271420,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -271213,7 +271527,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax-m3": {
 			"id": "minimax-m3",
@@ -271251,7 +271566,6 @@
 				"family": "m3"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -271359,7 +271673,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"muse-spark-1.2-contributor": {
 			"id": "muse-spark-1.2-contributor",
@@ -271396,7 +271711,6 @@
 				"revision": "1.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -271417,8 +271731,8 @@
 				"thinkingFormat": "openai",
 				"reasoningDisableMode": "lowest-effort",
 				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
 				"disableReasoningOnForcedToolChoice": false,
 				"disableReasoningOnToolChoice": false,
 				"supportsToolChoice": true,
@@ -271440,6 +271754,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -271450,7 +271765,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"muse-spark-1.3-contributor": {
 			"id": "muse-spark-1.3-contributor",
@@ -271487,7 +271803,6 @@
 				"revision": "1.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -271508,8 +271823,8 @@
 				"thinkingFormat": "openai",
 				"reasoningDisableMode": "lowest-effort",
 				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
 				"disableReasoningOnForcedToolChoice": false,
 				"disableReasoningOnToolChoice": false,
 				"supportsToolChoice": true,
@@ -271531,6 +271846,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -271541,7 +271857,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"ox-alpha-free": {
 			"id": "ox-alpha-free",
@@ -271865,7 +272182,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -271973,7 +272289,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.7-max": {
 			"id": "qwen3.7-max",
@@ -272010,7 +272327,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -272118,7 +272434,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.7-plus": {
 			"id": "qwen3.7-plus",
@@ -272156,7 +272473,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -272264,7 +272580,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.8-flash": {
 			"id": "qwen3.8-flash",
@@ -272301,7 +272618,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -272327,7 +272643,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.8-max": {
 			"id": "qwen3.8-max",
@@ -272365,7 +272682,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -272473,7 +272789,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"opencode-zen": {
@@ -272506,7 +272823,6 @@
 				"class": "deepseek"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -272616,7 +272932,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-3-5-haiku": {
 			"id": "claude-3-5-haiku",
@@ -272711,7 +273028,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -272737,7 +273053,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-fable-5-1": {
 			"id": "claude-fable-5-1",
@@ -272779,7 +273096,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -272805,7 +273121,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-haiku-4-5": {
 			"id": "claude-haiku-4-5",
@@ -272843,7 +273160,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -272869,7 +273185,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-1": {
 			"id": "claude-opus-4-1",
@@ -272973,7 +273290,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -272999,7 +273315,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-6": {
 			"id": "claude-opus-4-6",
@@ -273038,7 +273355,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -273064,7 +273380,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-7": {
 			"id": "claude-opus-4-7",
@@ -273105,7 +273422,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -273131,7 +273447,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-8": {
 			"id": "claude-opus-4-8",
@@ -273172,7 +273489,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -273198,7 +273514,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-5": {
 			"id": "claude-opus-5",
@@ -273239,7 +273556,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -273265,7 +273581,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4": {
 			"id": "claude-sonnet-4",
@@ -273303,7 +273620,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -273329,7 +273645,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-5": {
 			"id": "claude-sonnet-4-5",
@@ -273367,7 +273684,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -273393,7 +273709,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-6": {
 			"id": "claude-sonnet-4-6",
@@ -273431,7 +273748,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -273457,7 +273773,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-5": {
 			"id": "claude-sonnet-5",
@@ -273498,7 +273815,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -273524,7 +273840,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-v4-flash": {
 			"id": "deepseek-v4-flash",
@@ -273560,7 +273877,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -273670,7 +273986,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-v4-flash-free": {
 			"id": "deepseek-v4-flash-free",
@@ -273850,7 +274167,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -273960,7 +274276,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3-flash": {
 			"id": "gemini-3-flash",
@@ -273999,7 +274316,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -274012,7 +274328,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3-pro": {
 			"id": "gemini-3-pro",
@@ -274095,7 +274412,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -274108,7 +274424,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.5-flash": {
 			"id": "gemini-3.5-flash",
@@ -274147,7 +274464,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -274160,7 +274476,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.5-flash-lite": {
 			"id": "gemini-3.5-flash-lite",
@@ -274199,7 +274516,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -274212,7 +274528,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.6-flash": {
 			"id": "gemini-3.6-flash",
@@ -274251,7 +274568,6 @@
 				"revision": "3.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -274264,7 +274580,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.7-flash": {
 			"id": "gemini-3.7-flash",
@@ -274302,7 +274619,6 @@
 				"revision": "3.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -274315,7 +274631,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.8-flash": {
 			"id": "gemini-3.8-flash",
@@ -274354,7 +274671,6 @@
 				"revision": "3.8.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": true,
@@ -274367,7 +274683,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-4.6": {
 			"id": "glm-4.6",
@@ -274695,7 +275012,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -274805,7 +275121,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-5.1": {
 			"id": "glm-5.1",
@@ -274843,7 +275160,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -274953,7 +275269,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-5.2": {
 			"id": "glm-5.2",
@@ -274991,7 +275308,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -275101,7 +275417,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5": {
 			"id": "gpt-5",
@@ -275139,7 +275456,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -275183,6 +275499,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275193,7 +275510,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5-codex": {
 			"id": "gpt-5-codex",
@@ -275230,7 +275548,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -275274,6 +275591,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275284,7 +275602,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5-nano": {
 			"id": "gpt-5-nano",
@@ -275322,7 +275641,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -275366,6 +275684,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275376,7 +275695,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.1": {
 			"id": "gpt-5.1",
@@ -275414,7 +275734,6 @@
 				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -275458,6 +275777,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275468,7 +275788,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.1-codex": {
 			"id": "gpt-5.1-codex",
@@ -275505,7 +275826,6 @@
 				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -275549,6 +275869,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275559,7 +275880,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.1-codex-max": {
 			"id": "gpt-5.1-codex-max",
@@ -275597,7 +275919,6 @@
 				"logicalId": "gpt-5.1-codex"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -275641,6 +275962,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275651,7 +275973,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.1-codex-mini": {
 			"id": "gpt-5.1-codex-mini",
@@ -275686,7 +276009,6 @@
 				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -275730,6 +276052,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275740,7 +276063,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.2": {
 			"id": "gpt-5.2",
@@ -275778,7 +276102,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -275822,6 +276145,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275832,7 +276156,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.2-codex": {
 			"id": "gpt-5.2-codex",
@@ -275869,7 +276194,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -275913,6 +276237,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275923,7 +276248,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.3-codex": {
 			"id": "gpt-5.3-codex",
@@ -275961,7 +276287,6 @@
 				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -276005,6 +276330,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276015,7 +276341,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.3-codex-spark": {
 			"id": "gpt-5.3-codex-spark",
@@ -276051,7 +276378,6 @@
 				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -276095,6 +276421,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276105,7 +276432,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.4": {
 			"id": "gpt-5.4",
@@ -276143,7 +276471,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -276187,6 +276514,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276197,7 +276525,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.4-mini": {
 			"id": "gpt-5.4-mini",
@@ -276235,7 +276564,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -276279,6 +276607,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276289,7 +276618,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.4-nano": {
 			"id": "gpt-5.4-nano",
@@ -276327,7 +276657,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -276371,6 +276700,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276381,7 +276711,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.4-pro": {
 			"id": "gpt-5.4-pro",
@@ -276417,7 +276748,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -276461,6 +276791,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276471,7 +276802,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.5": {
 			"id": "gpt-5.5",
@@ -276510,7 +276842,6 @@
 				"revision": "5.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -276554,6 +276885,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276564,7 +276896,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.5-pro": {
 			"id": "gpt-5.5-pro",
@@ -276601,7 +276934,6 @@
 				"revision": "5.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -276645,6 +276977,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276655,7 +276988,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.6-luna": {
 			"id": "gpt-5.6-luna",
@@ -276694,7 +277028,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -276738,6 +277071,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276748,7 +277082,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.6-sol": {
 			"id": "gpt-5.6-sol",
@@ -276787,7 +277122,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -276831,6 +277165,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276841,7 +277176,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.6-terra": {
 			"id": "gpt-5.6-terra",
@@ -276880,7 +277216,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -276924,6 +277259,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276934,7 +277270,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"grok-4.5": {
 			"id": "grok-4.5",
@@ -276973,7 +277310,6 @@
 				"revision": "4.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -277018,6 +277354,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -277028,7 +277365,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"grok-4.6": {
 			"id": "grok-4.6",
@@ -277067,7 +277405,6 @@
 				"revision": "4.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -277112,6 +277449,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -277122,7 +277460,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"grok-build-0.1": {
 			"id": "grok-build-0.1",
@@ -277159,7 +277498,6 @@
 				"revision": "0.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -277204,6 +277542,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -277214,7 +277553,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"hy3-free": {
 			"id": "hy3-free",
@@ -277690,7 +278030,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -277800,7 +278139,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2.6": {
 			"id": "kimi-k2.6",
@@ -277839,7 +278179,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -277951,7 +278290,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2.7-code": {
 			"id": "kimi-k2.7-code",
@@ -277990,7 +278330,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -278100,7 +278439,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k3": {
 			"id": "kimi-k3",
@@ -278142,7 +278482,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -278262,7 +278601,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"laguna-s-2.1-free": {
 			"id": "laguna-s-2.1-free",
@@ -278516,7 +278856,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -278624,7 +278963,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"ling-3.0-flash-free": {
 			"id": "ling-3.0-flash-free",
@@ -279526,7 +279866,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -279640,7 +279979,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax-m2.1": {
 			"id": "minimax-m2.1",
@@ -279818,7 +280158,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -279926,7 +280265,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax-m2.5-free": {
 			"id": "minimax-m2.5-free",
@@ -280027,7 +280367,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -280135,7 +280474,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax-m3": {
 			"id": "minimax-m3",
@@ -280173,7 +280513,6 @@
 				"family": "m3"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -280281,7 +280620,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax-m3-free": {
 			"id": "minimax-m3-free",
@@ -280464,7 +280804,6 @@
 				"revision": "1.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -280485,8 +280824,8 @@
 				"thinkingFormat": "openai",
 				"reasoningDisableMode": "lowest-effort",
 				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
 				"disableReasoningOnForcedToolChoice": false,
 				"disableReasoningOnToolChoice": false,
 				"supportsToolChoice": true,
@@ -280508,6 +280847,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -280518,7 +280858,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"muse-spark-1.2-contributor-free": {
 			"id": "muse-spark-1.2-contributor-free",
@@ -280555,7 +280896,6 @@
 				"revision": "1.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -280576,8 +280916,8 @@
 				"thinkingFormat": "openai",
 				"reasoningDisableMode": "lowest-effort",
 				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
 				"disableReasoningOnForcedToolChoice": false,
 				"disableReasoningOnToolChoice": false,
 				"supportsToolChoice": true,
@@ -280599,6 +280939,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -280609,7 +280950,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"muse-spark-1.3-contributor-free": {
 			"id": "muse-spark-1.3-contributor-free",
@@ -280646,7 +280988,6 @@
 				"revision": "1.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -280667,8 +281008,8 @@
 				"thinkingFormat": "openai",
 				"reasoningDisableMode": "lowest-effort",
 				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
 				"disableReasoningOnForcedToolChoice": false,
 				"disableReasoningOnToolChoice": false,
 				"supportsToolChoice": true,
@@ -280690,6 +281031,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -280700,7 +281042,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nemotron-3-super-free": {
 			"id": "nemotron-3-super-free",
@@ -280876,7 +281219,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -280984,7 +281326,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nemotron-3.5-lightning-free": {
 			"id": "nemotron-3.5-lightning-free",
@@ -281018,7 +281361,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -281126,7 +281468,8 @@
 					"retryWithoutStrictOnGrammarError": false,
 					"supportsPromptCacheKey": false
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"north-mini-code-free": {
 			"id": "north-mini-code-free",
@@ -281305,7 +281648,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -281331,7 +281673,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.6-plus": {
 			"id": "qwen3.6-plus",
@@ -281370,7 +281713,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -281396,7 +281738,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3.6-plus-free": {
 			"id": "qwen3.6-plus-free",
@@ -331689,6 +332032,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -331779,6 +332123,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -331869,6 +332214,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -333005,7 +333351,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -333060,7 +333405,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V3-1": {
 			"id": "deepseek-ai/DeepSeek-V3-1",
@@ -333094,7 +333440,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -333149,7 +333494,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V3.1": {
 			"id": "deepseek-ai/DeepSeek-V3.1",
@@ -333265,7 +333611,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -333320,7 +333665,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V4-Pro": {
 			"id": "deepseek-ai/DeepSeek-V4-Pro",
@@ -333356,7 +333702,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -333411,7 +333756,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-ai/DeepSeek-V4-Pro-0813": {
 			"id": "deepseek-ai/DeepSeek-V4-Pro-0813",
@@ -333445,7 +333791,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -333500,7 +333845,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"essentialai/Rnj-1-Instruct": {
 			"id": "essentialai/Rnj-1-Instruct",
@@ -333524,7 +333870,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -333578,7 +333923,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemma-4-31B-it": {
 			"id": "google/gemma-4-31B-it",
@@ -333613,7 +333959,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -333667,7 +334012,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta-llama/Llama-3.3-70B-Instruct-Turbo": {
 			"id": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
@@ -333692,7 +334038,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -333746,7 +334091,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
 			"id": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
@@ -333942,7 +334288,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -333996,7 +334341,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMaxAI/MiniMax-M2.7": {
 			"id": "MiniMaxAI/MiniMax-M2.7",
@@ -334032,7 +334378,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -334086,7 +334431,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"MiniMaxAI/MiniMax-M3": {
 			"id": "MiniMaxAI/MiniMax-M3",
@@ -334124,7 +334470,6 @@
 				"family": "m3"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -334178,7 +334523,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/Kimi-K2-Instruct-0905": {
 			"id": "moonshotai/Kimi-K2-Instruct-0905",
@@ -334297,7 +334643,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -334352,7 +334697,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/Kimi-K2.6": {
 			"id": "moonshotai/Kimi-K2.6",
@@ -334391,7 +334737,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -334447,7 +334792,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/Kimi-K2.7-Code": {
 			"id": "moonshotai/Kimi-K2.7-Code",
@@ -334485,7 +334831,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -334540,7 +334885,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/Kimi-K3": {
 			"id": "moonshotai/Kimi-K3",
@@ -334582,7 +334928,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -334642,7 +334987,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3-ultra-550b-a55b": {
 			"id": "nvidia/nemotron-3-ultra-550b-a55b",
@@ -334676,7 +335022,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -334730,7 +335075,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-oss-120b": {
 			"id": "openai/gpt-oss-120b",
@@ -334765,7 +335111,6 @@
 				"family": "120b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -334819,7 +335164,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-oss-20b": {
 			"id": "openai/gpt-oss-20b",
@@ -334854,7 +335200,6 @@
 				"family": "20b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -334908,7 +335253,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen2.5-7B-Instruct-Turbo": {
 			"id": "Qwen/Qwen2.5-7B-Instruct-Turbo",
@@ -334933,7 +335279,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -334987,7 +335332,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
 			"id": "Qwen/Qwen3-235B-A22B-Instruct-2507-tput",
@@ -335012,7 +335358,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -335066,7 +335411,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
 			"id": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
@@ -335092,7 +335438,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -335146,7 +335491,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3-Coder-Next-FP8": {
 			"id": "Qwen/Qwen3-Coder-Next-FP8",
@@ -335172,7 +335518,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -335226,7 +335571,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3.5-397B-A17B": {
 			"id": "Qwen/Qwen3.5-397B-A17B",
@@ -335264,7 +335610,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -335318,7 +335663,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3.5-9B": {
 			"id": "Qwen/Qwen3.5-9B",
@@ -335356,7 +335702,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -335410,7 +335755,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3.6-Plus": {
 			"id": "Qwen/Qwen3.6-Plus",
@@ -335447,7 +335793,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -335501,7 +335846,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"Qwen/Qwen3.7-Max": {
 			"id": "Qwen/Qwen3.7-Max",
@@ -335529,7 +335875,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -335583,7 +335928,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"thinkingmachines/Inkling": {
 			"id": "thinkingmachines/Inkling",
@@ -335620,7 +335966,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -335674,7 +336019,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-4.7": {
 			"id": "zai-org/GLM-4.7",
@@ -335803,7 +336149,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -335857,7 +336202,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-5.1": {
 			"id": "zai-org/GLM-5.1",
@@ -335895,7 +336241,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -335949,7 +336294,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-5.2": {
 			"id": "zai-org/GLM-5.2",
@@ -335987,7 +336333,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -336041,7 +336386,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-5.3": {
 			"id": "zai-org/GLM-5.3",
@@ -336079,7 +336425,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -336133,7 +336478,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-5.3-Flash": {
 			"id": "zai-org/GLM-5.3-Flash",
@@ -336173,7 +336519,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -336227,7 +336572,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"umans": {
@@ -337063,7 +337409,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -337117,7 +337462,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"aion-labs-aion-3-0-mini": {
 			"id": "aion-labs-aion-3-0-mini",
@@ -337151,7 +337497,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -337205,7 +337550,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"aion-labs.aion-2-0": {
 			"id": "aion-labs.aion-2-0",
@@ -337416,7 +337762,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -337470,7 +337815,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-fable-5-1": {
 			"id": "claude-fable-5-1",
@@ -337511,7 +337857,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -337565,7 +337910,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-5": {
 			"id": "claude-opus-4-5",
@@ -337605,7 +337951,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -337659,7 +338004,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-6": {
 			"id": "claude-opus-4-6",
@@ -337699,7 +338045,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -337753,7 +338098,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-6-fast": {
 			"id": "claude-opus-4-6-fast",
@@ -337886,7 +338232,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -337940,7 +338285,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-7-fast": {
 			"id": "claude-opus-4-7-fast",
@@ -338073,7 +338419,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -338127,7 +338472,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4-8-fast": {
 			"id": "claude-opus-4-8-fast",
@@ -338165,7 +338511,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -338219,7 +338564,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-45": {
 			"id": "claude-opus-45",
@@ -338352,7 +338698,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -338406,7 +338751,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-5-fast": {
 			"id": "claude-opus-5-fast",
@@ -338444,7 +338790,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -338498,7 +338843,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-5": {
 			"id": "claude-sonnet-4-5",
@@ -338536,7 +338882,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -338590,7 +338935,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-6": {
 			"id": "claude-sonnet-4-6",
@@ -338630,7 +338976,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -338684,7 +339029,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-45": {
 			"id": "claude-sonnet-45",
@@ -338817,7 +339163,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -338871,7 +339216,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-v3.2": {
 			"id": "deepseek-v3.2",
@@ -338905,7 +339251,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -338960,7 +339305,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-v4-flash": {
 			"id": "deepseek-v4-flash",
@@ -338996,7 +339342,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -339051,7 +339396,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-v4-flash-0731": {
 			"id": "deepseek-v4-flash-0731",
@@ -339085,7 +339431,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -339140,7 +339485,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-v4-flash-0731-fast": {
 			"id": "deepseek-v4-flash-0731-fast",
@@ -339174,7 +339520,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -339229,7 +339574,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-v4-pro": {
 			"id": "deepseek-v4-pro",
@@ -339265,7 +339611,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -339320,7 +339665,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek-v4-pro-0813": {
 			"id": "deepseek-v4-pro-0813",
@@ -339354,7 +339700,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -339409,7 +339754,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"e2ee-deepseek-v4-flash": {
 			"id": "e2ee-deepseek-v4-flash",
@@ -340997,7 +341343,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -341052,7 +341397,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3-5-flash": {
 			"id": "gemini-3-5-flash",
@@ -341091,7 +341437,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -341146,7 +341491,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3-5-flash-lite": {
 			"id": "gemini-3-5-flash-lite",
@@ -341185,7 +341531,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -341240,7 +341585,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3-6-flash": {
 			"id": "gemini-3-6-flash",
@@ -341279,7 +341625,6 @@
 				"revision": "3.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -341334,7 +341679,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3-7-flash": {
 			"id": "gemini-3-7-flash",
@@ -341373,7 +341719,6 @@
 				"revision": "3.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -341428,7 +341773,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3-8-flash": {
 			"id": "gemini-3-8-flash",
@@ -341467,7 +341813,6 @@
 				"revision": "3.8.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -341522,7 +341867,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3-flash-preview": {
 			"id": "gemini-3-flash-preview",
@@ -341559,7 +341905,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -341614,7 +341959,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3-pro-preview": {
 			"id": "gemini-3-pro-preview",
@@ -341730,7 +342076,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -341784,7 +342129,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google-gemma-3-27b-it": {
 			"id": "google-gemma-3-27b-it",
@@ -341809,7 +342155,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -341863,7 +342208,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google-gemma-4-26b-a4b-it": {
 			"id": "google-gemma-4-26b-a4b-it",
@@ -341898,7 +342244,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -341952,7 +342297,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google-gemma-4-31b-it": {
 			"id": "google-gemma-4-31b-it",
@@ -341987,7 +342333,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -342041,7 +342386,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google.gemma-4-26b-a4b-it": {
 			"id": "google.gemma-4-26b-a4b-it",
@@ -342238,7 +342584,6 @@
 				"revision": "4.20.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -342293,7 +342638,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"grok-4-20-beta": {
 			"id": "grok-4-20-beta",
@@ -342581,7 +342927,6 @@
 				"revision": "4.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -342636,7 +342981,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"grok-4-5": {
 			"id": "grok-4-5",
@@ -342675,7 +343021,6 @@
 				"revision": "4.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -342730,7 +343075,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"grok-4-6": {
 			"id": "grok-4-6",
@@ -342769,7 +343115,6 @@
 				"revision": "4.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -342824,7 +343169,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"grok-41-fast": {
 			"id": "grok-41-fast",
@@ -342954,7 +343300,6 @@
 				"revision": "0.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -343009,7 +343354,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"grok-code-fast-1": {
 			"id": "grok-code-fast-1",
@@ -343220,7 +343566,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -343274,7 +343619,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2-5": {
 			"id": "kimi-k2-5",
@@ -343312,7 +343658,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -343367,7 +343712,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2-6": {
 			"id": "kimi-k2-6",
@@ -343406,7 +343752,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -343461,7 +343806,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2-7-code": {
 			"id": "kimi-k2-7-code",
@@ -343500,7 +343846,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -343555,7 +343900,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2-thinking": {
 			"id": "kimi-k2-thinking",
@@ -343694,7 +344040,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -343754,7 +344099,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k3-fast-api": {
 			"id": "kimi-k3-fast-api",
@@ -343794,7 +344140,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -343854,7 +344199,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"llama-3.2-3b": {
 			"id": "llama-3.2-3b",
@@ -343879,7 +344225,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -343933,7 +344278,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"llama-3.3-70b": {
 			"id": "llama-3.3-70b",
@@ -343958,7 +344304,6 @@
 				"family": "llama"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -344012,7 +344357,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mercury-2": {
 			"id": "mercury-2",
@@ -344048,7 +344394,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -344102,7 +344447,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax-m21": {
 			"id": "minimax-m21",
@@ -344225,7 +344571,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -344279,7 +344624,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax-m27": {
 			"id": "minimax-m27",
@@ -344313,7 +344659,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -344367,7 +344712,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax-m3": {
 			"id": "minimax-m3",
@@ -344496,7 +344842,6 @@
 				"family": "m3"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -344550,7 +344895,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral-31-24b": {
 			"id": "mistral-31-24b",
@@ -344667,7 +345013,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -344721,7 +345066,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistral-small-3-2-24b-instruct": {
 			"id": "mistral-small-3-2-24b-instruct",
@@ -344746,7 +345092,6 @@
 				"family": "mistral"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -344800,7 +345145,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia-nemotron-3-5-lightning-30b-a3b": {
 			"id": "nvidia-nemotron-3-5-lightning-30b-a3b",
@@ -344914,7 +345260,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -344968,7 +345313,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia-nemotron-3-ultra-550b-a55b": {
 			"id": "nvidia-nemotron-3-ultra-550b-a55b",
@@ -345004,7 +345350,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -345058,7 +345403,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia-nemotron-cascade-2-30b-a3b": {
 			"id": "nvidia-nemotron-cascade-2-30b-a3b",
@@ -345181,7 +345527,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -345235,7 +345580,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai-gpt-4o-2024-11-20": {
 			"id": "openai-gpt-4o-2024-11-20",
@@ -345260,7 +345606,6 @@
 				"class": "openai"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -345314,7 +345659,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai-gpt-4o-mini-2024-07-18": {
 			"id": "openai-gpt-4o-mini-2024-07-18",
@@ -345339,7 +345685,6 @@
 				"class": "openai"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -345393,7 +345738,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai-gpt-52": {
 			"id": "openai-gpt-52",
@@ -345428,7 +345774,6 @@
 				"revision": "52.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -345482,7 +345827,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai-gpt-52-codex": {
 			"id": "openai-gpt-52-codex",
@@ -345519,7 +345865,6 @@
 				"revision": "52.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -345573,7 +345918,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai-gpt-53-codex": {
 			"id": "openai-gpt-53-codex",
@@ -345610,7 +345956,6 @@
 				"revision": "53.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -345664,7 +346009,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai-gpt-54": {
 			"id": "openai-gpt-54",
@@ -345700,7 +346046,6 @@
 				"revision": "54.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -345754,7 +346099,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai-gpt-54-mini": {
 			"id": "openai-gpt-54-mini",
@@ -345790,7 +346136,6 @@
 				"revision": "54.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -345844,7 +346189,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai-gpt-54-pro": {
 			"id": "openai-gpt-54-pro",
@@ -345880,7 +346226,6 @@
 				"revision": "54.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -345934,7 +346279,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai-gpt-55": {
 			"id": "openai-gpt-55",
@@ -345970,7 +346316,6 @@
 				"revision": "55.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -346024,7 +346369,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai-gpt-55-pro": {
 			"id": "openai-gpt-55-pro",
@@ -346060,7 +346406,6 @@
 				"revision": "55.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -346114,7 +346459,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai-gpt-56-luna": {
 			"id": "openai-gpt-56-luna",
@@ -346150,7 +346496,6 @@
 				"revision": "56.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -346204,7 +346549,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai-gpt-56-luna-pro": {
 			"id": "openai-gpt-56-luna-pro",
@@ -346240,7 +346586,6 @@
 				"revision": "56.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -346294,7 +346639,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai-gpt-56-sol": {
 			"id": "openai-gpt-56-sol",
@@ -346330,7 +346676,6 @@
 				"revision": "56.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -346384,7 +346729,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai-gpt-56-sol-pro": {
 			"id": "openai-gpt-56-sol-pro",
@@ -346420,7 +346766,6 @@
 				"revision": "56.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -346474,7 +346819,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai-gpt-56-terra": {
 			"id": "openai-gpt-56-terra",
@@ -346510,7 +346856,6 @@
 				"revision": "56.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -346564,7 +346909,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai-gpt-56-terra-pro": {
 			"id": "openai-gpt-56-terra-pro",
@@ -346600,7 +346946,6 @@
 				"revision": "56.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -346654,7 +346999,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai-gpt-oss-120b": {
 			"id": "openai-gpt-oss-120b",
@@ -346689,7 +347035,6 @@
 				"family": "120b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -346743,7 +347088,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen-3-6-plus": {
 			"id": "qwen-3-6-plus",
@@ -346779,7 +347125,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -346833,7 +347178,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen-3-7-max": {
 			"id": "qwen-3-7-max",
@@ -346869,7 +347215,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -346923,7 +347268,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen-3-7-plus": {
 			"id": "qwen-3-7-plus",
@@ -346959,7 +347305,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -347013,7 +347358,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen-3-8-2-4t-a95b": {
 			"id": "qwen-3-8-2-4t-a95b",
@@ -347048,7 +347394,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -347102,7 +347447,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen-3-8-27b": {
 			"id": "qwen-3-8-27b",
@@ -347138,7 +347484,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -347192,7 +347537,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen-3-8-max": {
 			"id": "qwen-3-8-max",
@@ -347228,7 +347574,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -347282,7 +347627,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3-235b-a22b-instruct-2507": {
 			"id": "qwen3-235b-a22b-instruct-2507",
@@ -347309,7 +347655,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -347363,7 +347708,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3-235b-a22b-thinking-2507": {
 			"id": "qwen3-235b-a22b-thinking-2507",
@@ -347398,7 +347744,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -347452,7 +347797,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3-4b": {
 			"id": "qwen3-4b",
@@ -347579,7 +347925,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -347633,7 +347978,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3-5-397b-a17b": {
 			"id": "qwen3-5-397b-a17b",
@@ -347671,7 +348017,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -347725,7 +348070,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3-5-9b": {
 			"id": "qwen3-5-9b",
@@ -347763,7 +348109,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -347817,7 +348162,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3-6-27b": {
 			"id": "qwen3-6-27b",
@@ -347855,7 +348201,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -347909,7 +348254,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3-6-35b-a3b": {
 			"id": "qwen3-6-35b-a3b",
@@ -347947,7 +348293,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -348001,7 +348346,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3-coder-480b-a35b-instruct": {
 			"id": "qwen3-coder-480b-a35b-instruct",
@@ -348108,7 +348454,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -348162,7 +348507,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3-next-80b": {
 			"id": "qwen3-next-80b",
@@ -348188,7 +348534,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -348242,7 +348587,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen3-vl-235b-a22b": {
 			"id": "qwen3-vl-235b-a22b",
@@ -348271,7 +348617,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -348325,7 +348670,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"seed-2-1-turbo": {
 			"id": "seed-2-1-turbo",
@@ -348360,7 +348706,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -348414,7 +348759,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"stealth-ox-alpha": {
 			"id": "stealth-ox-alpha",
@@ -348696,7 +349042,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -348750,7 +349095,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"venice-uncensored-role-play": {
 			"id": "venice-uncensored-role-play",
@@ -348775,7 +349121,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -348829,7 +349174,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xiaomi-mimo-v2-5": {
 			"id": "xiaomi-mimo-v2-5",
@@ -348863,7 +349209,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -348920,7 +349265,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai-glm-5-3": {
 			"id": "z-ai-glm-5-3",
@@ -348954,7 +349300,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -349008,7 +349353,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai-glm-5-3-flash": {
 			"id": "z-ai-glm-5-3-flash",
@@ -349043,7 +349389,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -349097,7 +349442,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai-glm-5-turbo": {
 			"id": "z-ai-glm-5-turbo",
@@ -349131,7 +349477,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -349185,7 +349530,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai-glm-5v-turbo": {
 			"id": "z-ai-glm-5v-turbo",
@@ -349220,7 +349566,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -349274,7 +349619,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org-glm-4.6": {
 			"id": "zai-org-glm-4.6",
@@ -349308,7 +349654,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -349362,7 +349707,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org-glm-4.7": {
 			"id": "zai-org-glm-4.7",
@@ -349396,7 +349742,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -349450,7 +349795,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org-glm-4.7-flash": {
 			"id": "zai-org-glm-4.7-flash",
@@ -349484,7 +349830,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -349538,7 +349883,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org-glm-5": {
 			"id": "zai-org-glm-5",
@@ -349572,7 +349918,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -349626,7 +349971,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org-glm-5-1": {
 			"id": "zai-org-glm-5-1",
@@ -349660,7 +350006,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -349714,7 +350059,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"zai-org-glm-5-2": {
 			"id": "zai-org-glm-5-2",
@@ -349748,7 +350094,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -349802,7 +350147,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"vercel-ai-gateway": {
@@ -369607,6 +369953,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -369697,6 +370044,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -369787,6 +370135,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -369878,6 +370227,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -369969,6 +370319,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370060,6 +370411,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370150,6 +370502,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370240,6 +370593,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370330,6 +370684,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370420,6 +370775,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370522,6 +370878,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370629,6 +370986,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370736,6 +371094,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370843,6 +371202,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370938,6 +371298,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371029,6 +371390,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371120,6 +371482,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371211,6 +371574,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371302,6 +371666,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371348,6 +371713,12 @@
 			"contextWindow": 1000000,
 			"maxTokens": 30000,
 			"int": 37.4,
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.20.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -371396,6 +371767,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371408,12 +371780,6 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.20.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsReasoningEffort": false,
@@ -371448,6 +371814,12 @@
 			"contextWindow": 1000000,
 			"maxTokens": 30000,
 			"int": 37.4,
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.20.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -371496,6 +371868,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371508,12 +371881,6 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.20.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsReasoningEffort": false,
@@ -371601,6 +371968,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371700,6 +372068,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371810,6 +372179,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371860,6 +372230,24 @@
 			"maxTokens": 30000,
 			"int": 37.9,
 			"tps": 134.9,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.3.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -371908,6 +372296,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371920,24 +372309,6 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortMap": {
-					"minimal": "low"
-				}
-			},
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.3.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsReasoningEffort": true,
@@ -371978,6 +372349,24 @@
 			"maxTokens": 500000,
 			"int": 55.8,
 			"tps": 56.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.5.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -372026,6 +372415,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -372038,24 +372428,6 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortMap": {
-					"minimal": "low"
-				}
-			},
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.5.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsReasoningEffort": true,
@@ -372096,6 +372468,25 @@
 			"maxTokens": 500000,
 			"int": 60.9,
 			"tps": 61.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.6.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -372142,6 +372533,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -372154,25 +372546,6 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				],
-				"effortMap": {
-					"minimal": "low"
-				}
-			},
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.6.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsReasoningEffort": true,
@@ -372253,6 +372626,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -372298,6 +372672,12 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000,
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "0.1.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -372346,6 +372726,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -372358,12 +372739,6 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "0.1.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsReasoningEffort": false,
@@ -372442,6 +372817,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -372532,6 +372908,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -372579,13 +372956,6 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.20.0"
-			},
-			"requiresGlyphTokenization": false,
-			"int": 37.4,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -372634,6 +373004,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -372646,6 +373017,12 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.20.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"includeEncryptedReasoning": true,
@@ -372682,13 +373059,6 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.20.0"
-			},
-			"requiresGlyphTokenization": false,
-			"int": 37.4,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -372737,6 +373107,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -372749,6 +373120,12 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.20.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"includeEncryptedReasoning": true,
@@ -372784,25 +373161,6 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.20.0"
-			},
-			"requiresGlyphTokenization": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				],
-				"effortMap": {
-					"minimal": "low"
-				}
-			},
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -372849,6 +373207,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -372861,6 +373220,25 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.20.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"reasoningEffortMap": {
@@ -372900,26 +373278,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.3.0"
-			},
-			"requiresGlyphTokenization": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortMap": {
-					"minimal": "low"
-				}
-			},
-			"int": 37.9,
-			"tps": 134.9,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -372968,6 +373326,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -372980,6 +373339,24 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.3.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"reasoningEffortMap": {
@@ -373021,26 +373398,6 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.5.0"
-			},
-			"requiresGlyphTokenization": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortMap": {
-					"minimal": "low"
-				}
-			},
-			"int": 55.8,
-			"tps": 56.3,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -373089,6 +373446,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -373101,6 +373459,24 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.5.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"reasoningEffortMap": {
@@ -373142,27 +373518,6 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.6.0"
-			},
-			"requiresGlyphTokenization": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				],
-				"effortMap": {
-					"minimal": "low"
-				}
-			},
-			"int": 60.9,
-			"tps": 61.3,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -373209,6 +373564,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -373221,6 +373577,25 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.6.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"reasoningEffortMap": {
@@ -373245,27 +373620,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.25,
-				"output": 2.5,
-				"cacheRead": 0.2,
-				"cacheWrite": 0,
-				"longContext": {
-					"inputThreshold": 200000,
-					"inputThresholdInclusive": true,
-					"input": 2.5,
-					"output": 5,
-					"cacheRead": 0.4,
-					"cacheWrite": 0
-				}
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
 			"contextWindow": 512000,
 			"maxTokens": 512000,
-			"identity": {
-				"class": "xai",
-				"family": "grok"
-			},
-			"requiresGlyphTokenization": false,
-			"int": 37.4,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -373314,6 +373675,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -373326,6 +373688,11 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"identity": {
+				"class": "xai",
+				"family": "grok"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"includeEncryptedReasoning": true,
@@ -373362,12 +373729,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "0.1.0"
-			},
-			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -373416,6 +373777,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -373428,6 +373790,12 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "0.1.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"includeEncryptedReasoning": true,
@@ -373448,28 +373816,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.25,
-				"output": 2.5,
-				"cacheRead": 0.2,
-				"cacheWrite": 0,
-				"longContext": {
-					"inputThreshold": 200000,
-					"inputThresholdInclusive": true,
-					"input": 2.5,
-					"output": 5,
-					"cacheRead": 0.4,
-					"cacheWrite": 0
-				}
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
 			"maxTokens": 200000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "2.5.0"
-			},
-			"requiresGlyphTokenization": false,
-			"int": 37.4,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -373518,6 +373871,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -373530,6 +373884,12 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "2.5.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"includeEncryptedReasoning": true,
@@ -373560,6 +373920,20 @@
 			"contextWindow": 262144,
 			"maxTokens": 65536,
 			"int": 25.1,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "mimo",
+				"family": "v2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -373615,20 +373989,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "mimo",
-				"family": "v2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -373658,6 +374018,20 @@
 			"contextWindow": 262144,
 			"maxTokens": 131072,
 			"int": 35.9,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "mimo",
+				"family": "v2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -373713,20 +374087,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "mimo",
-				"family": "v2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -373755,6 +374115,20 @@
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
 			"int": 41.4,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "mimo",
+				"family": "v2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -373810,20 +374184,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "mimo",
-				"family": "v2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -373852,6 +374212,20 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "mimo",
+				"family": "v2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -373907,20 +374281,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "mimo",
-				"family": "v2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -373950,6 +374310,20 @@
 			"maxTokens": 131072,
 			"int": 42.9,
 			"tps": 35.4,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "mimo",
+				"family": "v2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -374005,20 +374379,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "mimo",
-				"family": "v2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -374046,6 +374406,20 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "mimo",
+				"family": "v2"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -374101,20 +374475,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "mimo",
-				"family": "v2"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -374250,7 +374610,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -374305,7 +374664,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mimo-v2.5": {
 			"id": "mimo-v2.5",
@@ -374340,7 +374700,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -374395,7 +374754,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mimo-v2.5-pro": {
 			"id": "mimo-v2.5-pro",
@@ -374431,7 +374791,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -374486,7 +374845,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"xiaomi-token-plan-cn": {
@@ -374614,7 +374974,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -374669,7 +375028,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mimo-v2.5": {
 			"id": "mimo-v2.5",
@@ -374704,7 +375064,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -374759,7 +375118,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mimo-v2.5-pro": {
 			"id": "mimo-v2.5-pro",
@@ -374795,7 +375155,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -374850,7 +375209,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"xiaomi-token-plan-sgp": {
@@ -374978,7 +375338,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -375033,7 +375392,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mimo-v2.5": {
 			"id": "mimo-v2.5",
@@ -375068,7 +375428,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -375123,7 +375482,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mimo-v2.5-pro": {
 			"id": "mimo-v2.5-pro",
@@ -375159,7 +375519,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -375214,7 +375573,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"yolo-auto": {
@@ -375255,7 +375615,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": null,
+			"maxTokens": 384000,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -375360,7 +375720,6 @@
 				"revision": "4.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -375386,7 +375745,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-4.5-air": {
 			"id": "glm-4.5-air",
@@ -375424,7 +375784,6 @@
 				"revision": "4.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -375450,7 +375809,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-4.5-flash": {
 			"id": "glm-4.5-flash",
@@ -375486,7 +375846,6 @@
 				"revision": "4.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -375512,7 +375871,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-4.5v": {
 			"id": "glm-4.5v",
@@ -375550,7 +375910,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -375576,7 +375935,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-4.6": {
 			"id": "glm-4.6",
@@ -375613,7 +375973,6 @@
 				"revision": "4.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -375639,7 +375998,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-4.6v": {
 			"id": "glm-4.6v",
@@ -375677,7 +376037,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -375703,7 +376062,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-4.7": {
 			"id": "glm-4.7",
@@ -375740,7 +376100,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -375766,7 +376125,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-4.7-flash": {
 			"id": "glm-4.7-flash",
@@ -375804,7 +376164,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -375830,7 +376189,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-4.7-flashx": {
 			"id": "glm-4.7-flashx",
@@ -375866,7 +376226,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -375892,7 +376251,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-5": {
 			"id": "glm-5",
@@ -375930,7 +376290,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -375956,7 +376315,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-5-turbo": {
 			"id": "glm-5-turbo",
@@ -375994,7 +376354,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -376020,7 +376379,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-5.1": {
 			"id": "glm-5.1",
@@ -376058,7 +376418,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -376084,7 +376443,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-5.2": {
 			"id": "glm-5.2",
@@ -376119,7 +376479,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -376145,7 +376504,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-5.3": {
 			"id": "glm-5.3",
@@ -376165,8 +376525,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 59.5,
-			"tps": 69.2,
 			"thinking": {
 				"mode": "anthropic-budget-effort",
 				"efforts": [
@@ -376215,8 +376573,8 @@
 			"id": "glm-5.3-flash",
 			"name": "GLM-5.3-Flash",
 			"api": "openai-completions",
-			"provider": "zai",
 			"baseUrl": "https://api.z.ai/api/coding/paas/v4",
+			"provider": "zai",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -376230,8 +376588,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 57.5,
-			"tps": 47.2,
 			"thinking": {
 				"mode": "anthropic-budget-effort",
 				"efforts": [
@@ -376341,7 +376697,6 @@
 				"family": "vision"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -376367,7 +376722,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"zenmux": {
@@ -376585,7 +376941,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -376611,7 +376966,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-fable-5-free": {
 			"id": "anthropic/claude-fable-5-free",
@@ -376773,7 +377129,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -376799,7 +377154,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4": {
 			"id": "anthropic/claude-opus-4",
@@ -376837,7 +377193,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -376863,7 +377218,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.1": {
 			"id": "anthropic/claude-opus-4.1",
@@ -376901,7 +377257,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -376927,7 +377282,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.5": {
 			"id": "anthropic/claude-opus-4.5",
@@ -376967,7 +377323,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -376993,7 +377348,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.6": {
 			"id": "anthropic/claude-opus-4.6",
@@ -377032,7 +377388,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -377058,7 +377413,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.7": {
 			"id": "anthropic/claude-opus-4.7",
@@ -377099,7 +377455,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -377125,7 +377480,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.8": {
 			"id": "anthropic/claude-opus-4.8",
@@ -377166,7 +377522,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v47",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -377192,7 +377547,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-5": {
 			"id": "anthropic/claude-opus-5",
@@ -377297,7 +377653,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -377323,7 +377678,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-sonnet-4.5": {
 			"id": "anthropic/claude-sonnet-4.5",
@@ -377361,7 +377717,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -377387,7 +377742,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-sonnet-4.6": {
 			"id": "anthropic/claude-sonnet-4.6",
@@ -377425,7 +377781,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -377451,7 +377806,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-sonnet-5": {
 			"id": "anthropic/claude-sonnet-5",
@@ -377492,7 +377848,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -377518,7 +377873,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-sonnet-5-free": {
 			"id": "anthropic/claude-sonnet-5-free",
@@ -377557,7 +377913,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -377583,7 +377938,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"baidu/ernie-5.0-thinking-preview": {
 			"id": "baidu/ernie-5.0-thinking-preview",
@@ -377621,7 +377977,6 @@
 				"family": "ernie"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -377675,7 +378030,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"baidu/ernie-5.1": {
 			"id": "baidu/ernie-5.1",
@@ -379133,7 +379489,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -379188,7 +379543,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v3.2-exp": {
 			"id": "deepseek/deepseek-v3.2-exp",
@@ -379221,7 +379577,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -379276,7 +379631,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-flash": {
 			"id": "deepseek/deepseek-v4-flash",
@@ -379312,7 +379668,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -379367,7 +379722,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-flash-free": {
 			"id": "deepseek/deepseek-v4-flash-free",
@@ -379673,7 +380029,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -379728,7 +380083,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-pro-free": {
 			"id": "deepseek/deepseek-v4-pro-free",
@@ -380111,7 +380467,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -380166,7 +380521,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-2.5-flash-lite": {
 			"id": "google/gemini-2.5-flash-lite",
@@ -380195,7 +380551,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -380250,7 +380605,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-2.5-pro": {
 			"id": "google/gemini-2.5-pro",
@@ -380289,7 +380645,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -380344,7 +380699,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3-flash-preview": {
 			"id": "google/gemini-3-flash-preview",
@@ -380381,7 +380737,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -380436,7 +380791,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3-pro-image-preview": {
 			"id": "google/gemini-3-pro-image-preview",
@@ -380655,7 +381011,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -380710,7 +381065,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.1-flash-lite-preview": {
 			"id": "google/gemini-3.1-flash-lite-preview",
@@ -380739,7 +381095,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -380794,7 +381149,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.1-pro-preview": {
 			"id": "google/gemini-3.1-pro-preview",
@@ -380831,7 +381187,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -380886,7 +381241,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.5-flash": {
 			"id": "google/gemini-3.5-flash",
@@ -380925,7 +381281,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -380980,7 +381335,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.5-flash-free": {
 			"id": "google/gemini-3.5-flash-free",
@@ -382720,7 +383076,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -382774,7 +383129,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"inclusionai/ring-flash-2.0": {
 			"id": "inclusionai/ring-flash-2.0",
@@ -383213,7 +383569,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -383267,7 +383622,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kuaishou/kat-coder-pro-v2.5": {
 			"id": "kuaishou/kat-coder-pro-v2.5",
@@ -384254,7 +384610,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -384308,7 +384663,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m2-her": {
 			"id": "minimax/minimax-m2-her",
@@ -384423,7 +384779,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -384477,7 +384832,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m2.5": {
 			"id": "minimax/minimax-m2.5",
@@ -384513,7 +384869,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -384567,7 +384922,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m2.5-lightning": {
 			"id": "minimax/minimax-m2.5-lightning",
@@ -384601,7 +384957,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -384655,7 +385010,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m2.7": {
 			"id": "minimax/minimax-m2.7",
@@ -384691,7 +385047,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -384745,7 +385100,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m2.7-highspeed": {
 			"id": "minimax/minimax-m2.7-highspeed",
@@ -384779,7 +385135,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -384833,7 +385188,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
@@ -384871,7 +385227,6 @@
 				"family": "m3"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -384925,7 +385280,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-large-2512": {
 			"id": "mistralai/mistral-large-2512",
@@ -385399,7 +385755,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -385454,7 +385809,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2.6": {
 			"id": "moonshotai/kimi-k2.6",
@@ -385493,7 +385849,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -385549,7 +385904,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2.7-code": {
 			"id": "moonshotai/kimi-k2.7-code",
@@ -385588,7 +385944,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -385643,7 +385998,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2.7-code-free": {
 			"id": "moonshotai/kimi-k2.7-code-free",
@@ -385680,7 +386036,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -385735,7 +386090,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k2.7-code-highspeed": {
 			"id": "moonshotai/kimi-k2.7-code-highspeed",
@@ -385869,7 +386225,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -385929,7 +386284,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k3-free": {
 			"id": "moonshotai/kimi-k3-free",
@@ -385969,7 +386325,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -386029,7 +386384,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nex-agi/nex-n2-pro": {
 			"id": "nex-agi/nex-n2-pro",
@@ -386650,7 +387006,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -386704,7 +387059,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5-chat": {
 			"id": "openai/gpt-5-chat",
@@ -386822,7 +387178,6 @@
 				"revision": "5.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -386876,7 +387231,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5-mini": {
 			"id": "openai/gpt-5-mini",
@@ -387188,7 +387544,6 @@
 				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -387242,7 +387597,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.1-chat": {
 			"id": "openai/gpt-5.1-chat",
@@ -387269,7 +387625,6 @@
 				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -387323,7 +387678,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.1-codex": {
 			"id": "openai/gpt-5.1-codex",
@@ -387360,7 +387716,6 @@
 				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -387414,7 +387769,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.1-codex-mini": {
 			"id": "openai/gpt-5.1-codex-mini",
@@ -387449,7 +387805,6 @@
 				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -387503,7 +387858,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.2": {
 			"id": "openai/gpt-5.2",
@@ -387541,7 +387897,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -387595,7 +387950,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.2-chat": {
 			"id": "openai/gpt-5.2-chat",
@@ -387713,7 +388069,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -387767,7 +388122,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.2-pro": {
 			"id": "openai/gpt-5.2-pro",
@@ -387803,7 +388159,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -387857,7 +388212,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.3-chat": {
 			"id": "openai/gpt-5.3-chat",
@@ -387883,7 +388239,6 @@
 				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -387937,7 +388292,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.3-codex": {
 			"id": "openai/gpt-5.3-codex",
@@ -387974,7 +388330,6 @@
 				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -388028,7 +388383,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.4": {
 			"id": "openai/gpt-5.4",
@@ -388066,7 +388422,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -388120,7 +388475,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.4-mini": {
 			"id": "openai/gpt-5.4-mini",
@@ -388148,7 +388504,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -388202,7 +388557,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.4-nano": {
 			"id": "openai/gpt-5.4-nano",
@@ -388230,7 +388586,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -388284,7 +388639,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.4-pro": {
 			"id": "openai/gpt-5.4-pro",
@@ -388320,7 +388676,6 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -388374,7 +388729,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.5": {
 			"id": "openai/gpt-5.5",
@@ -388413,7 +388769,6 @@
 				"revision": "5.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -388467,7 +388822,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.5-instant": {
 			"id": "openai/gpt-5.5-instant",
@@ -388504,7 +388860,6 @@
 				"revision": "5.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -388558,7 +388913,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.5-pro": {
 			"id": "openai/gpt-5.5-pro",
@@ -388595,7 +388951,6 @@
 				"revision": "5.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -388649,7 +389004,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-luna": {
 			"id": "openai/gpt-5.6-luna",
@@ -388688,7 +389044,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -388742,7 +389097,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-sol": {
 			"id": "openai/gpt-5.6-sol",
@@ -388781,7 +389137,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -388835,7 +389190,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-terra": {
 			"id": "openai/gpt-5.6-terra",
@@ -388874,7 +389230,6 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -388928,7 +389283,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-image-1.5": {
 			"id": "openai/gpt-image-1.5",
@@ -389790,7 +390146,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -389844,7 +390199,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-max": {
 			"id": "qwen/qwen3-max",
@@ -389880,7 +390236,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -389934,7 +390289,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3-max-preview": {
 			"id": "qwen/qwen3-max-preview",
@@ -390220,7 +390576,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -390274,7 +390629,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.5-plus": {
 			"id": "qwen/qwen3.5-plus",
@@ -390310,7 +390666,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -390364,7 +390719,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.6-flash": {
 			"id": "qwen/qwen3.6-flash",
@@ -390580,7 +390936,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -390634,7 +390989,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.7-flash": {
 			"id": "qwen/qwen3.7-flash",
@@ -390761,7 +391117,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -390815,7 +391170,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.7-plus": {
 			"id": "qwen/qwen3.7-plus",
@@ -390853,7 +391209,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -390907,7 +391262,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.8-2.4t-a95b": {
 			"id": "qwen/qwen3.8-2.4t-a95b",
@@ -391292,7 +391648,7 @@
 				"cacheWrite": 2.5
 			},
 			"contextWindow": 1000000,
-			"maxTokens": null,
+			"maxTokens": 65536,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.8.0"
@@ -391477,7 +391833,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -391531,7 +391886,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"sapiens-ai/agnes-1.5-pro": {
 			"id": "sapiens-ai/agnes-1.5-pro",
@@ -391565,7 +391921,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -391619,7 +391974,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"sapiens-ai/agnes-2.0-flash": {
 			"id": "sapiens-ai/agnes-2.0-flash",
@@ -392004,7 +392360,6 @@
 				"family": "step"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -392058,7 +392413,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"stepfun/step-3.5-flash-free": {
 			"id": "stepfun/step-3.5-flash-free",
@@ -392186,7 +392542,6 @@
 				"family": "step"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -392240,7 +392595,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"stepfun/step-3.7-flash-free": {
 			"id": "stepfun/step-3.7-flash-free",
@@ -392276,7 +392632,6 @@
 				"family": "step"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -392330,7 +392685,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"tencent/hunyuan-2.0-thinking": {
 			"id": "tencent/hunyuan-2.0-thinking",
@@ -392547,7 +392903,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -392601,7 +392956,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"volcengine/doubao-seed-1-6-vision": {
 			"id": "volcengine/doubao-seed-1-6-vision",
@@ -392728,7 +393084,6 @@
 				"family": "doubao"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -392782,7 +393137,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"volcengine/doubao-seed-2.0-code": {
 			"id": "volcengine/doubao-seed-2.0-code",
@@ -392807,7 +393163,6 @@
 				"family": "doubao"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -392861,7 +393216,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"volcengine/doubao-seed-2.0-lite": {
 			"id": "volcengine/doubao-seed-2.0-lite",
@@ -392897,7 +393253,6 @@
 				"family": "doubao"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -392951,7 +393306,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"volcengine/doubao-seed-2.0-mini": {
 			"id": "volcengine/doubao-seed-2.0-mini",
@@ -392987,7 +393343,6 @@
 				"family": "doubao"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -393041,7 +393396,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"volcengine/doubao-seed-2.0-pro": {
 			"id": "volcengine/doubao-seed-2.0-pro",
@@ -393077,7 +393433,6 @@
 				"family": "doubao"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -393131,7 +393486,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"volcengine/doubao-seed-code": {
 			"id": "volcengine/doubao-seed-code",
@@ -393704,7 +394060,6 @@
 				"revision": "4.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -393759,7 +394114,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"x-ai/grok-4.2-fast-non-reasoning": {
 			"id": "x-ai/grok-4.2-fast-non-reasoning",
@@ -393786,7 +394142,6 @@
 				"revision": "4.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -393841,7 +394196,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"x-ai/grok-4.3": {
 			"id": "x-ai/grok-4.3",
@@ -393880,7 +394236,6 @@
 				"revision": "4.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -393935,7 +394290,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"x-ai/grok-4.5": {
 			"id": "x-ai/grok-4.5",
@@ -393974,7 +394330,6 @@
 				"revision": "4.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -394029,7 +394384,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"x-ai/grok-4.5-free": {
 			"id": "x-ai/grok-4.5-free",
@@ -394253,7 +394609,6 @@
 				"revision": "0.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -394308,7 +394663,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"x-ai/grok-code-fast-1": {
 			"id": "x-ai/grok-code-fast-1",
@@ -394516,7 +394872,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -394573,7 +394928,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xiaomi/mimo-v2-flash-free": {
 			"id": "xiaomi/mimo-v2-flash-free",
@@ -394699,7 +395055,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -394756,7 +395111,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xiaomi/mimo-v2-pro": {
 			"id": "xiaomi/mimo-v2-pro",
@@ -394790,7 +395146,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -394847,7 +395202,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xiaomi/mimo-v2.5": {
 			"id": "xiaomi/mimo-v2.5",
@@ -394881,7 +395237,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -394938,7 +395293,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xiaomi/mimo-v2.5-pro": {
 			"id": "xiaomi/mimo-v2.5-pro",
@@ -394973,7 +395329,6 @@
 				"family": "v2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -395030,7 +395385,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.5": {
 			"id": "z-ai/glm-4.5",
@@ -395066,7 +395422,6 @@
 				"revision": "4.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -395120,7 +395475,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.5-air": {
 			"id": "z-ai/glm-4.5-air",
@@ -395158,7 +395514,6 @@
 				"revision": "4.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -395212,7 +395567,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.6": {
 			"id": "z-ai/glm-4.6",
@@ -395249,7 +395605,6 @@
 				"revision": "4.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -395303,7 +395658,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.6v": {
 			"id": "z-ai/glm-4.6v",
@@ -395341,7 +395697,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -395395,7 +395750,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.6v-flash": {
 			"id": "z-ai/glm-4.6v-flash",
@@ -395432,7 +395788,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -395486,7 +395841,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.6v-flash-free": {
 			"id": "z-ai/glm-4.6v-flash-free",
@@ -395523,7 +395879,6 @@
 				"revision": "4.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -395577,7 +395932,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.7": {
 			"id": "z-ai/glm-4.7",
@@ -395614,7 +395970,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -395668,7 +396023,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.7-flash-free": {
 			"id": "z-ai/glm-4.7-flash-free",
@@ -395704,7 +396060,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -395758,7 +396113,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.7-flashx": {
 			"id": "z-ai/glm-4.7-flashx",
@@ -395794,7 +396150,6 @@
 				"revision": "4.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -395848,7 +396203,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5": {
 			"id": "z-ai/glm-5",
@@ -395886,7 +396242,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -395940,7 +396295,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5-turbo": {
 			"id": "z-ai/glm-5-turbo",
@@ -395978,7 +396334,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -396032,7 +396387,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5.1": {
 			"id": "z-ai/glm-5.1",
@@ -396070,7 +396426,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -396124,7 +396479,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5.2": {
 			"id": "z-ai/glm-5.2",
@@ -396162,7 +396518,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -396216,7 +396571,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5.2-free": {
 			"id": "z-ai/glm-5.2-free",
@@ -396252,7 +396608,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -396306,7 +396661,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5.3": {
 			"id": "z-ai/glm-5.3",
@@ -396619,7 +396975,6 @@
 				"family": "vision"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -396673,7 +397028,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"zhipu-coding-plan": {
@@ -396968,6 +397324,20 @@
 			"maxTokens": 32768,
 			"int": 10.9,
 			"tps": 71.8,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "4.0.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -397022,20 +397392,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "glm",
-				"revision": "4.0.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"thinkingFormat": "zai",
@@ -397063,6 +397419,20 @@
 			"maxTokens": 131072,
 			"int": 34.5,
 			"tps": 97.2,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "4.7.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -397117,20 +397487,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "glm",
-				"revision": "4.7.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"thinkingFormat": "zai",
@@ -397249,6 +397605,22 @@
 			"contextWindow": 200000,
 			"maxTokens": 131072,
 			"int": 39.1,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "glm",
+				"family": "turbo",
+				"revision": "5.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -397304,22 +397676,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "glm",
-				"family": "turbo",
-				"revision": "5.0.0"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "glm5",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"thinkingFormat": "zai",
@@ -397347,6 +397703,21 @@
 			"maxTokens": 131072,
 			"int": 41,
 			"tps": 50.5,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.1.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -397402,21 +397773,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "glm",
-				"revision": "5.1.0"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "glm5",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"thinkingFormat": "zai",
@@ -397444,6 +397800,19 @@
 			"maxTokens": 131072,
 			"int": 52.6,
 			"tps": 69.1,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.2.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -397499,19 +397868,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"high",
-					"max"
-				]
-			},
-			"identity": {
-				"class": "glm",
-				"revision": "5.2.0"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "glm5",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"thinkingFormat": "zai",
@@ -397537,6 +397893,19 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.2.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -397592,19 +397961,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"high",
-					"max"
-				]
-			},
-			"identity": {
-				"class": "glm",
-				"revision": "5.2.0"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "glm5",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"thinkingFormat": "zai",
@@ -397720,6 +398076,22 @@
 			"maxTokens": 131072,
 			"int": 59.5,
 			"tps": 69.2,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.3.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -397775,22 +398147,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high",
-					"max"
-				],
-				"defaultLevel": "max",
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "glm",
-				"revision": "5.3.0"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "glm5",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"thinkingFormat": "zai",
@@ -397819,6 +398175,23 @@
 			"maxTokens": 131072,
 			"int": 57.5,
 			"tps": 47.2,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "glm",
+				"family": "flash",
+				"revision": "5.3.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -397874,23 +398247,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high",
-					"max"
-				],
-				"defaultLevel": "max",
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "glm",
-				"family": "flash",
-				"revision": "5.3.0"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "glm5",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"thinkingFormat": "zai",
@@ -397916,6 +398272,22 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.3.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -397971,22 +398343,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high",
-					"max"
-				],
-				"defaultLevel": "max",
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "glm",
-				"revision": "5.3.0"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "glm5",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"thinkingFormat": "zai",
@@ -398014,6 +398370,20 @@
 			"contextWindow": 200000,
 			"maxTokens": 131072,
 			"int": 35.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "glm",
+				"family": "vision"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -398068,20 +398438,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"identity": {
-				"class": "glm",
-				"family": "vision"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"thinkingFormat": "zai",

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -522,6 +522,37 @@ describe("openai-completions wire-quirk compat detection", () => {
 			).compat.supportsForcedToolChoice,
 		).toBe(true);
 	});
+	it("disables encrypted reasoning replay for Muse Spark on OpenCode gateways (#11928)", () => {
+		// The Zen/Go gateways proxy Muse Spark's Responses lane to Meta but
+		// cannot round-trip encrypted reasoning: the upstream binds
+		// `encrypted_content` to the gateway's caller, so replaying it on a
+		// later tool-call step 400s with "reasoning `encrypted_content` was not
+		// issued to this caller". The deployment contract must stop requesting
+		// it and drop native reasoning items from replay.
+		for (const [provider, id, baseUrl] of [
+			["opencode-zen", "muse-spark-1.3-contributor-free", "https://opencode.ai/zen/v1"],
+			["opencode-go", "muse-spark-1.3-contributor", "https://opencode.ai/zen/go/v1"],
+		] as const) {
+			const compat = resolveModelPolicy(
+				responsesSpec({ id, provider, name: "Muse Spark", baseUrl, reasoning: true }),
+			).compat;
+			expect(compat.includeEncryptedReasoning).toBe(false);
+			expect(compat.filterReasoningHistory).toBe(true);
+		}
+		// A non-Muse reasoning model on the same gateway keeps the Responses
+		// default replay behavior, so the carve-out is scoped to the broken lane.
+		const other = resolveModelPolicy(
+			responsesSpec({
+				id: "big-pickle",
+				provider: "opencode-zen",
+				name: "Big Pickle",
+				baseUrl: "https://opencode.ai/zen/v1",
+				reasoning: true,
+			}),
+		).compat;
+		expect(other.includeEncryptedReasoning).toBe(true);
+		expect(other.filterReasoningHistory).toBe(false);
+	});
 
 	it("requires a synthetic assistant bridge after tool results only for Mistral hosts", () => {
 		// Mistral/Devstral reject a user message directly after a tool result; the chat


### PR DESCRIPTION
## Repro
Select an `opencode-zen` Muse Spark reasoning model (e.g. `muse-spark-1.3-contributor-free`) and send any message that uses tools. The first step returns, but the follow-up step (tool result continuation) fails with `400 ... reasoning encrypted_content was not issued to this caller`, aborting the turn. The same breakage applies to the Muse Spark lane on `opencode-go`.

## Cause
`muse-spark-*` on the OpenCode gateways routes through the OpenAI Responses API (`runtime/behavior.kdl` `api-routes`), and as a reasoning model it inherited the Responses default `includeEncryptedReasoning: true` / `filterReasoningHistory: false` (`resolveOpenAIResponsesPolicy`, `packages/catalog/src/compat/resolve.ts`). `applyResponsesCompatPolicy` (`packages/ai/src/providers/openai-shared.ts`) therefore adds `include: ["reasoning.encrypted_content"]` and replays native reasoning items. The gateways proxy that lane to Meta but cannot round-trip encrypted reasoning — the upstream binds `encrypted_content` to the gateway's own caller — so replaying it on a later step 400s. Confirmed via `resolveModelPolicy(...).compat`: `includeEncryptedReasoning=true`, `filterReasoningHistory=false`.

## Fix
- Add a `class "meta" { family "muse-spark" { ... } }` deployment-contract block to both `packages/catalog/src/compat/rules/providers/opencode-zen.kdl` and `opencode-go.kdl`, setting `include-encrypted-reasoning #false` and `filter-reasoning-history #true` so encrypted reasoning is neither requested nor replayed for that lane.
- Regenerate `packages/catalog/src/compat/rules.json` via `bun run gen:compat`.
- Add a regression test in `packages/catalog/test/build.test.ts` asserting the two flags flip for Muse Spark on both gateways while a sibling reasoning model (`big-pickle`) keeps the Responses default.

## Verification
`bun test test/build.test.ts test/opencode-provider.test.ts test/meta-provider.test.ts` (packages/catalog) — all green (90 tests). New test confirms `includeEncryptedReasoning=false`/`filterReasoningHistory=true` for `opencode-zen`/`opencode-go` Muse Spark and unchanged defaults for a non-Muse reasoning model.

Fixes #11928