### PR TITLE
feat(stats): rebuild the /stats dashboard

### DIFF
--- a/packages/coding-agent/src/cli/command-help.ts
+++ b/packages/coding-agent/src/cli/command-help.ts
@@ -50,10 +50,6 @@ export const galleryHelp = {
 } satisfies CommandMetadata;
 
 export const gcHelp = { description: "Run storage garbage collection" } satisfies CommandMetadata;
-export const ifBenchHelp = {
-	description:
-		"Benchmark instruction following and working memory: one cached thread of glyph array actions with a moving cat-sound directive",
-} satisfies CommandMetadata;
 export const gitHelp = {
 	description: "Interactive fullscreen git UI: split diff viewer, staging sidebar, and commit composer",
 } satisfies CommandMetadata;

--- a/packages/coding-agent/src/cli/stats-cli.ts
+++ b/packages/coding-agent/src/cli/stats-cli.ts
@@ -4,6 +4,8 @@
  * Handles `omp stats` subcommand for viewing AI usage statistics.
  */
 
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import { truncateToWidth } from "@oh-my-pi/pi-tui/utils";
 import { formatDuration, formatNumber, formatPercent } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
@@ -60,6 +62,8 @@ export interface StatsCommandArgs {
 	host: string;
 	json: boolean;
 	summary: boolean;
+	action?: string;
+	name?: string;
 }
 
 function formatCost(n: number): string {
@@ -72,6 +76,149 @@ function normalizePremiumRequests(n: number): number {
 	return Math.round((n + Number.EPSILON) * 100) / 100;
 }
 
+/**
+ * Scaffold a blank starter site for the OMP Stats v1 API.
+ * Creates a minimal package.json, index.ts, and README.md in the target directory.
+ */
+async function createSite(name: string): Promise<void> {
+	// Validate: must be a simple relative name, no path traversal
+	if (!name || name === '.' || name === '..' || path.isAbsolute(name) || name.includes('..')) {
+		console.error(chalk.red('Invalid site name. Use a simple directory name (e.g. "my-dashboard").'));
+		process.exit(1);
+	}
+
+	const targetDir = path.resolve(process.cwd(), name);
+
+	// Fail if target already exists
+	try {
+		await fs.access(targetDir);
+		console.error(chalk.red(`Directory already exists: ${targetDir}`));
+		console.error(chalk.dim('Remove it first or choose a different name.'));
+		process.exit(1);
+	} catch {
+		// ENOENT — proceed
+	}
+
+	await fs.mkdir(path.join(targetDir, 'src'), { recursive: true });
+
+	// package.json
+	const packageJson = {
+		name,
+		version: '0.1.0',
+		private: true,
+		type: 'module',
+		scripts: {
+			dev: 'bun run src/server.ts',
+		},
+		dependencies: {
+			'@oh-my-pi/omp-stats': 'latest',
+		},
+	};
+	await fs.writeFile(path.join(targetDir, 'package.json'), JSON.stringify(packageJson, null, 2) + '\n');
+
+	// Dev server: serves static files, proxies /api/* to stats server.
+	const serverCode = [
+		'import * as http from "node:http";',
+		'import * as fs from "node:fs";',
+		'import * as path from "node:path";',
+		'',
+		'const PORT = 3000;',
+		'const STATS_URL = "http://127.0.0.1:3847";',
+		'',
+		'const MIME = { ".html": "text/html", ".js": "text/javascript", ".css": "text/css" };',
+		'',
+		'const server = http.createServer(async (req, res) => {',
+		'	const url = new URL(req.url ?? "/", "http://localhost:" + PORT);',
+		'',
+		'	if (url.pathname.startsWith("/api/")) {',
+		'		const upstream = new URL(url.pathname + url.search, STATS_URL);',
+		'		const resp = await fetch(upstream, { method: req.method });',
+		'		resp.headers.forEach((v, k) => res.setHeader(k, v));',
+		'		res.writeHead(resp.status);',
+		'		res.end(await resp.arrayBuffer());',
+		'		return;',
+		'	}',
+		'',
+		'	const filePath = url.pathname === "/" ? "./index.html" : "." + url.pathname;',
+		'	try {',
+		'		const content = fs.readFileSync(path.resolve(filePath));',
+		'		const ext = path.extname(filePath);',
+		'		res.writeHead(200, { "Content-Type": MIME[ext] || "application/octet-stream" });',
+		'		res.end(content);',
+		'	} catch {',
+		'		res.writeHead(404);',
+		'		res.end("Not Found");',
+		'	}',
+		'});',
+		'',
+		'server.listen(PORT, "127.0.0.1", () => {',
+		'	console.log("Dev server: http://127.0.0.1:" + PORT);',
+		'});',
+		'',
+	].join('\n');
+	await fs.writeFile(path.join(targetDir, 'src', 'server.ts'), serverCode);
+
+	// index.html — neutral unbranded page, fetches and renders one metric
+	const indexHtml = [
+		'<!DOCTYPE html>',
+		'<html lang="en">',
+		'<head>',
+		'  <meta charset="UTF-8">',
+		'  <meta name="viewport" content="width=device-width, initial-scale=1.0">',
+		`  <title>${name}</title>`,
+		'</head>',
+		'<body>',
+		'  <h1 id="title"></h1>',
+		'  <p id="value"></p>',
+		'  <script>',
+		'    (async function () {',
+		'      var res = await fetch("/api/v1/overview?range=7d");',
+		'      if (!res.ok) throw new Error("API " + res.status);',
+		'      var data = await res.json();',
+		'      document.getElementById("title").textContent = "Total requests in 7d";',
+		'      document.getElementById("value").textContent = data.overall.totalRequests;',
+		'    })().catch(function (err) {',
+		'      document.getElementById("value").textContent = "Error: " + err.message;',
+		'    });',
+		'  </script>',
+		'</body>',
+		'</html>',
+		'',
+	].join('\n');
+	await fs.writeFile(path.join(targetDir, 'index.html'), indexHtml);
+
+	const readme = `# ${name}
+
+A custom OMP Stats frontend using the v1 API.
+
+## Quick Start
+
+\`\`\`bash
+bun install
+bun run dev
+\`\`\`
+
+The dev server runs on port 3000 and proxies \`/api/*\` to the
+OMP Stats server on port 3847.
+
+## API
+
+See \`@oh-my-pi/omp-stats/client-sdk\` for the typed SDK, or
+fetch \`/api/v1/overview\`, \`/api/v1/models\`, etc. directly.
+`;
+	await fs.writeFile(path.join(targetDir, 'README.md'), readme);
+
+	console.log(chalk.green(`Created site: ${targetDir}`));
+	console.log(chalk.dim('  package.json'));
+	console.log(chalk.dim('  index.html'));
+	console.log(chalk.dim('  src/server.ts'));
+	console.log(chalk.dim('  README.md'));
+	console.log();
+	console.log(`  cd ${name} && bun install && bun run dev`);
+}
+
+
+
 // =============================================================================
 // Command Handler
 // =============================================================================
@@ -80,6 +227,18 @@ export async function runStatsCommand(cmd: StatsCommandArgs): Promise<void> {
 	// Lazy import to avoid loading stats module when not needed
 	const { closeDb, formatStatsDashboardUrl, getDashboardStats, getTotalMessageCount, startServer, syncAllSessions } =
 		await import("@oh-my-pi/omp-stats");
+
+
+	// Handle create-site action before syncing (no DB needed)
+	if (cmd.action === "create-site") {
+		const name = cmd.name?.trim();
+		if (!name) {
+			console.error(chalk.red("Site name is required. Usage: omp stats create-site <name>"));
+			process.exit(1);
+		}
+		await createSite(name);
+		return;
+	}
 
 	// Sync session files first
 	const progress = createSyncProgressReporter();

--- a/packages/coding-agent/src/commands/stats.ts
+++ b/packages/coding-agent/src/commands/stats.ts
@@ -2,14 +2,25 @@
  * View usage statistics dashboard.
  */
 
-import { Command, Flags } from "@oh-my-pi/pi-utils/cli";
+import { Args, Command, Flags } from "@oh-my-pi/pi-utils/cli";
 import { statsHelp as commandHelp } from "../cli/command-help";
 import type { StatsCommandArgs } from "../cli/stats-cli";
 import * as statsCli from "../cli/stats-cli";
-import * as theme from "../modes/theme/theme";
+import { initTheme } from "../modes/theme/theme";
 
 export default class Stats extends Command {
 	static description = commandHelp.description;
+	static args = {
+		action: Args.string({
+			description: "Stats action",
+			required: false,
+			options: ["create-site"] as const,
+		}),
+		name: Args.string({
+			description: "Site name (for create-site)",
+			required: false,
+		}),
+	};
 	static flags = {
 		port: Flags.integer({ char: "p", description: "Port for the dashboard server", default: 3847 }),
 		host: Flags.string({ description: "Host to bind", default: "127.0.0.1" }),
@@ -18,16 +29,18 @@ export default class Stats extends Command {
 	};
 
 	async run(): Promise<void> {
-		const { flags } = await this.parse(Stats);
+		const { args, flags } = await this.parse(Stats);
 
 		const cmd: StatsCommandArgs = {
 			port: flags.port,
 			host: flags.host ?? "127.0.0.1",
 			json: flags.json,
 			summary: flags.summary,
+			action: args.action as StatsCommandArgs["action"],
+			name: args.name,
 		};
 
-		await theme.initTheme();
+		await initTheme();
 		await statsCli.runStatsCommand(cmd);
 	}
 }

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added a redesigned /stats overview: an instrument-panel layout with per-section show/hide (localStorage persistence + presets), a `today` range anchored to local midnight with hourly buckets, and correct day/bucket accounting across DST transitions.
+
 ## [18.1.17] - 2026-09-10
 
 ### Fixed

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -34,6 +34,12 @@
 ### Fixed
 
 - Fixed inconsistent model colors between the Model Preference chart and Model Statistics table.
+### Added
+
+- Added a Today time range to the dashboard and stats API that anchors the chart to local midnight, so just-after-midnight activity is labeled on the correct day in any timezone.
+- Added a versioned public query API (`/api/v1/*`) with parameter validation and a framework-neutral TypeScript client SDK.
+- Added `omp stats create-site` scaffolding for embedding the stats dashboard into other pages.
+- Added a redesigned dashboard with overview and per-section inner pages, named dashboard layouts, density modes, and a command palette.
 
 ## [18.0.4] - 2026-08-24
 

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -83,10 +83,14 @@
       "types": "./src/client/*.ts",
       "import": "./src/client/*.ts"
     },
-    "./client/components/*": {
-      "types": "./src/client/components/*.ts",
-      "import": "./src/client/components/*.ts"
-    },
-    "./*.js": "./src/*.ts"
-  }
+    		"./client/components/*": {
+			"types": "./src/client/components/*.ts",
+			"import": "./src/client/components/*.ts"
+		},
+		"./client-sdk": {
+			"types": "./src/client-sdk.ts",
+			"import": "./src/client-sdk.ts"
+		},
+		"./*.js": "./src/*.ts"
+	}
 }

--- a/packages/stats/src/aggregator.ts
+++ b/packages/stats/src/aggregator.ts
@@ -329,7 +329,7 @@ const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
 const FIVE_MIN_MS = 5 * 60 * 1000;
 
-type TimeRange = "1h" | "24h" | "7d" | "30d" | "90d" | "all";
+type TimeRange = "today" | "1h" | "24h" | "7d" | "30d" | "90d" | "all";
 
 interface TimeRangeConfig {
 	timeSeriesHours: number;
@@ -345,6 +345,17 @@ interface TimeRangeConfig {
 const DEFAULT_TIME_RANGE: TimeRange = "24h";
 
 const TIME_RANGE_TO_CONFIG: Record<TimeRange, Omit<TimeRangeConfig, "cutoff">> = {
+	// Midnight-anchored window: same hourly bucketing as "24h", but the cutoff
+	// is local midnight rather than a rolling 24h (resolved below).
+	today: {
+		timeSeriesHours: 24,
+		timeSeriesBucketMs: HOUR_MS,
+		modelSeriesDays: 1,
+		modelSeriesBucketMs: HOUR_MS,
+		modelPerformanceDays: 1,
+		modelPerformanceBucketMs: HOUR_MS,
+		costSeriesDays: 1,
+	},
 	"1h": {
 		timeSeriesHours: 1,
 		timeSeriesBucketMs: FIVE_MIN_MS,
@@ -403,6 +414,12 @@ const TIME_RANGE_TO_CONFIG: Record<TimeRange, Omit<TimeRangeConfig, "cutoff">> =
 
 export function getTimeRangeConfig(range?: string | null): TimeRangeConfig {
 	const normalized = range?.trim().toLowerCase() ?? DEFAULT_TIME_RANGE;
+	if (normalized === "today") {
+		const config = TIME_RANGE_TO_CONFIG.today;
+		const midnight = new Date();
+		midnight.setHours(0, 0, 0, 0);
+		return { ...config, cutoff: midnight.getTime() };
+	}
 	const config = TIME_RANGE_TO_CONFIG[normalized as TimeRange];
 	if (config) {
 		const cutoff = normalized === "all" ? null : Date.now() - Math.max(1, config.timeSeriesHours * 60 * 60 * 1000);

--- a/packages/stats/src/aggregator.ts
+++ b/packages/stats/src/aggregator.ts
@@ -341,11 +341,13 @@ interface TimeRangeConfig {
 	modelPerformanceBucketMs: number;
 	costSeriesDays: number;
 	cutoff: number | null;
+	/** Bucket origin (ms) for today-aligned series; 0 keeps Unix-epoch alignment. */
+	bucketOrigin: number;
 }
 
 const DEFAULT_TIME_RANGE: TimeRange = "24h";
 
-const TIME_RANGE_TO_CONFIG: Record<TimeRange, Omit<TimeRangeConfig, "cutoff">> = {
+const TIME_RANGE_TO_CONFIG: Record<TimeRange, Omit<TimeRangeConfig, "cutoff" | "bucketOrigin">> = {
 	// Midnight-anchored window: same hourly bucketing as "24h", but the cutoff
 	// is local midnight rather than a rolling 24h (resolved below).
 	today: {
@@ -419,18 +421,22 @@ export function getTimeRangeConfig(range?: string | null): TimeRangeConfig {
 		const config = TIME_RANGE_TO_CONFIG.today;
 		const midnight = new Date();
 		midnight.setHours(0, 0, 0, 0);
-		return { ...config, cutoff: midnight.getTime() };
+		const cutoff = midnight.getTime();
+		// Align today's buckets to local midnight so fractional-UTC zones
+		// (e.g. Asia/Kolkata +05:30) label the first bucket at local midnight.
+		return { ...config, cutoff, bucketOrigin: cutoff };
 	}
 	const config = TIME_RANGE_TO_CONFIG[normalized as TimeRange];
 	if (config) {
 		const cutoff = normalized === "all" ? null : Date.now() - Math.max(1, config.timeSeriesHours * 60 * 60 * 1000);
-		return { ...config, cutoff };
+		return { ...config, cutoff, bucketOrigin: 0 };
 	}
 
 	const fallbackConfig = TIME_RANGE_TO_CONFIG[DEFAULT_TIME_RANGE];
 	return {
 		...fallbackConfig,
 		cutoff: Date.now() - fallbackConfig.timeSeriesHours * 60 * 60 * 1000,
+		bucketOrigin: 0,
 	};
 }
 
@@ -448,6 +454,7 @@ export async function getDashboardStats(range?: string | null): Promise<Dashboar
 		modelPerformanceBucketMs,
 		costSeriesDays,
 		cutoff,
+		bucketOrigin,
 	} = getTimeRangeConfig(range);
 
 	return {
@@ -455,10 +462,15 @@ export async function getDashboardStats(range?: string | null): Promise<Dashboar
 		byModel: getStatsByModel(cutoff ?? undefined),
 		byFolder: getStatsByFolder(cutoff ?? undefined),
 		byAgentType: getStatsByAgentType(cutoff ?? undefined),
-		timeSeries: getTimeSeries(timeSeriesHours, cutoff, timeSeriesBucketMs),
-		modelSeries: getModelTimeSeries(modelSeriesDays, cutoff, modelSeriesBucketMs),
-		modelPerformanceSeries: getModelPerformanceSeries(modelPerformanceDays, cutoff, modelPerformanceBucketMs),
-		costSeries: getCostTimeSeries(costSeriesDays, cutoff),
+		timeSeries: getTimeSeries(timeSeriesHours, cutoff, timeSeriesBucketMs, bucketOrigin),
+		modelSeries: getModelTimeSeries(modelSeriesDays, cutoff, modelSeriesBucketMs, bucketOrigin),
+		modelPerformanceSeries: getModelPerformanceSeries(
+			modelPerformanceDays,
+			cutoff,
+			modelPerformanceBucketMs,
+			bucketOrigin,
+		),
+		costSeries: getCostTimeSeries(costSeriesDays, cutoff, bucketOrigin),
 	};
 }
 
@@ -466,12 +478,12 @@ export async function getOverviewStats(
 	range?: string | null,
 ): Promise<Pick<DashboardStats, "overall" | "byAgentType" | "timeSeries">> {
 	await initDb();
-	const { timeSeriesHours, timeSeriesBucketMs, cutoff } = getTimeRangeConfig(range);
+	const { timeSeriesHours, timeSeriesBucketMs, cutoff, bucketOrigin } = getTimeRangeConfig(range);
 
 	return {
 		overall: getOverallStats(cutoff ?? undefined),
 		byAgentType: getStatsByAgentType(cutoff ?? undefined),
-		timeSeries: getTimeSeries(timeSeriesHours, cutoff, timeSeriesBucketMs),
+		timeSeries: getTimeSeries(timeSeriesHours, cutoff, timeSeriesBucketMs, bucketOrigin),
 	};
 }
 
@@ -479,22 +491,33 @@ export async function getModelDashboardStats(
 	range?: string | null,
 ): Promise<Pick<DashboardStats, "byModel" | "modelSeries" | "modelPerformanceSeries">> {
 	await initDb();
-	const { modelSeriesDays, modelSeriesBucketMs, modelPerformanceDays, modelPerformanceBucketMs, cutoff } =
-		getTimeRangeConfig(range);
+	const {
+		modelSeriesDays,
+		modelSeriesBucketMs,
+		modelPerformanceDays,
+		modelPerformanceBucketMs,
+		cutoff,
+		bucketOrigin,
+	} = getTimeRangeConfig(range);
 
 	return {
 		byModel: getStatsByModel(cutoff ?? undefined),
-		modelSeries: getModelTimeSeries(modelSeriesDays, cutoff, modelSeriesBucketMs),
-		modelPerformanceSeries: getModelPerformanceSeries(modelPerformanceDays, cutoff, modelPerformanceBucketMs),
+		modelSeries: getModelTimeSeries(modelSeriesDays, cutoff, modelSeriesBucketMs, bucketOrigin),
+		modelPerformanceSeries: getModelPerformanceSeries(
+			modelPerformanceDays,
+			cutoff,
+			modelPerformanceBucketMs,
+			bucketOrigin,
+		),
 	};
 }
 
 export async function getCostDashboardStats(range?: string | null): Promise<Pick<DashboardStats, "costSeries">> {
 	await initDb();
-	const { costSeriesDays, cutoff } = getTimeRangeConfig(range);
+	const { costSeriesDays, cutoff, bucketOrigin } = getTimeRangeConfig(range);
 
 	return {
-		costSeries: getCostTimeSeries(costSeriesDays, cutoff),
+		costSeries: getCostTimeSeries(costSeriesDays, cutoff, bucketOrigin),
 	};
 }
 
@@ -512,13 +535,15 @@ export async function getRecentRequests(limit?: number): Promise<MessageStats[]>
 /**
  * Paginated requests with real total count.
  * Returns the actual total number of rows (not min(total, limit+offset)).
+ * @param cutoff - Range cutoff (ms); null returns all rows.
  */
 export async function getRequestsPaginated(
 	limit: number,
 	offset: number,
+	cutoff?: number | null,
 ): Promise<{ items: MessageStats[]; total: number }> {
 	await initDb();
-	return dbGetRequestsPaginated(limit, offset);
+	return dbGetRequestsPaginated(limit, offset, cutoff);
 }
 
 export async function getRecentErrors(range?: string | null, limit?: number): Promise<MessageStats[]> {
@@ -570,11 +595,11 @@ export async function getBehaviorDashboardStats(range?: string | null): Promise<
  */
 export async function getToolDashboardStats(range?: string | null): Promise<ToolDashboardStats> {
 	await initDb();
-	const { modelSeriesDays, modelSeriesBucketMs, cutoff } = getTimeRangeConfig(range);
+	const { modelSeriesDays, modelSeriesBucketMs, cutoff, bucketOrigin } = getTimeRangeConfig(range);
 	return {
 		byTool: getToolStats(cutoff ?? undefined),
 		byToolModel: getToolStatsByModel(cutoff ?? undefined),
-		series: getToolTimeSeries(modelSeriesDays, cutoff, modelSeriesBucketMs),
+		series: getToolTimeSeries(modelSeriesDays, cutoff, modelSeriesBucketMs, bucketOrigin),
 	};
 }
 
@@ -589,7 +614,7 @@ export async function getToolDashboardStats(range?: string | null): Promise<Tool
  */
 export async function getProviderDashboardStats(range?: string | null): Promise<ProviderDashboardStats> {
 	await initDb();
-	const { modelSeriesDays, modelSeriesBucketMs, cutoff } = getTimeRangeConfig(range);
+	const { modelSeriesDays, modelSeriesBucketMs, cutoff, bucketOrigin } = getTimeRangeConfig(range);
 	const providers = getStatsByProvider(cutoff ?? undefined);
 	const usage = await fetchUsageData(cutoff ?? 0);
 	const tokensByProvider = usage.fleetTokensByProvider ?? new Map(providers.map(p => [p.provider, p.totalTokens]));
@@ -597,7 +622,7 @@ export async function getProviderDashboardStats(range?: string | null): Promise<
 	return {
 		providers,
 		hourly: getProviderHourlyBurn(cutoff ?? undefined),
-		series: getProviderTimeSeries(modelSeriesDays, cutoff, modelSeriesBucketMs),
+		series: getProviderTimeSeries(modelSeriesDays, cutoff, modelSeriesBucketMs, bucketOrigin),
 		usageSeries,
 		windowInsights,
 	};

--- a/packages/stats/src/aggregator.ts
+++ b/packages/stats/src/aggregator.ts
@@ -581,11 +581,11 @@ export async function getTotalMessageCount(): Promise<number> {
 
 export async function getBehaviorDashboardStats(range?: string | null): Promise<BehaviorDashboardStats> {
 	await initDb();
-	const { cutoff } = getTimeRangeConfig(range);
+	const { cutoff, bucketOrigin } = getTimeRangeConfig(range);
 	return {
 		overall: getBehaviorOverall(cutoff),
 		byModel: getBehaviorByModel(cutoff),
-		behaviorSeries: getBehaviorTimeSeries(cutoff),
+		behaviorSeries: getBehaviorTimeSeries(cutoff, bucketOrigin),
 	};
 }
 

--- a/packages/stats/src/aggregator.ts
+++ b/packages/stats/src/aggregator.ts
@@ -5,6 +5,7 @@ import { withFileLock } from "@oh-my-pi/pi-utils/file-lock";
 import {
 	getRecentErrors as dbGetRecentErrors,
 	getRecentRequests as dbGetRecentRequests,
+	getRequestsPaginated as dbGetRequestsPaginated,
 	getBehaviorByModel,
 	getBehaviorOverall,
 	getBehaviorTimeSeries,
@@ -506,6 +507,18 @@ export async function getFolderStats(range?: string | null): Promise<FolderStats
 export async function getRecentRequests(limit?: number): Promise<MessageStats[]> {
 	await initDb();
 	return dbGetRecentRequests(limit);
+}
+
+/**
+ * Paginated requests with real total count.
+ * Returns the actual total number of rows (not min(total, limit+offset)).
+ */
+export async function getRequestsPaginated(
+	limit: number,
+	offset: number,
+): Promise<{ items: MessageStats[]; total: number }> {
+	await initDb();
+	return dbGetRequestsPaginated(limit, offset);
 }
 
 export async function getRecentErrors(range?: string | null, limit?: number): Promise<MessageStats[]> {

--- a/packages/stats/src/aggregator.ts
+++ b/packages/stats/src/aggregator.ts
@@ -514,10 +514,10 @@ export async function getModelDashboardStats(
 
 export async function getCostDashboardStats(range?: string | null): Promise<Pick<DashboardStats, "costSeries">> {
 	await initDb();
-	const { costSeriesDays, cutoff, bucketOrigin } = getTimeRangeConfig(range);
+	const { costSeriesDays, timeSeriesBucketMs, cutoff, bucketOrigin } = getTimeRangeConfig(range);
 
 	return {
-		costSeries: getCostTimeSeries(costSeriesDays, cutoff, bucketOrigin),
+		costSeries: getCostTimeSeries(costSeriesDays, cutoff, bucketOrigin, timeSeriesBucketMs),
 	};
 }
 
@@ -581,11 +581,11 @@ export async function getTotalMessageCount(): Promise<number> {
 
 export async function getBehaviorDashboardStats(range?: string | null): Promise<BehaviorDashboardStats> {
 	await initDb();
-	const { cutoff, bucketOrigin } = getTimeRangeConfig(range);
+	const { cutoff, timeSeriesBucketMs, bucketOrigin } = getTimeRangeConfig(range);
 	return {
 		overall: getBehaviorOverall(cutoff),
 		byModel: getBehaviorByModel(cutoff),
-		behaviorSeries: getBehaviorTimeSeries(cutoff, bucketOrigin),
+		behaviorSeries: getBehaviorTimeSeries(cutoff, bucketOrigin, timeSeriesBucketMs),
 	};
 }
 

--- a/packages/stats/src/api-v1.ts
+++ b/packages/stats/src/api-v1.ts
@@ -22,6 +22,7 @@ import {
 	getProviderDashboardStats,
 	getRecentErrors,
 	getRequestsPaginated,
+	getTimeRangeConfig,
 	getToolDashboardStats,
 } from "./aggregator";
 import { getGainDashboardStats } from "./gain-aggregator";
@@ -152,7 +153,8 @@ export async function handleApiV1(req: Request): Promise<Response> {
 			const offset = offsetRaw ? Number.parseInt(offsetRaw, 10) : 0;
 			const effectiveLimit = Number.isFinite(limit) && limit >= 0 ? limit : 20;
 			const effectiveOffset = Number.isFinite(offset) && offset >= 0 ? offset : 0;
-			const { items, total } = await getRequestsPaginated(effectiveLimit, effectiveOffset);
+			const { cutoff } = getTimeRangeConfig(range);
+			const { items, total } = await getRequestsPaginated(effectiveLimit, effectiveOffset, cutoff);
 			return Response.json({ requests: items, total }, { headers: CORS_HEADERS });
 		}
 

--- a/packages/stats/src/api-v1.ts
+++ b/packages/stats/src/api-v1.ts
@@ -1,0 +1,170 @@
+/**
+ * Versioned Stats API v1 router.
+ *
+ * All endpoints return the same response shapes as the existing `/api/stats/*`
+ * routes (one source of truth: same aggregator functions). This module adds
+ * versioning, parameter validation, CORS headers for loopback dev, and honest
+ * error handling.
+ *
+ * Base path: /api/v1/
+ *
+ * Supported ranges: today, 1h, 24h, 7d, 30d, 90d, all (default 24h).
+ * from/to epoch-ms and model/provider/status filters: NOT supported by the
+ * existing query layer, so omitted. Documented in /api/v1/meta.
+ */
+
+import {
+	getBehaviorDashboardStats,
+	getCostDashboardStats,
+	getFolderStats,
+	getModelDashboardStats,
+	getOverviewStats,
+	getProviderDashboardStats,
+	getRecentErrors,
+	getRequestsPaginated,
+	getToolDashboardStats,
+} from "./aggregator";
+import { getGainDashboardStats } from "./gain-aggregator";
+
+const VALID_RANGES = ["today", "1h", "24h", "7d", "30d", "90d", "all"] as const;
+type ValidRange = (typeof VALID_RANGES)[number];
+
+const DEFAULT_RANGE: ValidRange = "24h";
+
+/** CORS header for loopback development. */
+const CORS_HEADERS: Record<string, string> = {
+	"Access-Control-Allow-Origin": "http://localhost:3000",
+	"Access-Control-Allow-Methods": "GET, OPTIONS",
+	"Access-Control-Allow-Headers": "Content-Type",
+	"Access-Control-Max-Age": "86400",
+};
+
+/**
+ * Handle an API v1 request.
+ *
+ * All handlers call the same functions as the existing unversioned routes.
+ * The response shapes are identical — this is a stable version boundary, not
+ * a different aggregation layer.
+ */
+export async function handleApiV1(req: Request): Promise<Response> {
+	const url = new URL(req.url);
+	const pathname = url.pathname;
+
+	// Only GET is supported (OPTIONS preflight is handled at the server level)
+	if (req.method !== "GET") {
+		return Response.json({ error: "Method not allowed" }, { status: 405, headers: CORS_HEADERS });
+	}
+
+	const rawRange = url.searchParams.get("range");
+	const normalized = rawRange?.trim().toLowerCase();
+	if (normalized !== undefined && normalized !== "" && !(VALID_RANGES as readonly string[]).includes(normalized)) {
+		return Response.json(
+			{ error: `Invalid range "${rawRange}". Valid ranges: ${VALID_RANGES.join(", ")}` },
+			{ status: 400, headers: CORS_HEADERS },
+		);
+	}
+	const range: ValidRange = normalized ? (normalized as ValidRange) : DEFAULT_RANGE;
+
+	try {
+		if (pathname === "/api/v1/meta") {
+			return Response.json(
+				{
+					version: 1,
+					ranges: [...VALID_RANGES],
+					endpoints: [
+						"/api/v1/meta",
+						"/api/v1/overview",
+						"/api/v1/models",
+						"/api/v1/providers",
+						"/api/v1/tools",
+						"/api/v1/projects",
+						"/api/v1/costs",
+						"/api/v1/behavior",
+						"/api/v1/errors",
+						"/api/v1/requests",
+						"/api/v1/gain",
+					],
+					serverTime: Date.now(),
+					supportedParams: {
+						range: VALID_RANGES,
+						limit: "number (errors, requests)",
+						offset: "number (requests)",
+						project: "string (gain)",
+					},
+					unsupportedParams: {
+						from: "not supported by query layer (use range instead)",
+						to: "not supported by query layer (use range instead)",
+						model: "not supported by query layer",
+						provider: "not supported by query layer",
+						status: "not supported by query layer",
+					},
+				},
+				{ headers: CORS_HEADERS },
+			);
+		}
+
+		if (pathname === "/api/v1/overview") {
+			const stats = await getOverviewStats(range);
+			return Response.json(stats, { headers: CORS_HEADERS });
+		}
+
+		if (pathname === "/api/v1/models") {
+			const stats = await getModelDashboardStats(range);
+			return Response.json(stats, { headers: CORS_HEADERS });
+		}
+
+		if (pathname === "/api/v1/providers") {
+			const stats = await getProviderDashboardStats(range);
+			return Response.json(stats, { headers: CORS_HEADERS });
+		}
+
+		if (pathname === "/api/v1/tools") {
+			const stats = await getToolDashboardStats(range);
+			return Response.json(stats, { headers: CORS_HEADERS });
+		}
+
+		if (pathname === "/api/v1/projects") {
+			const stats = await getFolderStats(range);
+			return Response.json(stats, { headers: CORS_HEADERS });
+		}
+
+		if (pathname === "/api/v1/costs") {
+			const stats = await getCostDashboardStats(range);
+			return Response.json(stats, { headers: CORS_HEADERS });
+		}
+
+		if (pathname === "/api/v1/behavior") {
+			const stats = await getBehaviorDashboardStats(range);
+			return Response.json(stats, { headers: CORS_HEADERS });
+		}
+
+		if (pathname === "/api/v1/errors") {
+			const limitRaw = url.searchParams.get("limit");
+			const limit = limitRaw ? Number.parseInt(limitRaw, 10) : 20;
+			const stats = await getRecentErrors(range, Number.isFinite(limit) && limit >= 0 ? limit : 20);
+			return Response.json(stats, { headers: CORS_HEADERS });
+		}
+
+		if (pathname === "/api/v1/requests") {
+			const limitRaw = url.searchParams.get("limit");
+			const offsetRaw = url.searchParams.get("offset");
+			const limit = limitRaw ? Number.parseInt(limitRaw, 10) : 20;
+			const offset = offsetRaw ? Number.parseInt(offsetRaw, 10) : 0;
+			const effectiveLimit = Number.isFinite(limit) && limit >= 0 ? limit : 20;
+			const effectiveOffset = Number.isFinite(offset) && offset >= 0 ? offset : 0;
+			const { items, total } = await getRequestsPaginated(effectiveLimit, effectiveOffset);
+			return Response.json({ requests: items, total }, { headers: CORS_HEADERS });
+		}
+
+		if (pathname === "/api/v1/gain") {
+			const project = url.searchParams.get("project");
+			const stats = await getGainDashboardStats(range, project);
+			return Response.json(stats, { headers: CORS_HEADERS });
+		}
+
+		return Response.json({ error: "Unknown v1 endpoint" }, { status: 404, headers: CORS_HEADERS });
+	} catch (err) {
+		const message = err instanceof Error ? err.message : "Internal server error";
+		return Response.json({ error: message }, { status: 500, headers: CORS_HEADERS });
+	}
+}

--- a/packages/stats/src/client-sdk.ts
+++ b/packages/stats/src/client-sdk.ts
@@ -1,0 +1,189 @@
+/**
+ * Framework-neutral TypeScript client SDK for OMP Stats v1 API.
+ *
+ * Usage:
+ * ```ts
+ * import { createOmpStatsClient } from "@oh-my-pi/omp-stats/client-sdk";
+ * const client = createOmpStatsClient({ baseUrl: "http://127.0.0.1:3847" });
+ * const overview = await client.overview({ range: "7d" });
+ * ```
+ */
+
+import type {
+	BehaviorDashboardStats,
+	CostTimeSeriesPoint,
+	GainDashboardStats,
+	ModelStats,
+	ProviderDashboardStats,
+	TimeSeriesPoint,
+	ToolDashboardStats,
+} from "./shared-types";
+import type { AggregatedStats, FolderStats, MessageStats } from "./types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Configuration for the OMP Stats client. */
+export interface OmpStatsClientOptions {
+	/** Base URL of the OMP Stats server (e.g. "http://127.0.0.1:3847"). */
+	baseUrl: string;
+	/** Optional fetch implementation for testing or custom transport. */
+	fetch?: typeof globalThis.fetch;
+}
+
+/** Supported time ranges. */
+export type TimeRange = "today" | "1h" | "24h" | "7d" | "30d" | "90d" | "all";
+
+/** Query options for endpoints that support a range parameter. */
+export interface RangeQuery {
+	/** Time range for the query. Defaults to "24h". */
+	range?: TimeRange;
+}
+
+/** Query options for the errors endpoint. */
+export interface ErrorsQuery extends RangeQuery {
+	/** Maximum number of errors to return. Defaults to 20. */
+	limit?: number;
+}
+
+/** Query options for the requests endpoint. */
+export interface RequestsQuery extends RangeQuery {
+	/** Maximum number of requests to return. Defaults to 20. */
+	limit?: number;
+	/** Offset for pagination. Defaults to 0. */
+	offset?: number;
+}
+
+/** Query options for the gain endpoint. */
+export interface GainQuery extends RangeQuery {
+	/** Project filter (cwd prefix). */
+	project?: string;
+}
+
+/** Meta response shape. */
+export interface MetaResponse {
+	version: number;
+	ranges: string[];
+	endpoints: string[];
+	serverTime: number;
+	supportedParams: Record<string, string>;
+	unsupportedParams: Record<string, string>;
+}
+
+/** Overview response shape (same as existing /api/stats/overview). */
+export interface OverviewResponse {
+	overall: AggregatedStats;
+	byAgentType: import("./shared-types").AgentTypeStats[];
+	timeSeries: TimeSeriesPoint[];
+}
+
+/** Models response shape (same as existing /api/stats/model-dashboard). */
+export interface ModelsResponse {
+	byModel: ModelStats[];
+	modelSeries: import("./shared-types").ModelTimeSeriesPoint[];
+	modelPerformanceSeries: import("./shared-types").ModelPerformancePoint[];
+}
+
+/** Providers response shape (same as existing /api/stats/providers). */
+export interface ProvidersResponse extends ProviderDashboardStats {}
+
+/** Tools response shape (same as existing /api/stats/tools). */
+export interface ToolsResponse extends ToolDashboardStats {}
+
+/** Projects response shape (same as existing /api/stats/folders). */
+export interface ProjectsResponse extends Array<FolderStats> {}
+
+/** Costs response shape (same as existing /api/stats/costs). */
+export interface CostsResponse {
+	costSeries: CostTimeSeriesPoint[];
+}
+
+/** Behavior response shape (same as existing /api/stats/behavior). */
+export interface BehaviorResponse extends BehaviorDashboardStats {}
+
+/** Errors response shape (same as existing /api/stats/errors). */
+export interface ErrorsResponse extends Array<MessageStats> {}
+
+/** Requests response shape (paginated). */
+export interface RequestsResponse {
+	requests: MessageStats[];
+	total: number;
+}
+
+/** Gain response shape (same as existing /api/stats/gain). */
+export interface GainResponse extends GainDashboardStats {}
+
+/** OMP Stats client interface. */
+export interface OmpStatsClient {
+	/** Fetch the v1 API metadata. */
+	meta(): Promise<MetaResponse>;
+	/** Fetch overview stats for the given time range. */
+	overview(query?: RangeQuery): Promise<OverviewResponse>;
+	/** Fetch model dashboard stats. */
+	models(query?: RangeQuery): Promise<ModelsResponse>;
+	/** Fetch provider dashboard stats. */
+	providers(query?: RangeQuery): Promise<ProvidersResponse>;
+	/** Fetch tool dashboard stats. */
+	tools(query?: RangeQuery): Promise<ToolsResponse>;
+	/** Fetch project/folder stats. */
+	projects(query?: RangeQuery): Promise<ProjectsResponse>;
+	/** Fetch cost dashboard stats. */
+	costs(query?: RangeQuery): Promise<CostsResponse>;
+	/** Fetch behavior dashboard stats. */
+	behavior(query?: RangeQuery): Promise<BehaviorResponse>;
+	/** Fetch recent errors. */
+	errors(query?: ErrorsQuery): Promise<ErrorsResponse>;
+	/** Fetch recent requests (paginated). */
+	requests(query?: RequestsQuery): Promise<RequestsResponse>;
+	/** Fetch gain/efficiency stats. */
+	gain(query?: GainQuery): Promise<GainResponse>;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an OMP Stats v1 API client.
+ *
+ * @param options - Client configuration.
+ * @returns A typed client with methods for each v1 endpoint.
+ */
+export function createOmpStatsClient(options: OmpStatsClientOptions): OmpStatsClient {
+	const baseUrl = options.baseUrl.replace(/\/+$/, "");
+	const fetchFn = options.fetch ?? globalThis.fetch;
+
+	const get = <T>(apiPath: string, params?: Record<string, string | number | undefined>): Promise<T> => {
+		const url = new URL(`${baseUrl}${apiPath}`);
+		if (params) {
+			for (const [key, value] of Object.entries(params)) {
+				if (value !== undefined && value !== null) {
+					url.searchParams.set(key, String(value));
+				}
+			}
+		}
+		return fetchFn(url.toString()).then(async response => {
+			if (!response.ok) {
+				const body = await response.text();
+				throw new Error(`OMP Stats API error ${response.status}: ${body}`);
+			}
+			return (await response.json()) as T;
+		});
+	};
+
+	return {
+		meta: () => get<MetaResponse>("/api/v1/meta"),
+		overview: query => get<OverviewResponse>("/api/v1/overview", { range: query?.range }),
+		models: query => get<ModelsResponse>("/api/v1/models", { range: query?.range }),
+		providers: query => get<ProvidersResponse>("/api/v1/providers", { range: query?.range }),
+		tools: query => get<ToolsResponse>("/api/v1/tools", { range: query?.range }),
+		projects: query => get<ProjectsResponse>("/api/v1/projects", { range: query?.range }),
+		costs: query => get<CostsResponse>("/api/v1/costs", { range: query?.range }),
+		behavior: query => get<BehaviorResponse>("/api/v1/behavior", { range: query?.range }),
+		errors: query => get<ErrorsResponse>("/api/v1/errors", { range: query?.range, limit: query?.limit }),
+		requests: query =>
+			get<RequestsResponse>("/api/v1/requests", { range: query?.range, limit: query?.limit, offset: query?.offset }),
+		gain: query => get<GainResponse>("/api/v1/gain", { range: query?.range, project: query?.project }),
+	};
+}

--- a/packages/stats/src/client-sdk.ts
+++ b/packages/stats/src/client-sdk.ts
@@ -10,10 +10,13 @@
  */
 
 import type {
+	AgentTypeStats,
 	BehaviorDashboardStats,
 	CostTimeSeriesPoint,
 	GainDashboardStats,
+	ModelPerformancePoint,
 	ModelStats,
+	ModelTimeSeriesPoint,
 	ProviderDashboardStats,
 	TimeSeriesPoint,
 	ToolDashboardStats,
@@ -67,22 +70,22 @@ export interface MetaResponse {
 	ranges: string[];
 	endpoints: string[];
 	serverTime: number;
-	supportedParams: Record<string, string>;
+	supportedParams: Record<string, string[] | string>;
 	unsupportedParams: Record<string, string>;
 }
 
 /** Overview response shape (same as existing /api/stats/overview). */
 export interface OverviewResponse {
 	overall: AggregatedStats;
-	byAgentType: import("./shared-types").AgentTypeStats[];
+	byAgentType: AgentTypeStats[];
 	timeSeries: TimeSeriesPoint[];
 }
 
 /** Models response shape (same as existing /api/stats/model-dashboard). */
 export interface ModelsResponse {
 	byModel: ModelStats[];
-	modelSeries: import("./shared-types").ModelTimeSeriesPoint[];
-	modelPerformanceSeries: import("./shared-types").ModelPerformancePoint[];
+	modelSeries: ModelTimeSeriesPoint[];
+	modelPerformanceSeries: ModelPerformancePoint[];
 }
 
 /** Providers response shape (same as existing /api/stats/providers). */

--- a/packages/stats/src/client/App.tsx
+++ b/packages/stats/src/client/App.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { AppLayout } from "./app/AppLayout";
+import { CommandPalette } from "./app/CommandPalette";
 import type { DashboardSection } from "./app/routes";
 import { useHashRoute } from "./data/useHashRoute";
 import {
@@ -15,6 +16,7 @@ import {
 	ToolsRoute,
 	TracesRoute,
 } from "./routes";
+import type { TimeRange } from "./types";
 import { RequestDrawer } from "./ui/RequestDrawer";
 
 export default function App() {
@@ -22,6 +24,7 @@ export default function App() {
 	const [refreshTrigger, setRefreshTrigger] = useState(0);
 	const [selectedRequestId, setSelectedRequestId] = useState<number | null>(null);
 	const [updatedAt, setUpdatedAt] = useState<number | null>(() => Date.now());
+	const [paletteOpen, setPaletteOpen] = useState(false);
 
 	const handleSyncComplete = useCallback((result: { success: boolean }) => {
 		if (result.success) {
@@ -30,16 +33,29 @@ export default function App() {
 		}
 	}, []);
 
-	// Stable identity so the drawer's effects don't tear down on every App render.
 	const closeDrawer = useCallback(() => setSelectedRequestId(null), []);
+
+	useEffect(() => {
+		const onKey = (e: KeyboardEvent) => {
+			if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+				e.preventDefault();
+				setPaletteOpen(o => !o);
+			}
+		};
+		window.addEventListener("keydown", onKey);
+		return () => window.removeEventListener("keydown", onKey);
+	}, []);
+
+	const handlePaletteNav = useCallback(
+		(sectionArg: string, rangeArg?: TimeRange) => {
+			if (rangeArg) setRange(rangeArg);
+			if (sectionArg) setSection(sectionArg as DashboardSection);
+		},
+		[setRange, setSection],
+	);
 
 	const active = section;
 
-	// Keep every visited section mounted and just toggle visibility. Remounting a
-	// route on each navigation replays the chart entry animations (a visible
-	// flicker); keeping it alive makes revisits instant while the live chart
-	// instances still animate in place on data/range updates. Only the active
-	// route fetches/polls (enabled), so hidden routes don't keep hitting the API.
 	const mountedRef = useRef<Set<DashboardSection>>(new Set());
 	mountedRef.current.add(active);
 
@@ -117,6 +133,7 @@ export default function App() {
 			</AppLayout>
 
 			<RequestDrawer id={selectedRequestId} onClose={closeDrawer} />
+			<CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} onNavigate={handlePaletteNav} />
 		</>
 	);
 }

--- a/packages/stats/src/client/api.ts
+++ b/packages/stats/src/client/api.ts
@@ -14,7 +14,8 @@ import type {
 	ToolDashboardStats,
 } from "./types";
 
-const API_BASE = "/api";
+const V1_BASE = "/api/v1";
+const LEGACY_BASE = "/api";
 
 export class ApiError extends Error {
 	status: number;
@@ -36,30 +37,65 @@ async function fetchJson<T>(endpoint: string, options?: RequestInit): Promise<T>
 	return res.json() as Promise<T>;
 }
 
+async function fetchV1<T>(v1Path: string, legacyPath: string, options?: RequestInit): Promise<T> {
+	try {
+		return await fetchJson<T>(`${V1_BASE}${v1Path}`, options);
+	} catch (err) {
+		if (err instanceof ApiError && err.status === 404) {
+			return fetchJson<T>(`${LEGACY_BASE}${legacyPath}`, options);
+		}
+		throw err;
+	}
+}
+
 export async function getOverviewStats(range: TimeRange = "24h", signal?: AbortSignal): Promise<OverviewStats> {
-	return fetchJson<OverviewStats>(`${API_BASE}/stats/overview?range=${encodeURIComponent(range)}`, {
-		signal,
-	});
+	return fetchV1<OverviewStats>(
+		`/overview?range=${encodeURIComponent(range)}`,
+		`/stats/overview?range=${encodeURIComponent(range)}`,
+		{
+			signal,
+		},
+	);
 }
 
 export async function getModelDashboardStats(
 	range: TimeRange = "24h",
 	signal?: AbortSignal,
 ): Promise<ModelDashboardStats> {
-	return fetchJson<ModelDashboardStats>(`${API_BASE}/stats/model-dashboard?range=${encodeURIComponent(range)}`, {
-		signal,
-	});
+	return fetchV1<ModelDashboardStats>(
+		`/models?range=${encodeURIComponent(range)}`,
+		`/stats/model-dashboard?range=${encodeURIComponent(range)}`,
+		{
+			signal,
+		},
+	);
 }
 
 export async function getCostDashboardStats(
 	range: TimeRange = "24h",
 	signal?: AbortSignal,
 ): Promise<CostDashboardStats> {
-	return fetchJson<CostDashboardStats>(`${API_BASE}/stats/costs?range=${encodeURIComponent(range)}`, { signal });
+	return fetchV1<CostDashboardStats>(
+		`/costs?range=${encodeURIComponent(range)}`,
+		`/stats/costs?range=${encodeURIComponent(range)}`,
+		{ signal },
+	);
 }
 
 export async function getRecentRequests(limit = 50, signal?: AbortSignal): Promise<MessageStats[]> {
-	return fetchJson<MessageStats[]>(`${API_BASE}/stats/recent?limit=${limit}`, { signal });
+	try {
+		const res = await fetchJson<{ requests: MessageStats[]; total: number }>(`${V1_BASE}/requests?limit=${limit}`, {
+			signal,
+		});
+		if (Array.isArray(res as unknown as MessageStats[])) return res as unknown as MessageStats[];
+		if (res && Array.isArray(res.requests)) return res.requests;
+		return [];
+	} catch (err) {
+		if (err instanceof ApiError && err.status === 404) {
+			return fetchJson<MessageStats[]>(`${LEGACY_BASE}/stats/recent?limit=${limit}`, { signal });
+		}
+		throw err;
+	}
 }
 
 export async function getRecentErrors(
@@ -67,30 +103,69 @@ export async function getRecentErrors(
 	limit = 50,
 	signal?: AbortSignal,
 ): Promise<MessageStats[]> {
-	return fetchJson<MessageStats[]>(`${API_BASE}/stats/errors?range=${encodeURIComponent(range)}&limit=${limit}`, {
-		signal,
-	});
+	return fetchV1<MessageStats[]>(
+		`/errors?range=${encodeURIComponent(range)}&limit=${limit}`,
+		`/stats/errors?range=${encodeURIComponent(range)}&limit=${limit}`,
+		{
+			signal,
+		},
+	);
+}
+
+export async function getRequestsPaginated(
+	range: TimeRange = "24h",
+	limit = 50,
+	offset = 0,
+	signal?: AbortSignal,
+): Promise<{ requests: MessageStats[]; total: number }> {
+	try {
+		const res = await fetchJson<{ requests: MessageStats[]; total: number }>(
+			`${V1_BASE}/requests?range=${encodeURIComponent(range)}&limit=${limit}&offset=${offset}`,
+			{ signal },
+		);
+		if (res && Array.isArray(res.requests) && typeof res.total === "number") return res;
+		// Fallback: legacy returned array
+		if (Array.isArray(res as unknown as MessageStats[])) {
+			const arr = res as unknown as MessageStats[];
+			return { requests: arr.slice(offset, offset + limit), total: arr.length };
+		}
+		return { requests: [], total: 0 };
+	} catch (err) {
+		if (err instanceof ApiError && err.status === 404) {
+			const legacy = await fetchJson<MessageStats[]>(`${LEGACY_BASE}/stats/recent?limit=${limit}`, { signal });
+			return { requests: legacy.slice(offset, offset + limit), total: legacy.length };
+		}
+		throw err;
+	}
 }
 
 export async function getRequestDetails(id: number, signal?: AbortSignal): Promise<RequestDetails> {
-	return fetchJson<RequestDetails>(`${API_BASE}/request/${id}`, { signal });
+	return fetchJson<RequestDetails>(`${LEGACY_BASE}/request/${id}`, { signal });
 }
 
 export async function sync(signal?: AbortSignal): Promise<{ processed: number; files: number; totalMessages: number }> {
-	return fetchJson<{ processed: number; files: number; totalMessages: number }>(`${API_BASE}/sync`, { signal });
+	return fetchJson<{ processed: number; files: number; totalMessages: number }>(`${LEGACY_BASE}/sync`, { signal });
 }
 
 export async function getBehaviorDashboardStats(
 	range: TimeRange = "24h",
 	signal?: AbortSignal,
 ): Promise<BehaviorDashboardStats> {
-	return fetchJson<BehaviorDashboardStats>(`${API_BASE}/stats/behavior?range=${encodeURIComponent(range)}`, {
-		signal,
-	});
+	return fetchV1<BehaviorDashboardStats>(
+		`/behavior?range=${encodeURIComponent(range)}`,
+		`/stats/behavior?range=${encodeURIComponent(range)}`,
+		{
+			signal,
+		},
+	);
 }
 
 export async function getFolderStats(range: TimeRange = "24h", signal?: AbortSignal): Promise<FolderStats[]> {
-	return fetchJson<FolderStats[]>(`${API_BASE}/stats/folders?range=${encodeURIComponent(range)}`, { signal });
+	return fetchV1<FolderStats[]>(
+		`/projects?range=${encodeURIComponent(range)}`,
+		`/stats/folders?range=${encodeURIComponent(range)}`,
+		{ signal },
+	);
 }
 
 export async function getGainDashboardStats(
@@ -100,21 +175,37 @@ export async function getGainDashboardStats(
 ): Promise<GainDashboardStats> {
 	const params = new URLSearchParams({ range });
 	if (project) params.set("project", project);
-	return fetchJson<GainDashboardStats>(`${API_BASE}/stats/gain?${params}`, { signal });
+	return fetchV1<GainDashboardStats>(`/gain?${params}`, `/stats/gain?${params}`, { signal });
 }
 
 export async function getToolDashboardStats(
 	range: TimeRange = "24h",
 	signal?: AbortSignal,
 ): Promise<ToolDashboardStats> {
-	return fetchJson<ToolDashboardStats>(`${API_BASE}/stats/tools?range=${encodeURIComponent(range)}`, { signal });
+	return fetchV1<ToolDashboardStats>(
+		`/tools?range=${encodeURIComponent(range)}`,
+		`/stats/tools?range=${encodeURIComponent(range)}`,
+		{ signal },
+	);
 }
 
 export async function getProviderDashboardStats(
 	range: TimeRange = "24h",
 	signal?: AbortSignal,
 ): Promise<ProviderDashboardStats> {
-	return fetchJson<ProviderDashboardStats>(`${API_BASE}/stats/providers?range=${encodeURIComponent(range)}`, {
+	return fetchV1<ProviderDashboardStats>(
+		`/providers?range=${encodeURIComponent(range)}`,
+		`/stats/providers?range=${encodeURIComponent(range)}`,
+		{
+			signal,
+		},
+	);
+}
+
+export async function getMeta(
+	signal?: AbortSignal,
+): Promise<{ version: number; ranges: string[]; endpoints: string[]; serverTime: number }> {
+	return fetchV1<{ version: number; ranges: string[]; endpoints: string[]; serverTime: number }>(`/meta`, `/stats`, {
 		signal,
 	});
 }

--- a/packages/stats/src/client/api.ts
+++ b/packages/stats/src/client/api.ts
@@ -129,7 +129,9 @@ export async function getRequestsPaginated(
 			{ signal },
 		);
 		if (res && Array.isArray(res.requests) && typeof res.total === "number") return res;
-		// Fallback: legacy returned array
+		// Fallback: legacy returned an unpaged array. Slice the requested page;
+		// total can only be the array length (a complete list here — the legacy
+		// shape has no way to express "more exist beyond what was returned").
 		if (Array.isArray(res as unknown as MessageStats[])) {
 			const arr = res as unknown as MessageStats[];
 			return { requests: arr.slice(offset, offset + limit), total: arr.length };
@@ -137,8 +139,14 @@ export async function getRequestsPaginated(
 		return { requests: [], total: 0 };
 	} catch (err) {
 		if (err instanceof ApiError && err.status === 404) {
-			const legacy = await fetchJson<MessageStats[]>(`${LEGACY_BASE}/stats/recent?limit=${limit}`, { signal });
-			return { requests: legacy.slice(offset, offset + limit), total: legacy.length };
+			// The legacy endpoint cannot paginate, so fetch enough rows to cover
+			// the requested page. `total` can only ever be the fetched prefix
+			// length — report it as such instead of claiming the page is all
+			// there is (an exact total is unknowable without the v1 API).
+			const fetched = await fetchJson<MessageStats[]>(`${LEGACY_BASE}/stats/recent?limit=${offset + limit}`, {
+				signal,
+			});
+			return { requests: fetched.slice(offset, offset + limit), total: fetched.length };
 		}
 		throw err;
 	}

--- a/packages/stats/src/client/api.ts
+++ b/packages/stats/src/client/api.ts
@@ -82,11 +82,16 @@ export async function getCostDashboardStats(
 	);
 }
 
-export async function getRecentRequests(limit = 50, signal?: AbortSignal): Promise<MessageStats[]> {
+export async function getRecentRequests(
+	limit = 50,
+	range: TimeRange = "24h",
+	signal?: AbortSignal,
+): Promise<MessageStats[]> {
 	try {
-		const res = await fetchJson<{ requests: MessageStats[]; total: number }>(`${V1_BASE}/requests?limit=${limit}`, {
-			signal,
-		});
+		const res = await fetchJson<{ requests: MessageStats[]; total: number }>(
+			`${V1_BASE}/requests?range=${encodeURIComponent(range)}&limit=${limit}`,
+			{ signal },
+		);
 		if (Array.isArray(res as unknown as MessageStats[])) return res as unknown as MessageStats[];
 		if (res && Array.isArray(res.requests)) return res.requests;
 		return [];

--- a/packages/stats/src/client/app/AppLayout.tsx
+++ b/packages/stats/src/client/app/AppLayout.tsx
@@ -1,7 +1,7 @@
 import { X } from "lucide-react";
 import type React from "react";
 import { useEffect, useState } from "react";
-import { applyDensity, DENSITY_STORAGE_KEY, type Density, loadDensity } from "../data/density";
+import { setDensity, useDensity } from "../data/density";
 import type { TimeRange } from "../types";
 import { NavRail } from "./NavRail";
 import type { DashboardSection } from "./routes";
@@ -38,21 +38,12 @@ export function AppLayout({
 			return false;
 		}
 	});
-	const [density, setDensity] = useState<Density>(() => loadDensity());
+	const density = useDensity();
 	useEffect(() => {
 		try {
 			localStorage.setItem(NAV_COLLAPSED_KEY, collapsed ? "1" : "0");
 		} catch {}
 	}, [collapsed]);
-	useEffect(() => {
-		applyDensity(density);
-		try {
-			localStorage.setItem(DENSITY_STORAGE_KEY, density);
-		} catch {}
-	}, [density]);
-	useEffect(() => {
-		applyDensity(loadDensity());
-	}, []);
 
 	const handleSectionChange = (section: DashboardSection) => {
 		onSectionChange(section);

--- a/packages/stats/src/client/app/AppLayout.tsx
+++ b/packages/stats/src/client/app/AppLayout.tsx
@@ -1,10 +1,13 @@
 import { X } from "lucide-react";
 import type React from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { applyDensity, DENSITY_STORAGE_KEY, type Density, loadDensity } from "../data/density";
 import type { TimeRange } from "../types";
 import { NavRail } from "./NavRail";
 import type { DashboardSection } from "./routes";
 import { TopBar } from "./TopBar";
+
+const NAV_COLLAPSED_KEY = "omp-stats:nav-collapsed";
 
 export interface AppLayoutProps {
 	activeSection: DashboardSection;
@@ -28,6 +31,28 @@ export function AppLayout({
 	children,
 }: AppLayoutProps) {
 	const [menuOpen, setMenuOpen] = useState(false);
+	const [collapsed, setCollapsed] = useState(() => {
+		try {
+			return localStorage.getItem(NAV_COLLAPSED_KEY) === "1";
+		} catch {
+			return false;
+		}
+	});
+	const [density, setDensity] = useState<Density>(() => loadDensity());
+	useEffect(() => {
+		try {
+			localStorage.setItem(NAV_COLLAPSED_KEY, collapsed ? "1" : "0");
+		} catch {}
+	}, [collapsed]);
+	useEffect(() => {
+		applyDensity(density);
+		try {
+			localStorage.setItem(DENSITY_STORAGE_KEY, density);
+		} catch {}
+	}, [density]);
+	useEffect(() => {
+		applyDensity(loadDensity());
+	}, []);
 
 	const handleSectionChange = (section: DashboardSection) => {
 		onSectionChange(section);
@@ -36,10 +61,14 @@ export function AppLayout({
 
 	return (
 		<div className="stats-app-container">
-			{/* Desktop Rail */}
-			<NavRail activeSection={activeSection} onSectionChange={handleSectionChange} className="stats-desktop-nav" />
+			<NavRail
+				activeSection={activeSection}
+				onSectionChange={handleSectionChange}
+				collapsed={collapsed}
+				onCollapsedChange={setCollapsed}
+				className="stats-desktop-nav"
+			/>
 
-			{/* Mobile Nav Drawer */}
 			{menuOpen && (
 				<div className="stats-mobile-drawer-overlay" onClick={() => setMenuOpen(false)} role="presentation">
 					<div
@@ -50,9 +79,14 @@ export function AppLayout({
 						aria-label="Navigation menu"
 					>
 						<div className="stats-mobile-drawer-header">
-							<div className="stats-logo-container">
-								<span className="stats-logo-text">OH MY PI</span>
-								<span className="stats-logo-subtext">Observability</span>
+							<div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+								<div className="stats-logo-mark" aria-hidden>
+									π
+								</div>
+								<div className="stats-logo-container">
+									<span className="stats-logo-text">OH MY PI</span>
+									<span className="stats-logo-subtext">Observability</span>
+								</div>
 							</div>
 							<button
 								type="button"
@@ -72,7 +106,6 @@ export function AppLayout({
 				</div>
 			)}
 
-			{/* Main Layout Pane */}
 			<div className="stats-main-pane">
 				<TopBar
 					activeSection={activeSection}
@@ -82,6 +115,8 @@ export function AppLayout({
 					onSyncStart={onSyncStart}
 					onSyncComplete={onSyncComplete}
 					onMenuToggle={() => setMenuOpen(true)}
+					density={density}
+					onDensityChange={setDensity}
 				/>
 
 				<main className="stats-content-area">

--- a/packages/stats/src/client/app/CommandPalette.tsx
+++ b/packages/stats/src/client/app/CommandPalette.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useMemo, useState } from "react";
+import type { TimeRange } from "../types";
+import { routes } from "./routes";
+
+interface CommandPaletteProps {
+	open: boolean;
+	onClose: () => void;
+	onNavigate: (section: string, range?: TimeRange) => void;
+}
+
+const RANGES: TimeRange[] = ["today", "1h", "24h", "7d", "30d", "90d", "all"];
+
+export function CommandPalette({ open, onClose, onNavigate }: CommandPaletteProps) {
+	const [query, setQuery] = useState("");
+	const [activeIdx, setActiveIdx] = useState(0);
+
+	const items = useMemo(() => {
+		const q = query.trim().toLowerCase();
+		const base: { label: string; action: () => void; hint?: string }[] = [];
+		for (const r of routes) base.push({ label: `Go to ${r.label}`, hint: r.id, action: () => onNavigate(r.id) });
+		for (const r of RANGES) base.push({ label: `Set range ${r}`, hint: "range", action: () => onNavigate("", r) });
+		base.push({
+			label: "Toggle density",
+			hint: "view",
+			action: () => {
+				const cur = document.documentElement.dataset.density;
+				const next = cur === "compact" ? "comfortable" : "compact";
+				document.documentElement.dataset.density = next;
+				try {
+					localStorage.setItem("omp-stats:density", next);
+				} catch {}
+			},
+		});
+		if (!q) return base.slice(0, 8);
+		return base.filter(it => it.label.toLowerCase().includes(q) || it.hint?.includes(q)).slice(0, 8);
+	}, [query, onNavigate]);
+
+	useEffect(() => {
+		setActiveIdx(0);
+	}, [query]);
+	useEffect(() => {
+		if (!open) return;
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === "ArrowDown") {
+				e.preventDefault();
+				setActiveIdx(i => Math.min(i + 1, items.length - 1));
+			}
+			if (e.key === "ArrowUp") {
+				e.preventDefault();
+				setActiveIdx(i => Math.max(i - 1, 0));
+			}
+			if (e.key === "Enter") {
+				e.preventDefault();
+				items[activeIdx]?.action();
+				onClose();
+			}
+			if (e.key === "Escape") onClose();
+		};
+		window.addEventListener("keydown", onKey);
+		return () => window.removeEventListener("keydown", onKey);
+	}, [open, items, activeIdx, onClose]);
+
+	if (!open) return null;
+	return (
+		<div className="omp-palette-overlay" onClick={onClose} role="presentation">
+			<div
+				className="omp-palette"
+				onClick={e => e.stopPropagation()}
+				role="dialog"
+				aria-modal="true"
+				aria-label="Command palette"
+			>
+				<input
+					className="omp-palette-input"
+					autoFocus
+					placeholder="Type a command — try “models”, “today”, “density”"
+					value={query}
+					onChange={e => setQuery(e.target.value)}
+				/>
+				<div className="omp-palette-list">
+					{items.map((it, idx) => (
+						<div
+							key={it.label}
+							className="omp-palette-item"
+							data-active={idx === activeIdx ? "true" : "false"}
+							onClick={() => {
+								it.action();
+								onClose();
+							}}
+						>
+							<span>{it.label}</span>
+							{it.hint && <span className="omp-palette-kbd">{it.hint}</span>}
+						</div>
+					))}
+					{items.length === 0 && (
+						<div style={{ padding: "12px 10px", color: "var(--muted)", fontSize: 12 }}>No matches</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/stats/src/client/app/CommandPalette.tsx
+++ b/packages/stats/src/client/app/CommandPalette.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { toggleDensity } from "../data/density";
 import type { TimeRange } from "../types";
 import { routes } from "./routes";
 
@@ -22,14 +23,7 @@ export function CommandPalette({ open, onClose, onNavigate }: CommandPaletteProp
 		base.push({
 			label: "Toggle density",
 			hint: "view",
-			action: () => {
-				const cur = document.documentElement.dataset.density;
-				const next = cur === "compact" ? "comfortable" : "compact";
-				document.documentElement.dataset.density = next;
-				try {
-					localStorage.setItem("omp-stats:density", next);
-				} catch {}
-			},
+			action: () => toggleDensity(),
 		});
 		if (!q) return base.slice(0, 8);
 		return base.filter(it => it.label.toLowerCase().includes(q) || it.hint?.includes(q)).slice(0, 8);

--- a/packages/stats/src/client/app/NavRail.tsx
+++ b/packages/stats/src/client/app/NavRail.tsx
@@ -1,19 +1,41 @@
+import { ChevronsLeft, ChevronsRight } from "lucide-react";
 import { type DashboardSection, routes } from "./routes";
 
 export interface NavRailProps {
 	activeSection: DashboardSection;
 	onSectionChange: (section: DashboardSection) => void;
+	collapsed?: boolean;
+	onCollapsedChange?: (next: boolean) => void;
 	className?: string;
 }
 
-export function NavRail({ activeSection, onSectionChange, className = "" }: NavRailProps) {
+export function NavRail({
+	activeSection,
+	onSectionChange,
+	collapsed = false,
+	onCollapsedChange,
+	className = "",
+}: NavRailProps) {
 	return (
-		<aside className={`stats-nav-rail ${className}`}>
+		<aside className={`stats-nav-rail ${className}`} data-collapsed={collapsed ? "true" : "false"}>
 			<div className="stats-nav-rail-header">
+				<div className="stats-logo-mark" aria-hidden>
+					π
+				</div>
 				<div className="stats-logo-container">
 					<span className="stats-logo-text">OH MY PI</span>
 					<span className="stats-logo-subtext">Observability</span>
 				</div>
+				{onCollapsedChange && (
+					<button
+						type="button"
+						className="stats-nav-collapse-btn"
+						aria-label={collapsed ? "Expand navigation" : "Collapse navigation"}
+						onClick={() => onCollapsedChange(!collapsed)}
+					>
+						{collapsed ? <ChevronsRight size={14} /> : <ChevronsLeft size={14} />}
+					</button>
+				)}
 			</div>
 
 			<nav className="stats-nav-rail-menu">
@@ -28,6 +50,7 @@ export function NavRail({ activeSection, onSectionChange, className = "" }: NavR
 							className="stats-nav-rail-item"
 							data-active={isActive ? "true" : "false"}
 							aria-current={isActive ? "page" : undefined}
+							title={collapsed ? route.label : undefined}
 						>
 							<Icon size={16} className="stats-nav-rail-item-icon" />
 							<span className="stats-nav-rail-item-label">{route.label}</span>
@@ -37,7 +60,10 @@ export function NavRail({ activeSection, onSectionChange, className = "" }: NavR
 			</nav>
 
 			<div className="stats-nav-rail-footer">
-				<span className="stats-version-tag">OMP Stats v1.0.0</span>
+				<span className="stats-nav-rail-footer-label" style={{ fontSize: 11 }}>
+					Local • 127.0.0.1
+				</span>
+				<span className="stats-version-tag">v1</span>
 			</div>
 		</aside>
 	);

--- a/packages/stats/src/client/app/RangeControl.tsx
+++ b/packages/stats/src/client/app/RangeControl.tsx
@@ -7,6 +7,7 @@ export interface RangeControlProps {
 }
 
 const RANGE_OPTIONS: { value: TimeRange; label: string }[] = [
+	{ value: "today", label: "Today" },
 	{ value: "1h", label: "1h" },
 	{ value: "24h", label: "24h" },
 	{ value: "7d", label: "7d" },
@@ -27,6 +28,7 @@ export function RangeControl({ value, onChange, className = "" }: RangeControlPr
 						role="radio"
 						aria-checked={isActive}
 						data-active={isActive ? "true" : "false"}
+						data-value={opt.value}
 						className="stats-range-control-btn"
 						onClick={() => onChange(opt.value)}
 					>

--- a/packages/stats/src/client/app/TopBar.tsx
+++ b/packages/stats/src/client/app/TopBar.tsx
@@ -1,4 +1,5 @@
-import { Menu } from "lucide-react";
+import { Command, Menu } from "lucide-react";
+import type { Density } from "../data/density";
 import type { TimeRange } from "../types";
 import { RangeControl } from "./RangeControl";
 import type { DashboardSection } from "./routes";
@@ -14,6 +15,8 @@ export interface TopBarProps {
 	onSyncStart?: () => void;
 	onSyncComplete?: (result: { success: boolean }) => void;
 	onMenuToggle?: () => void;
+	density?: Density;
+	onDensityChange?: (d: Density) => void;
 	className?: string;
 }
 
@@ -25,6 +28,8 @@ export function TopBar({
 	onSyncStart,
 	onSyncComplete,
 	onMenuToggle,
+	density = "comfortable",
+	onDensityChange,
 	className = "",
 }: TopBarProps) {
 	const currentRoute = routes.find(r => r.id === activeSection);
@@ -49,20 +54,40 @@ export function TopBar({
 						<Menu size={20} />
 					</button>
 				)}
-				<h1 className="stats-page-title">{title}</h1>
+				<h1 className="stats-page-title">
+					{title} <span className="stats-page-title-rule" aria-hidden />
+				</h1>
+				<span
+					style={{
+						fontFamily: "var(--font-mono)",
+						fontSize: 10,
+						color: "var(--dim)",
+						display: "inline-flex",
+						alignItems: "center",
+						gap: 4,
+					}}
+				>
+					<Command size={11} />K
+				</span>
 			</div>
 
 			<div className="stats-top-bar-right">
-				<div className="stats-top-bar-meta">
-					<span
-						className="stats-last-updated"
-						title={updatedAt ? new Date(updatedAt).toLocaleString() : undefined}
-					>
-						{formatLastUpdated(updatedAt)}
-					</span>
-				</div>
+				<span className="stats-last-updated" title={updatedAt ? new Date(updatedAt).toLocaleString() : undefined}>
+					{formatLastUpdated(updatedAt)}
+				</span>
 
 				<RangeControl value={range} onChange={onRangeChange} />
+
+				{onDensityChange && (
+					<button
+						type="button"
+						className="stats-density-toggle"
+						onClick={() => onDensityChange(density === "compact" ? "comfortable" : "compact")}
+						title={`Density: ${density} — click to toggle`}
+					>
+						{density === "compact" ? "Compact" : "Comfy"}
+					</button>
+				)}
 
 				<ThemeToggle />
 

--- a/packages/stats/src/client/components/AgentTokenShare.tsx
+++ b/packages/stats/src/client/components/AgentTokenShare.tsx
@@ -4,14 +4,13 @@ import { buildAgentTokenShare } from "../data/view-models";
 import type { AgentType, AgentTypeStats } from "../types";
 
 /**
- * Per-agent-type display chrome. Colors follow the OMP brand palette
- * (pink -> violet -> cyan) used by the dashboard charts so the bar reads on
- * both themes without per-theme overrides.
+ * Per-agent-type display: neutral greys (text/muted/dim) so color is not decoration —
+ * the bar reads on both themes via semantic surface tokens.
  */
 const AGENT_META: Record<AgentType, { label: string; color: string }> = {
-	main: { label: "Main agent", color: "#ed4abf" },
-	subagent: { label: "Subagents", color: "#9b4dff" },
-	advisor: { label: "Advisor", color: "#5ad8e6" },
+	main: { label: "Main agent", color: "var(--text)" },
+	subagent: { label: "Subagents", color: "var(--muted)" },
+	advisor: { label: "Advisor", color: "var(--dim)" },
 };
 
 export interface AgentTokenShareProps {

--- a/packages/stats/src/client/components/CustomizeDrawer.tsx
+++ b/packages/stats/src/client/components/CustomizeDrawer.tsx
@@ -1,0 +1,270 @@
+import { ChevronDown, ChevronUp, GripVertical, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { WidgetSize } from "../data/dashboard-prefs";
+import {
+	type DashboardPreset,
+	dashboardPrefsStore,
+	type OverviewWidgetId,
+	useDashboardPrefs,
+	WIDGET_META,
+} from "../data/dashboard-prefs";
+
+const PRESETS: { value: Exclude<DashboardPreset, "custom">; label: string }[] = [
+	{ value: "default", label: "Default" },
+	{ value: "cost", label: "Cost" },
+	{ value: "tokens", label: "Tokens" },
+	{ value: "developer", label: "Developer" },
+];
+
+const SIZE_OPTIONS: { value: WidgetSize; label: string }[] = [
+	{ value: "small", label: "S" },
+	{ value: "medium", label: "M" },
+	{ value: "wide", label: "W" },
+];
+
+interface CustomizeDrawerProps {
+	open: boolean;
+	onClose: () => void;
+}
+
+/**
+ * Customization drawer for the Overview dashboard (spec §10): preset pills,
+ * per-widget visibility/size/reorder rows (keyboard-accessible up/down +
+ * native drag enhancement), and a confirmed Reset.
+ * Right drawer ≥768px, bottom sheet below.
+ */
+export function CustomizeDrawer({ open, onClose }: CustomizeDrawerProps) {
+	const prefs = useDashboardPrefs();
+	const closeButtonRef = useRef<HTMLButtonElement>(null);
+	const restoreFocusRef = useRef<HTMLElement | null>(null);
+	const [confirmingReset, setConfirmingReset] = useState(false);
+
+	// Focus management: move focus into the drawer on open, restore on close.
+	useEffect(() => {
+		if (!open) return;
+		restoreFocusRef.current = document.activeElement as HTMLElement | null;
+		closeButtonRef.current?.focus();
+		return () => {
+			restoreFocusRef.current?.focus();
+			restoreFocusRef.current = null;
+		};
+	}, [open]);
+
+	useEffect(() => {
+		if (!open) return;
+		const handleKey = (e: KeyboardEvent) => {
+			if (e.key === "Escape") onClose();
+		};
+		window.addEventListener("keydown", handleKey);
+		return () => window.removeEventListener("keydown", handleKey);
+	}, [open, onClose]);
+
+	const handleDragStart = useCallback((e: React.DragEvent, id: OverviewWidgetId) => {
+		e.dataTransfer.setData("text/omp-widget-id", id);
+		e.dataTransfer.effectAllowed = "move";
+	}, []);
+
+	const handleDrop = useCallback(
+		(e: React.DragEvent, targetId: OverviewWidgetId) => {
+			e.preventDefault();
+			const sourceId = e.dataTransfer.getData("text/omp-widget-id");
+			if (!sourceId || sourceId === targetId) return;
+			const ids = prefs.widgets.map(w => w.id);
+			const fromIndex = ids.indexOf(sourceId as OverviewWidgetId);
+			let toIndex = ids.indexOf(targetId);
+			if (fromIndex === -1 || toIndex === -1) return;
+			ids.splice(fromIndex, 1);
+			// Dropping onto the lower half of a row targets the slot after it.
+			toIndex = ids.indexOf(targetId) + 1;
+			ids.splice(toIndex, 0, sourceId as OverviewWidgetId);
+			dashboardPrefsStore.reorderByIds(ids.filter(id => prefs.widgets.some(w => w.id === id)));
+		},
+		[prefs.widgets],
+	);
+
+	if (!open) return null;
+
+	return (
+		<>
+			<div className="stats-customize-overlay" onClick={onClose} role="presentation" />
+			<aside className="stats-customize-drawer" role="dialog" aria-modal="true" aria-label="Customize overview">
+				<header className="stats-customize-header">
+					<div>
+						<h2 className="stats-customize-title">Customize overview</h2>
+						<p className="stats-customize-subtitle">Choose which sections you see and how they're arranged.</p>
+					</div>
+					<button
+						ref={closeButtonRef}
+						type="button"
+						onClick={() => {
+							setConfirmingReset(false);
+							onClose();
+						}}
+						className="stats-customize-close-btn"
+						aria-label="Close customization"
+					>
+						<X size={16} />
+					</button>
+				</header>
+
+				<div className="stats-customize-body">
+					<section aria-label="Preset">
+						<div className="stats-customize-label" id="customize-preset-label">
+							Preset
+						</div>
+						<div className="stats-preset-row" role="group" aria-labelledby="customize-preset-label">
+							{PRESETS.map(preset => (
+								<button
+									key={preset.value}
+									type="button"
+									className="stats-preset-pill"
+									data-active={prefs.preset === preset.value ? "true" : "false"}
+									aria-pressed={prefs.preset === preset.value}
+									onClick={() => {
+										setConfirmingReset(false);
+										dashboardPrefsStore.setPreset(preset.value);
+									}}
+								>
+									{preset.label}
+								</button>
+							))}
+						</div>
+						{prefs.preset === "custom" && (
+							<p className="stats-customize-hint">Custom arrangement — edit freely or pick a preset.</p>
+						)}
+					</section>
+
+					<section aria-label="Sections">
+						<div className="stats-customize-label">Sections</div>
+						<ul className="stats-widget-list">
+							{prefs.widgets.map((entry, index) => {
+								const meta = WIDGET_META[entry.id];
+								return (
+									<li
+										key={entry.id}
+										className="stats-widget-row"
+										data-disabled={!entry.visible}
+										draggable
+										onDragStart={e => handleDragStart(e, entry.id)}
+										onDragOver={e => {
+											if (e.dataTransfer.types.includes("text/omp-widget-id")) e.preventDefault();
+										}}
+										onDrop={e => handleDrop(e, entry.id)}
+									>
+										<span className="stats-widget-drag-handle" title="Drag to reorder">
+											<GripVertical size={14} />
+										</span>
+										<input
+											type="checkbox"
+											className="stats-widget-checkbox"
+											checked={entry.visible}
+											onChange={e => {
+												setConfirmingReset(false);
+												dashboardPrefsStore.setWidgetVisible(entry.id, e.target.checked);
+											}}
+											aria-label={`Show ${meta.title}`}
+										/>
+										<div className="stats-widget-row-text">
+											<span className="stats-widget-row-title">{meta.title}</span>
+											<span className="stats-widget-row-desc">{meta.description}</span>
+										</div>
+										<div
+											className="stats-widget-size-control"
+											role="radiogroup"
+											aria-label={`Size for ${meta.title}`}
+										>
+											{SIZE_OPTIONS.map(size => (
+												<button
+													key={size.value}
+													type="button"
+													disabled={!entry.visible}
+													aria-checked={entry.size === size.value}
+													data-active={entry.size === size.value ? "true" : "false"}
+													className="stats-size-btn"
+													onClick={() => dashboardPrefsStore.setWidgetSize(entry.id, size.value)}
+												>
+													{size.label}
+												</button>
+											))}
+										</div>
+										<div className="stats-reorder-btns">
+											<button
+												type="button"
+												className="stats-reorder-btn"
+												disabled={index === 0}
+												aria-label={`Move ${meta.title} up`}
+												onClick={() => dashboardPrefsStore.moveWidget(entry.id, "up")}
+											>
+												<ChevronUp size={14} />
+											</button>
+											<button
+												type="button"
+												className="stats-reorder-btn"
+												disabled={index === prefs.widgets.length - 1}
+												aria-label={`Move ${meta.title} down`}
+												onClick={() => dashboardPrefsStore.moveWidget(entry.id, "down")}
+											>
+												<ChevronDown size={14} />
+											</button>
+										</div>
+									</li>
+								);
+							})}
+						</ul>
+					</section>
+				</div>
+
+				<footer className="stats-customize-footer">
+					{confirmingReset ? (
+						<div className="stats-reset-confirm">
+							<span className="stats-customize-hint">Restore the default layout? This cannot be undone.</span>
+							<div className="stats-reset-confirm-actions">
+								<button
+									type="button"
+									className="stats-button stats-button-secondary stats-reset-cancel"
+									onClick={() => setConfirmingReset(false)}
+								>
+									Cancel
+								</button>
+								<button
+									type="button"
+									className="stats-button stats-button-primary stats-reset-apply"
+									onClick={() => {
+										dashboardPrefsStore.reset();
+										setConfirmingReset(false);
+									}}
+								>
+									Confirm reset
+								</button>
+							</div>
+						</div>
+					) : (
+						<button
+							type="button"
+							className="stats-button stats-button-secondary stats-reset-btn"
+							onClick={() => setConfirmingReset(true)}
+						>
+							Reset to default
+						</button>
+					)}
+				</footer>
+			</aside>
+		</>
+	);
+}
+
+/** TopBar customize button (rendered only on the Overview route). */
+export function CustomizeButton({ open, onToggle }: { open: boolean; onToggle: () => void }) {
+	return (
+		<button
+			type="button"
+			className="stats-customize-btn"
+			data-active={open ? "true" : "false"}
+			aria-expanded={open}
+			aria-haspopup="dialog"
+			onClick={onToggle}
+		>
+			Customize
+		</button>
+	);
+}

--- a/packages/stats/src/client/components/DashboardGrid.tsx
+++ b/packages/stats/src/client/components/DashboardGrid.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+import type { WidgetSize } from "../data/dashboard-prefs";
+
+/**
+ * 12-column customizable grid for the Overview route. Widgets are placed in
+ * the persisted preference order; `data-size` maps to grid-column spans in
+ * styles.css (small=4 / medium=6 / wide=12 at desktop, all full-width below).
+ * Hidden widgets are simply not rendered — no placeholders.
+ */
+export function DashboardGrid({ children }: { children: ReactNode }) {
+	return (
+		<div className="stats-dashboard-grid" role="list">
+			{children}
+		</div>
+	);
+}
+
+export interface GridWidgetProps {
+	id: string;
+	size: WidgetSize;
+	children: ReactNode;
+}
+
+/** One widget cell inside the DashboardGrid. */
+export function DashboardWidget({ id, size, children }: GridWidgetProps) {
+	return (
+		<div className="stats-widget" data-size={size} data-widget-id={id} role="listitem">
+			{children}
+		</div>
+	);
+}

--- a/packages/stats/src/client/components/range-meta.ts
+++ b/packages/stats/src/client/components/range-meta.ts
@@ -25,6 +25,13 @@ export interface RangeMeta {
 }
 
 const RANGE_META: Record<TimeRange, RangeMeta> = {
+	today: {
+		windowLabel: "today since midnight",
+		trendLabel: "Today",
+		bucketMs: HOUR_MS,
+		bucketCount: 24,
+		tickFormat: "HH:mm",
+	},
 	"1h": {
 		windowLabel: "the last hour",
 		trendLabel: "1h Trend",
@@ -62,7 +69,6 @@ const RANGE_META: Record<TimeRange, RangeMeta> = {
 	},
 	all: { windowLabel: "all time", trendLabel: "Trend", bucketMs: DAY_MS, bucketCount: 0, tickFormat: "MMM d" },
 };
-
 export function rangeMeta(range: TimeRange): RangeMeta {
 	return RANGE_META[range];
 }

--- a/packages/stats/src/client/data/dashboard-prefs.ts
+++ b/packages/stats/src/client/data/dashboard-prefs.ts
@@ -200,7 +200,7 @@ function persist(prefs: StatsDashboardPrefs): void {
 
 let current: StatsDashboardPrefs = readStored();
 const listeners = new Set<() => void>();
-let persistTimer: ReturnType<typeof setTimeout> | null = null;
+let persistTimer: Timer | null = null;
 
 function emit(): void {
 	for (const listener of listeners) listener();

--- a/packages/stats/src/client/data/dashboard-prefs.ts
+++ b/packages/stats/src/client/data/dashboard-prefs.ts
@@ -1,0 +1,301 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * Client-side dashboard customization state.
+ *
+ * Persisted under localStorage key `omp-stats-dashboard` with a versioned,
+ * validated schema (v1). Corrupt/stale/partial data degrades gracefully to
+ * the default layout — preference failures must never break `/stats`.
+ * Only the Overview route is customizable in v1; other routes render their
+ * fixed section stack.
+ */
+
+export type OverviewWidgetId =
+	| "kpi-primary"
+	| "kpi-secondary"
+	| "agent-tokens"
+	| "throughput"
+	| "feed"
+	| "recent-preview";
+
+export type WidgetSize = "small" | "medium" | "wide";
+
+export type DashboardPreset = "default" | "cost" | "tokens" | "developer" | "custom";
+
+export interface DashboardWidgetPref {
+	id: OverviewWidgetId;
+	visible: boolean;
+	size: WidgetSize;
+}
+
+export interface StatsDashboardPrefs {
+	version: 1;
+	preset: DashboardPreset;
+	widgets: DashboardWidgetPref[];
+}
+
+const STORAGE_KEY = "omp-stats-dashboard";
+const PREFS_VERSION = 1;
+
+const VALID_WIDGET_IDS: readonly OverviewWidgetId[] = [
+	"kpi-primary",
+	"kpi-secondary",
+	"agent-tokens",
+	"throughput",
+	"feed",
+	"recent-preview",
+];
+
+const VALID_SIZES: readonly WidgetSize[] = ["small", "medium", "wide"];
+
+const VALID_PRESETS: readonly DashboardPreset[] = ["default", "cost", "tokens", "developer", "custom"];
+
+/** Display metadata for the customization drawer (titles/descriptions per widget). */
+export const WIDGET_META: Record<OverviewWidgetId, { title: string; description: string }> = {
+	"kpi-primary": {
+		title: "Costs & Requests",
+		description: "Total cost, requests, cache savings/rate, error rate",
+	},
+	"kpi-secondary": {
+		title: "Token Details",
+		description: "Token breakdown, premium requests, speed and latency",
+	},
+	"agent-tokens": {
+		title: "Tokens by Agent",
+		description: "Conversation-token share across main/subagents/advisor",
+	},
+	throughput: {
+		title: "System Throughput",
+		description: "Request volume and errors over time",
+	},
+	feed: {
+		title: "Operational Feed",
+		description: "Live request log with status, model and cost",
+	},
+	"recent-preview": {
+		title: "Recent Requests",
+		description: "Latest requests table with detail drawer",
+	},
+};
+
+function widget(id: OverviewWidgetId, visible: boolean, size: WidgetSize): DashboardWidgetPref {
+	return { id, visible, size };
+}
+
+/** Canonical default arrangement — also what Reset restores. */
+export const DEFAULT_WIDGETS: DashboardWidgetPref[] = [
+	widget("kpi-primary", true, "wide"),
+	widget("kpi-secondary", true, "wide"),
+	widget("agent-tokens", true, "medium"),
+	widget("throughput", true, "medium"),
+	widget("feed", true, "small"),
+	widget("recent-preview", true, "wide"),
+];
+
+export const DEFAULT_PREFS: StatsDashboardPrefs = {
+	version: PREFS_VERSION,
+	preset: "default",
+	widgets: DEFAULT_WIDGETS.map(w => ({ ...w })),
+};
+
+/**
+ * Complete arrangements per preset. Choosing a preset writes this whole array;
+ * any subsequent manual edit flips the preset back to `custom`.
+ */
+export const PRESET_WIDGETS: Record<Exclude<DashboardPreset, "custom">, DashboardWidgetPref[]> = {
+	default: DEFAULT_WIDGETS.map(w => ({ ...w })),
+	cost: [
+		widget("kpi-primary", true, "wide"),
+		widget("kpi-secondary", true, "wide"),
+		widget("throughput", true, "medium"),
+		widget("recent-preview", true, "wide"),
+		widget("agent-tokens", false, "medium"),
+		widget("feed", false, "small"),
+	],
+	tokens: [
+		widget("kpi-primary", true, "wide"),
+		widget("kpi-secondary", true, "wide"),
+		widget("agent-tokens", true, "wide"),
+		widget("throughput", true, "medium"),
+		widget("recent-preview", true, "medium"),
+		widget("feed", false, "small"),
+	],
+	developer: [
+		widget("kpi-primary", true, "medium"),
+		widget("throughput", true, "medium"),
+		widget("feed", true, "wide"),
+		widget("recent-preview", true, "wide"),
+		widget("kpi-secondary", false, "wide"),
+		widget("agent-tokens", false, "medium"),
+	],
+};
+
+function clonePreset(preset: Exclude<DashboardPreset, "custom">): StatsDashboardPrefs {
+	return {
+		version: PREFS_VERSION,
+		preset,
+		widgets: PRESET_WIDGETS[preset].map(w => ({ ...w })),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Validation / migration of stored prefs
+// ---------------------------------------------------------------------------
+export function validatePrefs(parsed: unknown): StatsDashboardPrefs | null {
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+	const raw = parsed as Record<string, unknown>;
+	if (raw.version !== PREFS_VERSION) return null;
+	if (!VALID_PRESETS.includes(raw.preset as DashboardPreset)) return null;
+	if (!Array.isArray(raw.widgets) || raw.widgets.length === 0) return null;
+
+	const seen = new Set<string>();
+	const out: DashboardWidgetPref[] = [];
+	for (const entry of raw.widgets) {
+		if (typeof entry !== "object" || entry === null) return null;
+		const e = entry as Record<string, unknown>;
+		if (!VALID_WIDGET_IDS.includes(e.id as OverviewWidgetId)) continue; // drop unknown ids
+		if (typeof e.visible !== "boolean") return null;
+		if (!VALID_SIZES.includes(e.size as WidgetSize)) return null;
+		if (seen.has(e.id as string)) return null; // duplicates invalidate the whole blob
+		seen.add(e.id as string);
+		out.push({ id: e.id as OverviewWidgetId, visible: e.visible, size: e.size as WidgetSize });
+	}
+
+	// Splice in widgets the stored blob predates so upgrades surface them.
+	for (const def of DEFAULT_WIDGETS) {
+		if (!seen.has(def.id)) out.push({ ...def });
+	}
+
+	return { version: PREFS_VERSION, preset: raw.preset as DashboardPreset, widgets: out };
+}
+
+function readStored(): StatsDashboardPrefs {
+	let parsed: unknown;
+	try {
+		const text = localStorage.getItem(STORAGE_KEY);
+		if (text === null) return structuredClone(DEFAULT_PREFS);
+		parsed = JSON.parse(text);
+	} catch {
+		parsed = undefined;
+	}
+	const result = validatePrefs(parsed);
+	if (!result) {
+		console.warn("[stats] invalid dashboard prefs, resetting to default");
+		return structuredClone(DEFAULT_PREFS);
+	}
+	return result;
+}
+
+function persist(prefs: StatsDashboardPrefs): void {
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+	} catch {
+		// Quota/private-mode failures keep the session-local state; never break the page.
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Module-level store (same external-store pattern as useSystemTheme)
+// ---------------------------------------------------------------------------
+
+let current: StatsDashboardPrefs = readStored();
+const listeners = new Set<() => void>();
+let persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+function emit(): void {
+	for (const listener of listeners) listener();
+	if (persistTimer !== null) clearTimeout(persistTimer);
+	persistTimer = setTimeout(() => {
+		persistTimer = null;
+		persist(current);
+	}, 250);
+}
+
+function replace(next: StatsDashboardPrefs): void {
+	current = next;
+	emit();
+}
+
+function subscribe(callback: () => void): () => void {
+	listeners.add(callback);
+	return () => listeners.delete(callback);
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+function applyEdit(edit: (widgets: DashboardWidgetPref[]) => DashboardWidgetPref[]): void {
+	// Manual edits flip the preset to custom; the widget list itself is preserved.
+	replace({ version: PREFS_VERSION, preset: "custom", widgets: edit(current.widgets.map(w => ({ ...w }))) });
+}
+
+export const dashboardPrefsStore = {
+	subscribe,
+
+	setPreset(preset: DashboardPreset): void {
+		if (preset === "custom") {
+			// Selecting Custom keeps the current arrangement as-is.
+			if (current.preset !== "custom") replace({ ...current, preset: "custom" });
+			return;
+		}
+		replace(clonePreset(preset));
+	},
+
+	setWidgetVisible(id: OverviewWidgetId, visible: boolean): void {
+		applyEdit(widgets => widgets.map(w => (w.id === id ? { ...w, visible } : w)));
+	},
+
+	setWidgetSize(id: OverviewWidgetId, size: WidgetSize): void {
+		applyEdit(widgets => widgets.map(w => (w.id === id ? { ...w, size } : w)));
+	},
+
+	moveWidget(id: OverviewWidgetId, direction: "up" | "down"): void {
+		applyEdit(widgets => {
+			const index = widgets.findIndex(w => w.id === id);
+			const target = direction === "up" ? index - 1 : index + 1;
+			if (index === -1 || target < 0 || target >= widgets.length) return widgets;
+			const next = [...widgets];
+			const [entry] = next.splice(index, 1);
+			next.splice(target, 0, entry);
+			return next;
+		});
+	},
+
+	reorderByIds(orderedIds: OverviewWidgetId[]): void {
+		applyEdit(widgets => {
+			const byId = new Map(widgets.map(w => [w.id, w]));
+			const reordered: DashboardWidgetPref[] = [];
+			for (const id of orderedIds) {
+				const found = byId.get(id);
+				if (found) {
+					reordered.push(found);
+					byId.delete(id);
+				}
+			}
+			return [...reordered, ...byId.values()];
+		});
+	},
+
+	reset(): void {
+		replace(structuredClone(DEFAULT_PREFS));
+	},
+
+	/** Write any pending debounced state now (used by tests and page hide). */
+	flush(): void {
+		if (persistTimer !== null) {
+			clearTimeout(persistTimer);
+			persistTimer = null;
+			persist(current);
+		}
+	},
+};
+
+/** Reader hook for the customized dashboard layout. */
+export function useDashboardPrefs(): StatsDashboardPrefs {
+	return useSyncExternalStore(
+		dashboardPrefsStore.subscribe,
+		() => current,
+		() => DEFAULT_PREFS,
+	);
+}

--- a/packages/stats/src/client/data/density.ts
+++ b/packages/stats/src/client/data/density.ts
@@ -1,0 +1,23 @@
+export type Density = "comfortable" | "compact";
+
+export const DENSITY_STORAGE_KEY = "omp-stats:density";
+
+export function loadDensity(storage: Pick<Storage, "getItem"> = globalThis.localStorage): Density {
+	try {
+		const raw = storage.getItem(DENSITY_STORAGE_KEY);
+		if (raw === "compact" || raw === "comfortable") return raw;
+	} catch {}
+	return "comfortable";
+}
+
+export function saveDensity(value: Density, storage: Pick<Storage, "setItem"> = globalThis.localStorage): void {
+	try {
+		storage.setItem(DENSITY_STORAGE_KEY, value);
+	} catch {}
+}
+
+export function applyDensity(value: Density): void {
+	if (typeof document !== "undefined") {
+		document.documentElement.dataset.density = value;
+	}
+}

--- a/packages/stats/src/client/data/density.ts
+++ b/packages/stats/src/client/data/density.ts
@@ -1,3 +1,5 @@
+import { useSyncExternalStore } from "react";
+
 export type Density = "comfortable" | "compact";
 
 export const DENSITY_STORAGE_KEY = "omp-stats:density";
@@ -20,4 +22,42 @@ export function applyDensity(value: Density): void {
 	if (typeof document !== "undefined") {
 		document.documentElement.dataset.density = value;
 	}
+}
+
+// Module-level store shared by the palette toggle, the TopBar toggle and
+// AppLayout so DOM + storage writes always agree with the rendered label
+// (the palette used to mutate DOM+storage directly, leaving AppLayout stale).
+let density: Density = loadDensity();
+const listeners = new Set<() => void>();
+
+function emit(): void {
+	for (const listener of listeners) listener();
+}
+
+applyDensity(density);
+
+export function setDensity(value: Density): void {
+	density = value;
+	saveDensity(value);
+	applyDensity(value);
+	emit();
+}
+
+/** Flip between comfortable and compact through the shared store. */
+export function toggleDensity(): void {
+	setDensity(density === "compact" ? "comfortable" : "compact");
+}
+
+function subscribe(callback: () => void): () => void {
+	listeners.add(callback);
+	return () => listeners.delete(callback);
+}
+
+/** Reader for the active density; re-renders on palette/TopBar toggles. */
+export function useDensity(): Density {
+	return useSyncExternalStore(
+		subscribe,
+		() => density,
+		() => "comfortable" as Density,
+	);
 }

--- a/packages/stats/src/client/data/overview-prefs.ts
+++ b/packages/stats/src/client/data/overview-prefs.ts
@@ -145,3 +145,171 @@ export function activeDaysFromSeries(series: { timestamp: number; requests: numb
 	}
 	return days.size;
 }
+
+// ---------------------------------------------------------------------------
+// Named dashboards — evolution of per-section prefs
+// ---------------------------------------------------------------------------
+
+export interface Dashboard {
+	id: string;
+	name: string;
+	visible: Record<OverviewSectionKey, boolean>;
+	createdAt: number;
+}
+
+export interface DashboardState {
+	activeId: string;
+	dashboards: Dashboard[];
+}
+
+export const DASHBOARD_STORAGE_KEY = "omp-stats:dashboards";
+
+export function defaultDashboards(): Dashboard[] {
+	return [
+		{ id: "default", name: "Default", visible: { ...PRESET_DEFS.default.visible }, createdAt: 1 },
+		{ id: "tokens", name: "Tokens", visible: { ...PRESET_DEFS.tokens.visible }, createdAt: 2 },
+		{ id: "models", name: "Models", visible: { ...PRESET_DEFS.models.visible }, createdAt: 3 },
+		{
+			id: "reliability",
+			name: "Reliability",
+			visible: {
+				tape: true,
+				scope: true,
+				models: false,
+				providers: false,
+				tokens: false,
+				agents: false,
+				tools: false,
+				projects: false,
+				errors: true,
+			},
+			createdAt: 4,
+		},
+	];
+}
+
+function isValidVisible(v: unknown): v is Record<OverviewSectionKey, boolean> {
+	if (!v || typeof v !== "object") return false;
+	return SECTION_ORDER.every(k => typeof (v as Record<string, unknown>)[k] === "boolean");
+}
+
+export function loadDashboardState(storage: Pick<Storage, "getItem"> = globalThis.localStorage): DashboardState {
+	try {
+		const raw = storage.getItem(DASHBOARD_STORAGE_KEY);
+		if (raw) {
+			const parsed = JSON.parse(raw) as Partial<DashboardState>;
+			if (Array.isArray(parsed.dashboards) && typeof parsed.activeId === "string" && parsed.dashboards.length > 0) {
+				const cleaned: Dashboard[] = [];
+				for (const d of parsed.dashboards as unknown[]) {
+					if (!d || typeof d !== "object") continue;
+					const rec = d as Record<string, unknown>;
+					if (typeof rec.id !== "string" || typeof rec.name !== "string" || !isValidVisible(rec.visible)) continue;
+					cleaned.push({
+						id: rec.id,
+						name: rec.name,
+						visible: rec.visible as Record<OverviewSectionKey, boolean>,
+						createdAt: typeof rec.createdAt === "number" ? rec.createdAt : Date.now(),
+					});
+				}
+				if (cleaned.length > 0) {
+					const active = cleaned.find(d => d.id === parsed.activeId) ? (parsed.activeId as string) : cleaned[0].id;
+					return { activeId: active, dashboards: cleaned };
+				}
+			}
+		}
+		const legacyRaw = storage.getItem(STORAGE_KEY);
+		if (legacyRaw) {
+			try {
+				const legacy = JSON.parse(legacyRaw) as Partial<PrefsState>;
+				if (legacy.visible && isValidVisible(legacy.visible)) {
+					const visible = legacy.visible as Record<OverviewSectionKey, boolean>;
+					return {
+						activeId: "custom",
+						dashboards: [
+							{ id: "custom", name: "My Dashboard", visible, createdAt: Date.now() },
+							...defaultDashboards().slice(1),
+						],
+					};
+				}
+			} catch {}
+		}
+	} catch {}
+	return { activeId: "default", dashboards: defaultDashboards() };
+}
+
+export function saveDashboardState(
+	state: DashboardState,
+	storage: Pick<Storage, "setItem"> = globalThis.localStorage,
+): void {
+	try {
+		storage.setItem(DASHBOARD_STORAGE_KEY, JSON.stringify(state));
+	} catch {}
+}
+
+export function createDashboard(
+	state: DashboardState,
+	name: string,
+	visible?: Record<OverviewSectionKey, boolean>,
+): DashboardState {
+	const id = Math.random().toString(36).slice(2, 9);
+	const base = visible ??
+		state.dashboards.find(d => d.id === state.activeId)?.visible ?? { ...PRESET_DEFS.default.visible };
+	const dash: Dashboard = {
+		id,
+		name: name.trim() || `Dashboard ${state.dashboards.length + 1}`,
+		visible: { ...base },
+		createdAt: Date.now(),
+	};
+	return { activeId: id, dashboards: [...state.dashboards, dash] };
+}
+
+export function duplicateDashboard(state: DashboardState, id: string): DashboardState {
+	const src = state.dashboards.find(d => d.id === id);
+	if (!src) return state;
+	const dup: Dashboard = {
+		id: Math.random().toString(36).slice(2, 9),
+		name: `${src.name} copy`,
+		visible: { ...src.visible },
+		createdAt: Date.now(),
+	};
+	return { activeId: dup.id, dashboards: [...state.dashboards, dup] };
+}
+
+export function deleteDashboard(state: DashboardState, id: string): DashboardState {
+	if (state.dashboards.length <= 1) return state;
+	const filtered = state.dashboards.filter(d => d.id !== id);
+	const activeId = state.activeId === id ? filtered[0].id : state.activeId;
+	return { activeId, dashboards: filtered };
+}
+
+export function renameDashboard(state: DashboardState, id: string, name: string): DashboardState {
+	return {
+		...state,
+		dashboards: state.dashboards.map(d => (d.id === id ? { ...d, name: name.trim() || d.name } : d)),
+	};
+}
+
+export function setActiveDashboard(state: DashboardState, id: string): DashboardState {
+	if (!state.dashboards.some(d => d.id === id)) return state;
+	return { ...state, activeId: id };
+}
+
+export function updateDashboardVisible(state: DashboardState, id: string, key: OverviewSectionKey): DashboardState {
+	return {
+		...state,
+		dashboards: state.dashboards.map(d =>
+			d.id === id ? { ...d, visible: { ...d.visible, [key]: !d.visible[key] } } : d,
+		),
+	};
+}
+
+export function resetDashboard(state: DashboardState, id: string, preset: PresetId = "default"): DashboardState {
+	return {
+		...state,
+		dashboards: state.dashboards.map(d => (d.id === id ? { ...d, visible: { ...PRESET_DEFS[preset].visible } } : d)),
+	};
+}
+
+export function resetAllDashboards(): DashboardState {
+	return { activeId: "default", dashboards: defaultDashboards() };
+}

--- a/packages/stats/src/client/data/overview-prefs.ts
+++ b/packages/stats/src/client/data/overview-prefs.ts
@@ -1,0 +1,147 @@
+export type OverviewSectionKey =
+	| "tape"
+	| "scope"
+	| "models"
+	| "providers"
+	| "tokens"
+	| "agents"
+	| "tools"
+	| "projects"
+	| "errors";
+
+export const SECTION_ORDER: OverviewSectionKey[] = [
+	"tape",
+	"scope",
+	"tokens",
+	"agents",
+	"models",
+	"providers",
+	"tools",
+	"projects",
+	"errors",
+];
+
+export const SECTION_LABELS: Record<OverviewSectionKey, string> = {
+	tape: "KPI tape",
+	scope: "Usage over time",
+	models: "Models",
+	providers: "Providers",
+	tokens: "Token breakdown",
+	agents: "Agents",
+	tools: "Tools",
+	projects: "Projects",
+	errors: "Recent errors",
+};
+
+export type PresetId = "default" | "tokens" | "models";
+
+export const PRESET_DEFS: Record<PresetId, { label: string; visible: Record<OverviewSectionKey, boolean> }> = {
+	default: {
+		label: "Default",
+		visible: {
+			tape: true,
+			scope: true,
+			models: true,
+			providers: true,
+			tokens: true,
+			agents: true,
+			tools: true,
+			projects: true,
+			errors: true,
+		},
+	},
+	tokens: {
+		label: "Tokens",
+		visible: {
+			tape: true,
+			scope: true,
+			models: false,
+			providers: false,
+			tokens: true,
+			agents: true,
+			tools: true,
+			projects: false,
+			errors: false,
+		},
+	},
+	models: {
+		label: "Models",
+		visible: {
+			tape: true,
+			scope: true,
+			models: true,
+			providers: true,
+			tokens: false,
+			agents: true,
+			tools: false,
+			projects: false,
+			errors: true,
+		},
+	},
+};
+
+export const STORAGE_KEY = "omp-stats:overview-prefs";
+
+export interface PrefsState {
+	preset: PresetId | "custom";
+	visible: Record<OverviewSectionKey, boolean>;
+}
+
+export function loadPrefs(storage: Pick<Storage, "getItem"> = globalThis.localStorage): PrefsState {
+	try {
+		const raw = storage.getItem(STORAGE_KEY);
+		if (raw) {
+			const parsed = JSON.parse(raw) as Partial<PrefsState>;
+			if (parsed.visible && typeof parsed.preset === "string") {
+				const base = PRESET_DEFS.default.visible;
+				const visible = { ...base } as Record<OverviewSectionKey, boolean>;
+				for (const k of SECTION_ORDER) {
+					if (typeof (parsed.visible as Record<string, unknown>)[k] === "boolean") {
+						visible[k] = (parsed.visible as Record<string, boolean>)[k];
+					}
+				}
+				const preset = (["default", "tokens", "models", "custom"] as const).includes(parsed.preset as PresetId)
+					? (parsed.preset as PrefsState["preset"])
+					: "custom";
+				return { preset, visible };
+			}
+		}
+	} catch {
+		// ignore
+	}
+	return { preset: "default", visible: { ...PRESET_DEFS.default.visible } };
+}
+
+export function savePrefs(prefs: PrefsState, storage: Pick<Storage, "setItem"> = globalThis.localStorage): void {
+	try {
+		storage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+	} catch {
+		// ignore quota
+	}
+}
+
+export function nextPrefsOnToggle(prev: PrefsState, key: OverviewSectionKey): PrefsState {
+	const nextVisible = { ...prev.visible, [key]: !prev.visible[key] };
+	let matched: PrefsState["preset"] = "custom";
+	for (const pid of Object.keys(PRESET_DEFS) as PresetId[]) {
+		const def = PRESET_DEFS[pid].visible;
+		if (SECTION_ORDER.every(k => def[k] === nextVisible[k])) matched = pid;
+	}
+	return { preset: matched, visible: nextVisible };
+}
+
+export function prefsForPreset(id: PresetId): PrefsState {
+	return { preset: id, visible: { ...PRESET_DEFS[id].visible } };
+}
+
+export function activeDaysFromSeries(series: { timestamp: number; requests: number }[] | undefined): number {
+	if (!series || series.length === 0) return 0;
+	const days = new Set<string>();
+	for (const pt of series) if (pt.requests > 0) days.add(new Date(pt.timestamp).toDateString());
+	if (days.size === 0) {
+		const hasAny = series.some(p => p.requests > 0);
+		if (!hasAny) return 0;
+		return new Set(series.map(p => new Date(p.timestamp).toDateString())).size;
+	}
+	return days.size;
+}

--- a/packages/stats/src/client/data/overview-prefs.ts
+++ b/packages/stats/src/client/data/overview-prefs.ts
@@ -7,7 +7,9 @@ export type OverviewSectionKey =
 	| "agents"
 	| "tools"
 	| "projects"
-	| "errors";
+	| "errors"
+	| "liveFeed"
+	| "recentRequests";
 
 export const SECTION_ORDER: OverviewSectionKey[] = [
 	"tape",
@@ -19,6 +21,8 @@ export const SECTION_ORDER: OverviewSectionKey[] = [
 	"tools",
 	"projects",
 	"errors",
+	"liveFeed",
+	"recentRequests",
 ];
 
 export const SECTION_LABELS: Record<OverviewSectionKey, string> = {
@@ -31,6 +35,8 @@ export const SECTION_LABELS: Record<OverviewSectionKey, string> = {
 	tools: "Tools",
 	projects: "Projects",
 	errors: "Recent errors",
+	liveFeed: "Live feed",
+	recentRequests: "Recent requests",
 };
 
 export type PresetId = "default" | "tokens" | "models";
@@ -48,6 +54,8 @@ export const PRESET_DEFS: Record<PresetId, { label: string; visible: Record<Over
 			tools: true,
 			projects: true,
 			errors: true,
+			liveFeed: true,
+			recentRequests: true,
 		},
 	},
 	tokens: {
@@ -62,6 +70,8 @@ export const PRESET_DEFS: Record<PresetId, { label: string; visible: Record<Over
 			tools: true,
 			projects: false,
 			errors: false,
+			liveFeed: false,
+			recentRequests: false,
 		},
 	},
 	models: {
@@ -76,6 +86,8 @@ export const PRESET_DEFS: Record<PresetId, { label: string; visible: Record<Over
 			tools: false,
 			projects: false,
 			errors: true,
+			liveFeed: true,
+			recentRequests: true,
 		},
 	},
 };
@@ -182,15 +194,30 @@ export function defaultDashboards(): Dashboard[] {
 				tools: false,
 				projects: false,
 				errors: true,
+				liveFeed: false,
+				recentRequests: false,
 			},
 			createdAt: 4,
 		},
 	];
 }
 
-function isValidVisible(v: unknown): v is Record<OverviewSectionKey, boolean> {
+function isValidVisible(v: unknown): v is Record<string, boolean> {
 	if (!v || typeof v !== "object") return false;
-	return SECTION_ORDER.every(k => typeof (v as Record<string, unknown>)[k] === "boolean");
+	return Object.values(v).every(val => typeof val === "boolean");
+}
+
+/**
+ * Fill every known section key from a stored visibility record. Records saved
+ * by older builds lack `liveFeed`/`recentRequests`; those default to visible
+ * so legacy dashboards survive the migration instead of being discarded.
+ */
+function completeVisible(v: Record<string, boolean>): Record<OverviewSectionKey, boolean> {
+	const visible = { ...PRESET_DEFS.default.visible } as Record<OverviewSectionKey, boolean>;
+	for (const k of SECTION_ORDER) {
+		if (typeof v[k] === "boolean") visible[k] = v[k];
+	}
+	return visible;
 }
 
 export function loadDashboardState(storage: Pick<Storage, "getItem"> = globalThis.localStorage): DashboardState {
@@ -203,11 +230,13 @@ export function loadDashboardState(storage: Pick<Storage, "getItem"> = globalThi
 				for (const d of parsed.dashboards as unknown[]) {
 					if (!d || typeof d !== "object") continue;
 					const rec = d as Record<string, unknown>;
-					if (typeof rec.id !== "string" || typeof rec.name !== "string" || !isValidVisible(rec.visible)) continue;
+					if (typeof rec.id !== "string" || typeof rec.name !== "string" || !isValidVisible(rec.visible)) {
+						continue;
+					}
 					cleaned.push({
 						id: rec.id,
 						name: rec.name,
-						visible: rec.visible as Record<OverviewSectionKey, boolean>,
+						visible: completeVisible(rec.visible as Record<string, boolean>),
 						createdAt: typeof rec.createdAt === "number" ? rec.createdAt : Date.now(),
 					});
 				}
@@ -222,7 +251,7 @@ export function loadDashboardState(storage: Pick<Storage, "getItem"> = globalThi
 			try {
 				const legacy = JSON.parse(legacyRaw) as Partial<PrefsState>;
 				if (legacy.visible && isValidVisible(legacy.visible)) {
-					const visible = legacy.visible as Record<OverviewSectionKey, boolean>;
+					const visible = completeVisible(legacy.visible as Record<string, boolean>);
 					return {
 						activeId: "custom",
 						dashboards: [

--- a/packages/stats/src/client/data/useHashRoute.ts
+++ b/packages/stats/src/client/data/useHashRoute.ts
@@ -16,7 +16,7 @@ const VALID_SECTIONS: DashboardSection[] = [
 	"gain",
 ];
 
-const VALID_RANGES: TimeRange[] = ["1h", "24h", "7d", "30d", "90d", "all"];
+const VALID_RANGES: TimeRange[] = ["today", "1h", "24h", "7d", "30d", "90d", "all"];
 
 function parseHash(hash: string): { section: DashboardSection; range: TimeRange; session: string | null } {
 	const cleanHash = hash.replace(/^#\/?/, "");

--- a/packages/stats/src/client/data/view-models.ts
+++ b/packages/stats/src/client/data/view-models.ts
@@ -6,7 +6,10 @@ import type {
 	BehaviorTimeSeriesPoint,
 	CostTimeSeriesPoint,
 	FolderStats,
+	MessageStats,
 	ModelPerformancePoint,
+	ModelStats,
+	ProviderAggregate,
 	TimeRange,
 	ToolUsageStats,
 } from "../types";
@@ -259,4 +262,211 @@ export function buildToolRows(tools: ToolUsageStats[]): ToolRowView[] {
 		errorRate: t.calls > 0 ? t.errors / t.calls : 0,
 		callsPercentage: maxCalls > 0 ? (t.calls / maxCalls) * 100 : 0,
 	}));
+}
+// ---------------------------------------------------------------------------
+// Model rows — share bars + sorting (client-side view-model, no server change)
+// ---------------------------------------------------------------------------
+
+export type ModelSortKey = "requests" | "tokens" | "cost" | "cache" | "errorRate" | "model";
+export type SortDir = "asc" | "desc";
+
+export interface ModelRowView extends ModelStats {
+	/** Share of total requests, 0-1. */
+	share: number;
+	/** Total tokens (input+output+cache). */
+	totalTokens: number;
+}
+
+export function buildModelRows(models: ModelStats[]): ModelRowView[] {
+	const totalRequests = models.reduce((sum, m) => sum + m.totalRequests, 0);
+	return models.map(m => ({
+		...m,
+		share: totalRequests > 0 ? m.totalRequests / totalRequests : 0,
+		totalTokens: m.totalInputTokens + m.totalOutputTokens + m.totalCacheReadTokens + m.totalCacheWriteTokens,
+	}));
+}
+
+export function sortModelRows(rows: ModelRowView[], key: ModelSortKey, dir: SortDir): ModelRowView[] {
+	const mul = dir === "asc" ? 1 : -1;
+	return [...rows].sort((a, b) => {
+		let cmp = 0;
+		switch (key) {
+			case "requests":
+				cmp = a.totalRequests - b.totalRequests;
+				break;
+			case "tokens":
+				cmp = a.totalTokens - b.totalTokens;
+				break;
+			case "cost":
+				cmp = a.totalCost - b.totalCost;
+				break;
+			case "cache":
+				cmp = a.cacheRate - b.cacheRate;
+				break;
+			case "errorRate":
+				cmp = a.errorRate - b.errorRate;
+				break;
+			case "model":
+				cmp = a.model.localeCompare(b.model);
+				break;
+		}
+		if (cmp !== 0) return cmp * mul;
+		return b.totalRequests - a.totalRequests;
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Provider rows — sorting + elevated failure flag
+// ---------------------------------------------------------------------------
+
+export type ProviderSortKey = "requests" | "cost" | "failure" | "cache" | "provider";
+export type ProviderFailureTone = "ok" | "warning" | "danger";
+
+export function providerFailureTone(errorRate: number): ProviderFailureTone {
+	if (errorRate >= 0.08) return "danger";
+	if (errorRate >= 0.03) return "warning";
+	return "ok";
+}
+
+export function sortProviderRows(rows: ProviderAggregate[], key: ProviderSortKey, dir: SortDir): ProviderAggregate[] {
+	const mul = dir === "asc" ? 1 : -1;
+	return [...rows].sort((a, b) => {
+		let cmp = 0;
+		switch (key) {
+			case "requests":
+				cmp = a.totalRequests - b.totalRequests;
+				break;
+			case "cost":
+				cmp = a.totalCost - b.totalCost;
+				break;
+			case "failure": {
+				const ar = a.totalRequests > 0 ? a.failedRequests / a.totalRequests : 0;
+				const br = b.totalRequests > 0 ? b.failedRequests / b.totalRequests : 0;
+				cmp = ar - br;
+				break;
+			}
+			case "cache": {
+				const ar = a.totalTokens > 0 ? a.totalCacheReadTokens / a.totalTokens : 0;
+				const br = b.totalTokens > 0 ? b.totalCacheReadTokens / b.totalTokens : 0;
+				cmp = ar - br;
+				break;
+			}
+			case "provider":
+				cmp = a.provider.localeCompare(b.provider);
+				break;
+		}
+		if (cmp !== 0) return cmp * mul;
+		return b.totalRequests - a.totalRequests;
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Errors — normalize + group (client-side view-model for the explorer)
+// ---------------------------------------------------------------------------
+
+export type ErrorGroupBy = "error" | "provider" | "model";
+
+export function normalizeErrorMessage(msg: string | null): string {
+	if (!msg) return "Unknown error";
+	let s = msg.trim();
+	// Collapse whitespace and take first line only (often stack follows).
+	s = s.split("\n")[0] ?? s;
+	s = s.replace(/\s+/g, " ").trim();
+	// Strip leading status codes in brackets like [403] or "Error:" prefix noise? Keep as part of signature
+	// Normalize: lower doesn't — keep case for display but key is lowercased.
+	// For key purposes we lowercase and strip trailing punctuation.
+	// Also truncate very long messages to 160 chars for grouping stability.
+	if (s.length > 160) s = s.slice(0, 160);
+	return s || "Unknown error";
+}
+
+export function errorGroupKey(msg: string | null, provider: string, model: string, groupBy: ErrorGroupBy): string {
+	const norm = normalizeErrorMessage(msg).toLowerCase();
+	switch (groupBy) {
+		case "provider":
+			return provider || "unknown";
+		case "model":
+			return model || "unknown";
+		default:
+			return `${provider}::${norm}`;
+	}
+}
+
+export interface ErrorGroup {
+	key: string;
+	signature: string;
+	provider: string;
+	model: string;
+	count: number;
+	items: MessageStats[];
+	latestTimestamp: number;
+	representativeMessage: string;
+}
+
+export function groupErrors(messages: MessageStats[], groupBy: ErrorGroupBy = "error"): ErrorGroup[] {
+	const map = new Map<string, ErrorGroup>();
+	for (const m of messages) {
+		if (!m.errorMessage) continue;
+		const key = errorGroupKey(m.errorMessage, m.provider, m.model, groupBy);
+		const sig =
+			groupBy === "provider" ? m.provider : groupBy === "model" ? m.model : normalizeErrorMessage(m.errorMessage);
+		const existing = map.get(key);
+		if (existing) {
+			existing.count += 1;
+			existing.items.push(m);
+			if (m.timestamp > existing.latestTimestamp) existing.latestTimestamp = m.timestamp;
+		} else {
+			map.set(key, {
+				key,
+				signature: sig,
+				provider: m.provider,
+				model: m.model,
+				count: 1,
+				items: [m],
+				latestTimestamp: m.timestamp,
+				representativeMessage: normalizeErrorMessage(m.errorMessage),
+			});
+		}
+	}
+	const groups = [...map.values()];
+	// Most frequent / most recent first: sort by count desc then latest desc.
+	groups.sort((a, b) => {
+		if (b.count !== a.count) return b.count - a.count;
+		return b.latestTimestamp - a.latestTimestamp;
+	});
+	// Within each group sort occurrences newest first for detail list.
+	for (const g of groups) g.items.sort((a, b) => b.timestamp - a.timestamp);
+	return groups;
+}
+
+// ---------------------------------------------------------------------------
+// Requests — sort helpers (re-used for the explorer table)
+// ---------------------------------------------------------------------------
+
+export type RequestSortKey = "timestamp" | "tokens" | "cost" | "duration" | "model";
+
+export function sortRequests(rows: MessageStats[], key: RequestSortKey, dir: SortDir): MessageStats[] {
+	const mul = dir === "asc" ? 1 : -1;
+	return [...rows].sort((a, b) => {
+		let cmp = 0;
+		switch (key) {
+			case "timestamp":
+				cmp = a.timestamp - b.timestamp;
+				break;
+			case "tokens":
+				cmp = a.usage.totalTokens - b.usage.totalTokens;
+				break;
+			case "cost":
+				cmp = a.usage.cost.total - b.usage.cost.total;
+				break;
+			case "duration":
+				cmp = (a.duration ?? 0) - (b.duration ?? 0);
+				break;
+			case "model":
+				cmp = a.model.localeCompare(b.model);
+				break;
+		}
+		if (cmp !== 0) return cmp * mul;
+		return b.timestamp - a.timestamp;
+	});
 }

--- a/packages/stats/src/client/data/view-models.ts
+++ b/packages/stats/src/client/data/view-models.ts
@@ -116,7 +116,9 @@ export interface FolderRowView extends FolderStats {
 export function buildCostSummary(costSeries: CostTimeSeriesPoint[]): CostSummaryView {
 	const totalCost = costSeries.reduce((sum, p) => sum + p.cost, 0);
 	const unpricedRequests = costSeries.reduce((sum, point) => sum + point.unpricedRequests, 0);
-	const dayBuckets = new Set(costSeries.map(p => p.timestamp)).size;
+	// Distinct LOCAL CALENDAR days, not distinct bucket timestamps: hourly
+	// Today buckets would otherwise report 24 "days".
+	const dayBuckets = new Set(costSeries.map(p => new Date(p.timestamp).toDateString())).size;
 	const avgDailyCost = dayBuckets > 0 ? totalCost / dayBuckets : 0;
 
 	const modelTotals = new Map<string, number>();

--- a/packages/stats/src/client/routes/BehaviorRoute.tsx
+++ b/packages/stats/src/client/routes/BehaviorRoute.tsx
@@ -1,38 +1,12 @@
-import { format } from "@oh-my-pi/pi-utils/dates";
 import { useMemo, useState } from "react";
-import { Bar, Line } from "react-chartjs-2";
+import { Line } from "react-chartjs-2";
 import { getBehaviorDashboardStats } from "../api";
-import {
-	barDatasetStyle,
-	buildAggregateTimeSeries,
-	buildSharedPlugins,
-	buildSharedScales,
-	buildTopNByModelSeries,
-	CHART_THEMES,
-	lineDatasetStyle,
-	MODEL_COLORS,
-	styleDatasets,
-} from "../components/chart-shared";
-import {
-	DetailChartEmpty,
-	detailChartPlugins,
-	detailChartScalesSingleAxis,
-	ExpandableModelRow,
-	lineSeriesStyle,
-	MiniSparkline,
-	ModelNameCell,
-	ModelTableBody,
-	ModelTableHeader,
-	ModelTableShell,
-	TABLE_CHART_THEMES,
-	type TableChartTheme,
-	TrendEmpty,
-} from "../components/models-table-shared";
+import { CHART_THEMES } from "../components/chart-shared";
 import { formatInteger } from "../data/formatters";
 import { useResource } from "../data/useResource";
 import { buildBehaviorSummary } from "../data/view-models";
 import type { BehaviorModelStats, BehaviorOverallStats, BehaviorTimeSeriesPoint, TimeRange } from "../types";
-import { AsyncBoundary, Panel, SegmentedControl } from "../ui";
+import { AsyncBoundary } from "../ui";
 import { useSystemTheme } from "../useSystemTheme";
 
 export interface BehaviorRouteProps {
@@ -52,13 +26,40 @@ export function BehaviorRoute({ active, range, refreshTrigger }: BehaviorRoutePr
 	});
 
 	return (
-		<div className="stats-route-container space-y-6">
+		<div className="stats-route-container">
+			<div className="omp-hero">
+				<div className="omp-hero-head">
+					<h2 className="omp-hero-title">
+						Behavior <span>{range} · user-message telemetry</span>
+					</h2>
+					<span className="omp-hero-range">
+						{stats
+							? `${formatInteger(stats.overall.totalMessages)} messages · ${stats.byModel.length} models`
+							: "loading"}
+					</span>
+				</div>
+				<p
+					style={{
+						fontFamily: "var(--font-sans)",
+						fontSize: 12,
+						color: "var(--muted)",
+						margin: 0,
+						maxWidth: 760,
+						lineHeight: 1.5,
+					}}
+				>
+					OMP-specific signals from user messages — yelling, profanity, anguish, negation, repetition, blame. Not
+					sentiment guesses; deterministic lexical heuristics surfaced per responding model so you see which
+					contexts attract friction.
+				</p>
+			</div>
+
 			<AsyncBoundary loading={loading} error={error} data={stats}>
 				{stats && (
 					<>
-						<BehaviorSummaryPanel overall={stats.overall} behaviorSeries={stats.behaviorSeries} />
-						<BehaviorChartPanel behaviorSeries={stats.behaviorSeries} />
-						<BehaviorModelsTable models={stats.byModel} behaviorSeries={stats.behaviorSeries} />
+						<BehaviorSummary overall={stats.overall} series={stats.behaviorSeries} />
+						<BehaviorChart series={stats.behaviorSeries} />
+						<BehaviorModels models={stats.byModel} />
 					</>
 				)}
 			</AsyncBoundary>
@@ -66,558 +67,261 @@ export function BehaviorRoute({ active, range, refreshTrigger }: BehaviorRoutePr
 	);
 }
 
-function perMsg(total: number, messages: number): string | undefined {
-	if (messages <= 0) return undefined;
-	return `${(total / messages).toFixed(2)} / msg`;
-}
-
-function BehaviorSummaryPanel({
-	overall,
-	behaviorSeries,
-}: {
-	overall: BehaviorOverallStats;
-	behaviorSeries: BehaviorTimeSeriesPoint[];
-}) {
-	const summary = useMemo(() => buildBehaviorSummary(overall, behaviorSeries), [overall, behaviorSeries]);
-	const messages = overall.totalMessages;
-
-	const cards = [
-		{
-			label: "User Messages",
-			value: formatInteger(overall.totalMessages),
-			sub: messages > 0 ? "in range" : undefined,
-		},
-		{
-			label: "Yelling (CAPS)",
-			value: formatInteger(overall.totalYelling),
-			sub: perMsg(overall.totalYelling, messages),
-		},
-		{
-			label: "Profanity Hits",
-			value: formatInteger(overall.totalProfanity),
-			sub: perMsg(overall.totalProfanity, messages),
-		},
-		{
-			label: "Anguish Signals",
-			value: formatInteger(overall.totalAnguish),
-			sub: perMsg(overall.totalAnguish, messages),
-		},
-		{
-			label: "Friction Signals",
-			value: formatInteger(summary.totalFrustration),
-			sub: perMsg(summary.totalFrustration, messages),
-		},
-		{
-			label: "Highest Friction Model",
-			value: summary.highestFrictionModel?.model ?? "—",
-			sub: summary.highestFrictionModel ? `${formatInteger(summary.highestFrictionModel.score)} hits` : undefined,
-		},
-	];
-
+function BehaviorSummary({ overall, series }: { overall: BehaviorOverallStats; series: BehaviorTimeSeriesPoint[] }) {
+	const summary = useMemo(() => buildBehaviorSummary(overall, series), [overall, series]);
+	const perMsg = (total: number) =>
+		overall.totalMessages > 0 ? `${(total / overall.totalMessages).toFixed(2)} / msg` : undefined;
 	return (
-		<div className="grid grid-cols-2 md:grid-cols-6 gap-4">
-			{cards.map(card => (
-				<Panel key={card.label} className="stats-behavior-summary-card py-3 px-4">
-					<p className="text-xs stats-text-muted mb-1 font-medium truncate">{card.label}</p>
-					<p className="text-lg font-bold stats-text-primary truncate" title={card.value}>
-						{card.value}
+		<div className="omp-section">
+			<div className="omp-section-head">
+				<div>
+					<div className="omp-section-title">Overview</div>
+					<p className="omp-section-desc">
+						Counts are hits across all user messages in window. Highest-friction model surfaces where intervention
+						may help.
 					</p>
-					{card.sub && <p className="text-xs stats-text-muted mt-0.5">{card.sub}</p>}
-				</Panel>
-			))}
+				</div>
+			</div>
+			<div className="omp-section-rule" />
+			<div className="omp-section-body">
+				<div className="omp-behavior-grid">
+					<div className="omp-behavior-kpi">
+						<div className="omp-behavior-kpi-label">Messages</div>
+						<div className="omp-behavior-kpi-value">{formatInteger(overall.totalMessages)}</div>
+						<div className="omp-behavior-kpi-sub">{overall.totalChars.toLocaleString()} chars</div>
+					</div>
+					<div className="omp-behavior-kpi">
+						<div className="omp-behavior-kpi-label">Yelling</div>
+						<div className="omp-behavior-kpi-value">{formatInteger(overall.totalYelling)}</div>
+						<div className="omp-behavior-kpi-sub">{perMsg(overall.totalYelling)}</div>
+					</div>
+					<div className="omp-behavior-kpi">
+						<div className="omp-behavior-kpi-label">Profanity</div>
+						<div className="omp-behavior-kpi-value">{formatInteger(overall.totalProfanity)}</div>
+						<div className="omp-behavior-kpi-sub">{perMsg(overall.totalProfanity)}</div>
+					</div>
+					<div className="omp-behavior-kpi">
+						<div className="omp-behavior-kpi-label">Anguish</div>
+						<div className="omp-behavior-kpi-value">{formatInteger(overall.totalAnguish)}</div>
+						<div className="omp-behavior-kpi-sub">{perMsg(overall.totalAnguish)}</div>
+					</div>
+					<div className="omp-behavior-kpi">
+						<div className="omp-behavior-kpi-label">Negation</div>
+						<div className="omp-behavior-kpi-value">{formatInteger(overall.totalNegation)}</div>
+						<div className="omp-behavior-kpi-sub">{perMsg(overall.totalNegation)}</div>
+					</div>
+					<div className="omp-behavior-kpi">
+						<div className="omp-behavior-kpi-label">Repetition</div>
+						<div className="omp-behavior-kpi-value">{formatInteger(overall.totalRepetition)}</div>
+						<div className="omp-behavior-kpi-sub">{perMsg(overall.totalRepetition)}</div>
+					</div>
+					<div className="omp-behavior-kpi">
+						<div className="omp-behavior-kpi-label">Blame</div>
+						<div className="omp-behavior-kpi-value">{formatInteger(overall.totalBlame)}</div>
+						<div className="omp-behavior-kpi-sub">{perMsg(overall.totalBlame)}</div>
+					</div>
+					<div className="omp-behavior-kpi">
+						<div className="omp-behavior-kpi-label">Peak friction model</div>
+						<div className="omp-behavior-kpi-value" style={{ fontSize: 13 }}>
+							{summary.highestFrictionModel?.model ?? "—"}
+						</div>
+						<div className="omp-behavior-kpi-sub">
+							{summary.highestFrictionModel
+								? `${formatInteger(summary.highestFrictionModel.score)} hits`
+								: "no data"}
+						</div>
+					</div>
+				</div>
+			</div>
 		</div>
 	);
 }
 
-const METRIC_OPTIONS = [
-	{ value: "yelling", label: "CAPS", title: "Yelling (CAPS)" },
-	{ value: "profanity", label: "Profanity", title: "Profanity" },
-	{ value: "anguish", label: "Anguish", title: "Anguish (!!!, nooo, ugh, dude, ':(')" },
-	{ value: "negation", label: "Negation", title: "Negation (no/nope/wrong, makes no sense)" },
-	{
-		value: "repetition",
-		label: "Repetition",
-		title: "Repetition (i meant, still doesnt)",
-	},
-	{ value: "blame", label: "Blame", title: "Blame (you didnt, why did you, stop X-ing)" },
-	{
-		value: "frustration",
-		label: "Frustration",
-		title: "Frustration (neg + rep + blame)",
-	},
-	{ value: "total", label: "All", title: "All signals combined" },
-] as const;
+type Metric = "yelling" | "profanity" | "anguish" | "negation" | "repetition" | "blame";
+const METRICS: { value: Metric; label: string }[] = [
+	{ value: "yelling", label: "Yelling" },
+	{ value: "profanity", label: "Profanity" },
+	{ value: "anguish", label: "Anguish" },
+	{ value: "negation", label: "Negation" },
+	{ value: "repetition", label: "Repetition" },
+	{ value: "blame", label: "Blame" },
+];
 
-type Metric = (typeof METRIC_OPTIONS)[number]["value"];
-
-function formatRateAxis(value: number): string {
-	if (!Number.isFinite(value)) return "-";
-	if (value === 0) return "0%";
-	if (Math.abs(value) < 1) return `${value.toFixed(1)}%`;
-	return `${value.toFixed(0)}%`;
-}
-
-function pointHits(point: BehaviorTimeSeriesPoint, metric: Metric): number {
-	if (metric === "frustration") {
-		return point.negation + point.repetition + point.blame;
-	}
-	if (metric === "total") {
-		return point.yelling + point.profanity + point.anguish + point.negation + point.repetition + point.blame;
-	}
-	return point[metric];
-}
-
-function ratePercent(hits: number, messages: number): number {
-	if (messages <= 0) return 0;
-	return (hits / messages) * 100;
-}
-
-interface DailyBucket {
-	hits: number;
-	messages: number;
-}
-
-function BehaviorChartPanel({ behaviorSeries }: { behaviorSeries: BehaviorTimeSeriesPoint[] }) {
-	const [byModel, setByModel] = useState(false);
-	const [metric, setMetric] = useState<Metric>("total");
+function BehaviorChart({ series }: { series: BehaviorTimeSeriesPoint[] }) {
+	const [metric, setMetric] = useState<Metric>("anguish");
 	const theme = useSystemTheme();
 	const chartTheme = CHART_THEMES[theme];
 
-	const chartData = useMemo(() => {
-		if (byModel) {
-			return buildTopNByModelSeries<BehaviorTimeSeriesPoint, DailyBucket>(behaviorSeries, {
-				rankWeight: point => point.messages,
-				initBucket: () => ({ hits: 0, messages: 0 }),
-				accumulate: (bucket, point) => {
-					bucket.hits += pointHits(point, metric);
-					bucket.messages += point.messages;
-				},
-				bucketToValue: bucket => ratePercent(bucket.hits, bucket.messages),
-			});
+	const bucketed = useMemo(() => {
+		const map = new Map<number, number>();
+		for (const p of series) {
+			const v =
+				metric === "yelling"
+					? p.yelling
+					: metric === "profanity"
+						? p.profanity
+						: metric === "anguish"
+							? p.anguish
+							: metric === "negation"
+								? p.negation
+								: metric === "repetition"
+									? p.repetition
+									: p.blame;
+			map.set(p.timestamp, (map.get(p.timestamp) ?? 0) + v);
 		}
-		const metricLabel = METRIC_OPTIONS.find(m => m.value === metric)?.title ?? "Hits";
-		return buildAggregateTimeSeries<BehaviorTimeSeriesPoint, DailyBucket>(behaviorSeries, metricLabel, {
-			initBucket: () => ({ hits: 0, messages: 0 }),
-			accumulate: (bucket, point) => {
-				bucket.hits += pointHits(point, metric);
-				bucket.messages += point.messages;
+		return [...map.entries()].sort((a, b) => a[0] - b[0]);
+	}, [series, metric]);
+
+	const data = useMemo(() => {
+		const labels = bucketed.map(([ts]) =>
+			new Date(ts).toLocaleDateString(undefined, { month: "short", day: "numeric" }),
+		);
+		return {
+			labels,
+			datasets: [
+				{
+					label: metric,
+					data: bucketed.map(([, v]) => v),
+					borderColor: theme === "dark" ? "oklch(0.78 0.09 30)" : "oklch(0.55 0.12 30)",
+					backgroundColor: theme === "dark" ? "oklch(0.78 0.09 30 / 0.08)" : "oklch(0.55 0.12 30 / 0.06)",
+					tension: 0.3,
+					borderWidth: 1.6,
+					pointRadius: bucketed.length <= 12 ? 3 : 0,
+					fill: true,
+				},
+			],
+		};
+	}, [bucketed, metric, theme]);
+
+	const options = useMemo(
+		() => ({
+			responsive: true,
+			maintainAspectRatio: false,
+			interaction: { mode: "index" as const, intersect: false },
+			plugins: {
+				legend: { display: false },
+				tooltip: {
+					backgroundColor: chartTheme.tooltipBackground,
+					titleColor: chartTheme.tooltipTitle,
+					bodyColor: chartTheme.tooltipBody,
+					borderColor: chartTheme.tooltipBorder,
+					borderWidth: 1,
+					cornerRadius: 8,
+					padding: 8,
+				},
 			},
-			bucketToValue: bucket => ratePercent(bucket.hits, bucket.messages),
-		});
-	}, [behaviorSeries, byModel, metric]);
-
-	const sharedPlugins = useMemo(() => {
-		return buildSharedPlugins({
-			chartTheme,
-			showLegend: byModel,
-			defaultLabel: "Hits",
-			formatValue: formatRateAxis,
-		});
-	}, [chartTheme, byModel]);
-
-	const { sharedScaleBase, yScale } = useMemo(() => {
-		return buildSharedScales({ chartTheme, formatY: formatRateAxis });
-	}, [chartTheme]);
-
-	const metricLabel = useMemo(() => {
-		return METRIC_OPTIONS.find(m => m.value === metric)?.title ?? "";
-	}, [metric]);
-
-	const lineData = useMemo(() => {
-		if (!byModel) return null;
-		return {
-			labels: chartData.labels,
-			datasets: styleDatasets(chartData, i => lineDatasetStyle(MODEL_COLORS[i % MODEL_COLORS.length])),
-		};
-	}, [chartData, byModel]);
-
-	const lineOptions = useMemo(() => {
-		return {
-			responsive: true,
-			maintainAspectRatio: false,
-			interaction: { mode: "index" as const, intersect: false },
-			plugins: sharedPlugins,
-			scales: { x: sharedScaleBase, y: yScale },
-		};
-	}, [sharedPlugins, sharedScaleBase, yScale]);
-
-	const barData = useMemo(() => {
-		if (byModel) return null;
-		return {
-			labels: chartData.labels,
-			datasets: styleDatasets(chartData, i => barDatasetStyle(MODEL_COLORS[i % MODEL_COLORS.length])),
-		};
-	}, [chartData, byModel]);
-
-	const barOptions = useMemo(() => {
-		return {
-			responsive: true,
-			maintainAspectRatio: false,
-			interaction: { mode: "index" as const, intersect: false },
-			plugins: sharedPlugins,
 			scales: {
-				x: { ...sharedScaleBase, stacked: true },
-				y: { ...yScale, stacked: true },
+				x: {
+					grid: { color: chartTheme.grid, drawBorder: false },
+					ticks: {
+						color: chartTheme.tick,
+						font: { size: 10, family: "var(--font-mono)" },
+						maxTicksLimit: 8,
+						maxRotation: 0,
+					},
+					border: { display: false },
+				},
+				y: {
+					grid: { color: chartTheme.grid, drawBorder: false },
+					ticks: { color: chartTheme.tick, font: { size: 10, family: "var(--font-mono)" } },
+					min: 0,
+					border: { display: false },
+				},
 			},
-			layout: { padding: { top: 8 } },
-		};
-	}, [sharedPlugins, sharedScaleBase, yScale]);
-
-	const byModelOptions = [
-		{ value: false, label: "All Models" },
-		{ value: true, label: "By Model" },
-	];
+		}),
+		[chartTheme],
+	);
 
 	return (
-		<Panel
-			title="User Friction Signals"
-			subtitle={`${metricLabel} as % of user messages per day`}
-			actions={
-				<div className="flex items-center gap-3 flex-wrap">
-					<SegmentedControl
-						options={METRIC_OPTIONS.map(o => ({
-							value: o.value,
-							label: o.label,
-							title: o.title,
-						}))}
-						value={metric}
-						onChange={setMetric}
-					/>
-					<SegmentedControl options={byModelOptions} value={byModel} onChange={setByModel} />
+		<div className="omp-section">
+			<div className="omp-section-head">
+				<div>
+					<div className="omp-section-title">Signals over time</div>
+					<p className="omp-section-desc">Daily buckets — pick a signal to see when friction rose.</p>
 				</div>
-			}
-		>
-			<div className="h-[300px]">
-				{chartData.labels.length === 0 ? (
-					<div className="h-full flex items-center justify-center text-stats-muted text-sm">
-						No friction signal data available
-					</div>
-				) : byModel && lineData ? (
-					<Line data={lineData} options={lineOptions} />
-				) : barData ? (
-					<Bar data={barData} options={barOptions} />
-				) : null}
+				<div className="stats-segmented-control">
+					{METRICS.map(m => (
+						<button
+							key={m.value}
+							type="button"
+							className="stats-segmented-control-btn"
+							data-active={metric === m.value ? "true" : "false"}
+							onClick={() => setMetric(m.value)}
+						>
+							{m.label}
+						</button>
+					))}
+				</div>
 			</div>
-		</Panel>
-	);
-}
-
-const TABLE_GRID_TEMPLATE = "2fr 0.9fr 0.8fr 0.8fr 0.8fr 0.9fr 0.8fr 140px 40px";
-
-function totalHitRate(model: BehaviorModelStats): number {
-	if (model.totalMessages === 0) return 0;
-	const hits =
-		model.totalYelling +
-		model.totalProfanity +
-		model.totalAnguish +
-		model.totalNegation +
-		model.totalRepetition +
-		model.totalBlame;
-	return hits / model.totalMessages;
-}
-
-function formatRate(total: number, messages: number): string {
-	if (messages === 0) return "-";
-	const pct = (total / messages) * 100;
-	if (pct === 0) return "0%";
-	if (pct < 1) return `${pct.toFixed(1)}%`;
-	return `${pct.toFixed(0)}%`;
-}
-
-function BehaviorModelsTable({
-	models,
-	behaviorSeries,
-}: {
-	models: BehaviorModelStats[];
-	behaviorSeries: BehaviorTimeSeriesPoint[];
-}) {
-	const [expandedKey, setExpandedKey] = useState<string | null>(null);
-	const theme = useSystemTheme();
-	const chartTheme = TABLE_CHART_THEMES[theme];
-
-	const trendByKey = useMemo(() => buildTrendLookup(behaviorSeries), [behaviorSeries]);
-
-	const sortedModels = useMemo(() => {
-		return [...models].sort((a, b) => {
-			if (b.totalMessages !== a.totalMessages) {
-				return b.totalMessages - a.totalMessages;
-			}
-			return totalHitRate(b) - totalHitRate(a);
-		});
-	}, [models]);
-
-	return (
-		<ModelTableShell title="Behavior Signals by Model" subtitle="Rates are per user message">
-			<ModelTableHeader
-				gridTemplate={TABLE_GRID_TEMPLATE}
-				columns={[
-					{ label: "Model" },
-					{ label: "Messages", align: "right" },
-					{ label: "CAPS %", align: "right" },
-					{ label: "Profanity %", align: "right" },
-					{ label: "Anguish %", align: "right" },
-					{ label: "Frustration %", align: "right" },
-					{ label: "Hits %", align: "right" },
-					{ label: "Trend", align: "center" },
-				]}
-			/>
-
-			<ModelTableBody>
-				{sortedModels.map((model, index) => {
-					const key = `${model.model}::${model.provider}`;
-					const trend = trendByKey.get(key)?.data ?? [];
-					const trendColor = MODEL_COLORS[index % MODEL_COLORS.length];
-					const isExpanded = expandedKey === key;
-					const totalFrustration = model.totalNegation + model.totalRepetition + model.totalBlame;
-					const totalHits = model.totalYelling + model.totalProfanity + model.totalAnguish + totalFrustration;
-
-					return (
-						<ExpandableModelRow
-							key={key}
-							gridTemplate={TABLE_GRID_TEMPLATE}
-							isExpanded={isExpanded}
-							onToggle={() => setExpandedKey(isExpanded ? null : key)}
-							cells={[
-								<ModelNameCell key="name" model={model.model} provider={model.provider} />,
-								<div key="messages" className="text-right text-[var(--text-secondary)] font-mono text-sm">
-									{formatInteger(model.totalMessages)}
-								</div>,
-								<div key="caps" className="text-right text-[var(--text-secondary)] font-mono text-sm">
-									{formatRate(model.totalYelling, model.totalMessages)}
-								</div>,
-								<div key="profanity" className="text-right text-[var(--text-secondary)] font-mono text-sm">
-									{formatRate(model.totalProfanity, model.totalMessages)}
-								</div>,
-								<div key="anguish" className="text-right text-[var(--text-secondary)] font-mono text-sm">
-									{formatRate(model.totalAnguish, model.totalMessages)}
-								</div>,
-								<div key="frustration" className="text-right text-[var(--text-secondary)] font-mono text-sm">
-									{formatRate(totalFrustration, model.totalMessages)}
-								</div>,
-								<div key="hits" className="text-right text-[var(--text-secondary)] font-mono text-sm">
-									{formatRate(totalHits, model.totalMessages)}
-								</div>,
-							]}
-							trendCell={
-								trend.length === 0 ? (
-									<TrendEmpty />
-								) : (
-									<MiniSparkline
-										timestamps={trend.map(d => d.timestamp)}
-										values={trend.map(d => d.total)}
-										color={trendColor}
-									/>
-								)
-							}
-							expandedContent={
-								<div className="grid gap-4" style={{ gridTemplateColumns: "220px 1fr" }}>
-									<div className="space-y-4 text-sm">
-										<DetailRow
-											label="Yelling (CAPS)"
-											total={model.totalYelling}
-											messages={model.totalMessages}
-											valueClass="text-[#ed4abf]"
-										/>
-										<DetailRow
-											label="Profanity"
-											total={model.totalProfanity}
-											messages={model.totalMessages}
-											valueClass="text-[#ff6b7d]"
-										/>
-										<DetailRow
-											label="Anguish (!!!, nooo, dude, ..)"
-											total={model.totalAnguish}
-											messages={model.totalMessages}
-											valueClass="text-[#9b4dff]"
-										/>
-										<DetailRow
-											label="Negation (no/nope/wrong)"
-											total={model.totalNegation}
-											messages={model.totalMessages}
-											valueClass="text-[#5ad8e6]"
-										/>
-										<DetailRow
-											label="Repetition (i meant, still doesnt)"
-											total={model.totalRepetition}
-											messages={model.totalMessages}
-											valueClass="text-[#5ad8e6]"
-										/>
-										<DetailRow
-											label="Blame (you didnt, stop X-ing)"
-											total={model.totalBlame}
-											messages={model.totalMessages}
-											valueClass="text-[#5ad8e6]"
-										/>
-										<DetailRow
-											label="Avg chars / msg"
-											total={model.totalChars}
-											messages={model.totalMessages}
-											valueClass="stats-text-secondary"
-											mode="average"
-										/>
-									</div>
-									<div className="h-[200px]">
-										{trend.length === 0 ? (
-											<DetailChartEmpty />
-										) : (
-											<BreakdownChart data={trend} chartTheme={chartTheme} />
-										)}
-									</div>
-								</div>
-							}
-						/>
-					);
-				})}
-				{sortedModels.length === 0 ? (
-					<div className="border-t border-[var(--border-subtle)] px-5 py-8 text-center text-[var(--text-muted)] text-sm">
-						No user behavior recorded for this range yet.
-					</div>
-				) : null}
-			</ModelTableBody>
-		</ModelTableShell>
-	);
-}
-
-function DetailRow({
-	label,
-	total,
-	messages,
-	valueClass,
-	mode = "rate",
-}: {
-	label: string;
-	total: number;
-	messages: number;
-	valueClass: string;
-	mode?: "rate" | "average";
-}) {
-	const perMsgLabel = mode === "rate" ? "% of msgs" : "Per msg";
-	const perMsgValue = useMemo(() => {
-		if (messages === 0) return "-";
-		return mode === "rate" ? formatRate(total, messages) : (total / messages).toFixed(0);
-	}, [total, messages, mode]);
-
-	return (
-		<div>
-			<div className="text-[var(--text-primary)] font-medium mb-1">{label}</div>
-			<div className="space-y-0.5 text-[var(--text-secondary)]">
-				<div className="flex items-center justify-between">
-					<span className="stats-text-muted text-xs">Total</span>
-					<span className={`font-mono text-xs ${valueClass}`}>{formatInteger(total)}</span>
-				</div>
-				<div className="flex items-center justify-between">
-					<span className="stats-text-muted text-xs">{perMsgLabel}</span>
-					<span className="font-mono text-xs stats-text-primary">{perMsgValue}</span>
+			<div className="omp-section-rule" />
+			<div className="omp-section-body">
+				<div style={{ height: 220 }}>
+					{bucketed.length === 0 ? (
+						<div className="stats-table-empty">No behavior data in range.</div>
+					) : (
+						<Line data={data as never} options={options as never} />
+					)}
 				</div>
 			</div>
 		</div>
 	);
 }
 
-const SERIES_COLORS = {
-	yelling: "#ed4abf", // brand pink
-	profanity: "#ff6b7d", // rose
-	anguish: "#9b4dff", // brand violet
-	frustration: "#5ad8e6", // brand cyan
-} as const;
-
-function BreakdownChart({ data, chartTheme }: { data: DailyPoint[]; chartTheme: TableChartTheme }) {
-	const chartData = useMemo(() => {
-		return {
-			labels: data.map(d => format(new Date(d.timestamp), "MMM d")),
-			datasets: [
-				{
-					label: "CAPS",
-					data: data.map(d => d.yelling),
-					...lineSeriesStyle(SERIES_COLORS.yelling),
-				},
-				{
-					label: "Profanity",
-					data: data.map(d => d.profanity),
-					...lineSeriesStyle(SERIES_COLORS.profanity),
-				},
-				{
-					label: "Anguish",
-					data: data.map(d => d.anguish),
-					...lineSeriesStyle(SERIES_COLORS.anguish),
-				},
-				{
-					label: "Frustration",
-					data: data.map(d => d.frustration),
-					...lineSeriesStyle(SERIES_COLORS.frustration),
-				},
-			],
-		};
-	}, [data]);
-
-	const options = useMemo(() => {
-		return {
-			responsive: true,
-			maintainAspectRatio: false,
-			plugins: detailChartPlugins(chartTheme),
-			scales: detailChartScalesSingleAxis(chartTheme),
-		};
-	}, [chartTheme]);
-
-	return <Line data={chartData} options={options} />;
-}
-
-interface DailyPoint {
-	timestamp: number;
-	yelling: number;
-	profanity: number;
-	anguish: number;
-	frustration: number;
-	total: number;
-}
-
-interface ModelTrendSeries {
-	data: DailyPoint[];
-}
-
-function buildTrendLookup(points: BehaviorTimeSeriesPoint[]): Map<string, ModelTrendSeries> {
-	if (points.length === 0) return new Map();
-
-	const allDays = [...new Set(points.map(p => p.timestamp))].sort((a, b) => a - b);
-	const byKey = new Map<string, Map<number, DailyPoint>>();
-
-	for (const point of points) {
-		const key = `${point.model}::${point.provider}`;
-		let dayMap = byKey.get(key);
-		if (!dayMap) {
-			dayMap = new Map();
-			byKey.set(key, dayMap);
-		}
-		const existing = dayMap.get(point.timestamp) ?? {
-			timestamp: point.timestamp,
-			yelling: 0,
-			profanity: 0,
-			anguish: 0,
-			frustration: 0,
-			total: 0,
-		};
-		existing.yelling += point.yelling;
-		existing.profanity += point.profanity;
-		existing.anguish += point.anguish;
-		existing.frustration += point.negation + point.repetition + point.blame;
-		existing.total = existing.yelling + existing.profanity + existing.anguish + existing.frustration;
-		dayMap.set(point.timestamp, existing);
-	}
-
-	const out = new Map<string, ModelTrendSeries>();
-	for (const [key, dayMap] of byKey) {
-		const data = allDays.map(
-			ts =>
-				dayMap.get(ts) ?? {
-					timestamp: ts,
-					yelling: 0,
-					profanity: 0,
-					anguish: 0,
-					frustration: 0,
-					total: 0,
-				},
-		);
-		out.set(key, { data });
-	}
-	return out;
+function BehaviorModels({ models }: { models: BehaviorModelStats[] }) {
+	const rows = useMemo(() => [...models].sort((a, b) => b.totalMessages - a.totalMessages), [models]);
+	return (
+		<div className="omp-section">
+			<div className="omp-section-head">
+				<div>
+					<div className="omp-section-title">Per-model friction</div>
+					<p className="omp-section-desc">
+						Hits per responding model — helps isolate which model contexts attract user frustration.
+					</p>
+				</div>
+			</div>
+			<div className="omp-section-rule" />
+			<div className="omp-section-body">
+				<div className="omp-ranked-list">
+					<div
+						className="omp-ranked-head"
+						style={{ display: "grid", gridTemplateColumns: "22px minmax(0, 1.6fr) repeat(6, 64px) 70px", gap: 8 }}
+					>
+						<span>#</span>
+						<span>Model</span>
+						<span style={{ textAlign: "right" }}>Msgs</span>
+						<span style={{ textAlign: "right" }}>Yell</span>
+						<span style={{ textAlign: "right" }}>Prof</span>
+						<span style={{ textAlign: "right" }}>Angu</span>
+						<span style={{ textAlign: "right" }}>Neg</span>
+						<span style={{ textAlign: "right" }}>Rep</span>
+						<span style={{ textAlign: "right" }}>Blame</span>
+					</div>
+					{rows.map((m, i) => (
+						<div
+							key={`${m.model}::${m.provider}`}
+							className="omp-ranked-row"
+							style={{ gridTemplateColumns: "22px minmax(0, 1.6fr) repeat(6, 64px) 70px", padding: "8px 0" }}
+						>
+							<span className="omp-ranked-row-rank">{i + 1}</span>
+							<span className="omp-ranked-row-main">
+								<span className="omp-ranked-row-title" style={{ fontSize: 12 }}>
+									{m.model}
+								</span>
+								<span className="omp-ranked-row-sub">{m.provider}</span>
+							</span>
+							<span className="omp-ranked-metric">
+								<strong>{formatInteger(m.totalMessages)}</strong>
+							</span>
+							<span className="omp-ranked-metric">{formatInteger(m.totalYelling)}</span>
+							<span className="omp-ranked-metric">{formatInteger(m.totalProfanity)}</span>
+							<span className="omp-ranked-metric">{formatInteger(m.totalAnguish)}</span>
+							<span className="omp-ranked-metric">{formatInteger(m.totalNegation)}</span>
+							<span className="omp-ranked-metric">{formatInteger(m.totalRepetition)}</span>
+							<span className="omp-ranked-metric">{formatInteger(m.totalBlame)}</span>
+						</div>
+					))}
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/packages/stats/src/client/routes/CostsRoute.tsx
+++ b/packages/stats/src/client/routes/CostsRoute.tsx
@@ -1,4 +1,3 @@
-import type { Plugin } from "chart.js";
 import { useMemo, useState } from "react";
 import { Bar, Line } from "react-chartjs-2";
 import { getCostDashboardStats } from "../api";
@@ -17,7 +16,7 @@ import { formatCost, formatEstimatedCost } from "../data/formatters";
 import { useResource } from "../data/useResource";
 import { buildCostSummary } from "../data/view-models";
 import type { CostTimeSeriesPoint, TimeRange } from "../types";
-import { AsyncBoundary, Panel, SegmentedControl } from "../ui";
+import { AsyncBoundary } from "../ui";
 import { useSystemTheme } from "../useSystemTheme";
 
 export interface CostsRouteProps {
@@ -37,11 +36,35 @@ export function CostsRoute({ active, range, refreshTrigger }: CostsRouteProps) {
 	});
 
 	return (
-		<div className="stats-route-container space-y-6">
+		<div className="stats-route-container">
+			<div className="omp-hero">
+				<div className="omp-hero-head">
+					<h2 className="omp-hero-title">
+						Costs <span>{range} · api-equivalent</span>
+					</h2>
+					<span className="omp-hero-range">
+						{costStats ? `${costStats.costSeries.length} days · rate-card value` : "loading"}
+					</span>
+				</div>
+				<p
+					style={{
+						fontFamily: "var(--font-sans)",
+						fontSize: 12,
+						color: "var(--muted)",
+						margin: 0,
+						maxWidth: 760,
+						lineHeight: 1.5,
+					}}
+				>
+					Public API rate-card estimate — not billed cost. Unpriced subscription requests (e.g. xai-oauth) are
+					excluded and disclosed, not silently zeroed.
+				</p>
+			</div>
+
 			<AsyncBoundary loading={loading} error={error} data={costStats}>
 				{costStats && (
 					<>
-						<CostOverviewPanel costSeries={costStats.costSeries} />
+						<CostSummaryPanel costSeries={costStats.costSeries} />
 						<CostTrendPanel costSeries={costStats.costSeries} />
 					</>
 				)}
@@ -50,93 +73,69 @@ export function CostsRoute({ active, range, refreshTrigger }: CostsRouteProps) {
 	);
 }
 
-function CostOverviewPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
+function CostSummaryPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
 	const summary = useMemo(() => buildCostSummary(costSeries), [costSeries]);
-
-	const cards = [
-		{
-			label: "API-equivalent estimate",
-			value: formatEstimatedCost(summary.totalCost, summary.unpricedRequests),
-			sub:
-				summary.unpricedRequests > 0
-					? `Excludes ${summary.unpricedRequests.toLocaleString()} unpriced subscription request${summary.unpricedRequests === 1 ? "" : "s"}`
-					: undefined,
-		},
-		{
-			label: "Average estimate / Day",
-			value: formatEstimatedCost(summary.avgDailyCost, summary.unpricedRequests),
-		},
-		{
-			label: "Top Model",
-			value: summary.topModelName || "—",
-			sub: summary.topModelName ? `API-equivalent estimate: ${formatCost(summary.topModelCost)}` : undefined,
-		},
-	];
-
 	return (
-		<div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-			{cards.map(card => (
-				<Panel key={card.label} className="stats-cost-overview-card py-4 px-5">
-					<p className="text-xs stats-text-muted mb-1 font-medium uppercase tracking-wider">{card.label}</p>
-					<p className="text-2xl font-bold stats-text-primary truncate" title={card.value}>
-						{card.value}
-					</p>
-					{card.sub && <p className="text-xs stats-text-muted mt-1 font-medium">{card.sub}</p>}
-				</Panel>
-			))}
+		<div className="omp-section">
+			<div className="omp-section-head">
+				<div>
+					<div className="omp-section-title">Totals</div>
+					<p className="omp-section-desc">Aggregated across daily buckets. Average is total / days with data.</p>
+				</div>
+			</div>
+			<div className="omp-section-rule" />
+			<div className="omp-section-body">
+				<div className="omp-token-grid">
+					<div className="omp-token-item">
+						<div className="omp-token-label">API-equivalent estimate</div>
+						<div className="omp-token-value">
+							{formatEstimatedCost(summary.totalCost, summary.unpricedRequests)}
+						</div>
+						<div style={{ fontFamily: "var(--font-sans)", fontSize: 11, color: "var(--muted)" }}>
+							{summary.unpricedRequests > 0
+								? `Excludes ${summary.unpricedRequests.toLocaleString()} unpriced`
+								: "all priced"}
+						</div>
+					</div>
+					<div className="omp-token-item">
+						<div className="omp-token-label">Avg / day</div>
+						<div className="omp-token-value">
+							{formatEstimatedCost(summary.avgDailyCost, summary.unpricedRequests)}
+						</div>
+						<div style={{ fontFamily: "var(--font-sans)", fontSize: 11, color: "var(--muted)" }}>
+							{costSeries.length} buckets
+						</div>
+					</div>
+					<div className="omp-token-item">
+						<div className="omp-token-label">Top model</div>
+						<div className="omp-token-value" style={{ fontSize: 14 }}>
+							{summary.topModelName || "—"}
+						</div>
+						<div style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--muted)" }}>
+							{summary.topModelName ? formatCost(summary.topModelCost) : ""}
+						</div>
+					</div>
+					<div className="omp-token-item">
+						<div className="omp-token-label">Days</div>
+						<div className="omp-token-value">{costSeries.length}</div>
+						<div style={{ fontFamily: "var(--font-sans)", fontSize: 11, color: "var(--muted)" }}>in window</div>
+					</div>
+				</div>
+			</div>
 		</div>
 	);
-}
-
-const BAR_LABEL_COLORS = {
-	dark: "rgba(248, 250, 252, 0.7)",
-	light: "rgba(15, 23, 42, 0.6)",
-} as const;
-
-// Inline Chart.js plugin to draw cost value above bars
-function makeBarLabelPlugin(color: string): Plugin<"bar"> {
-	return {
-		id: "costBarLabels",
-		afterDatasetsDraw(chart) {
-			const { ctx } = chart;
-			const dataset = chart.data.datasets[0];
-			if (!dataset) return;
-			const meta = chart.getDatasetMeta(0);
-			ctx.save();
-			ctx.font = "11px system-ui, sans-serif";
-			ctx.fillStyle = color;
-			ctx.textAlign = "center";
-			ctx.textBaseline = "bottom";
-			for (const bar of meta.data) {
-				// Accessing Chart.js internal parsed coordinates via unknown cast
-				const value = (bar as unknown as { $context: { parsed: { y: number } } }).$context.parsed.y;
-				if (!value) continue;
-				const label = `$${Math.round(value)}`;
-				// Accessing internal getProps for positioning via unknown cast
-				const { x, y } = bar.getProps(["x", "y"], true) as {
-					x: number;
-					y: number;
-				};
-				ctx.fillText(label, x, y - 3);
-			}
-			ctx.restore();
-		},
-	};
 }
 
 function CostTrendPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
 	const [byModel, setByModel] = useState(false);
 	const theme = useSystemTheme();
 	const chartTheme = CHART_THEMES[theme];
-	const unpricedRequests = useMemo(
-		() => costSeries.reduce((sum, point) => sum + point.unpricedRequests, 0),
-		[costSeries],
-	);
+	const unpricedRequests = useMemo(() => costSeries.reduce((sum, p) => sum + p.unpricedRequests, 0), [costSeries]);
 
 	const chartData = useMemo(() => {
 		if (byModel) {
 			return buildTopNByModelSeries<CostTimeSeriesPoint, { total: number }>(costSeries, {
-				rankWeight: point => point.cost,
+				rankWeight: p => p.cost,
 				initBucket: () => ({ total: 0 }),
 				accumulate: (bucket, point) => {
 					bucket.total += point.cost;
@@ -153,30 +152,26 @@ function CostTrendPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
 		});
 	}, [costSeries, byModel]);
 
-	const sharedPlugins = useMemo(() => {
-		return buildSharedPlugins({
-			chartTheme,
-			showLegend: byModel,
-			defaultLabel: "API-equivalent estimate",
-			formatValue: v => `$${v.toFixed(2)}`,
-			footer: items => {
-				if (!byModel || items.length < 2) return undefined;
-				const total = items.reduce((sum, item) => sum + (item.parsed.y ?? 0), 0);
-				return `Total: $${total.toFixed(2)}`;
-			},
-		});
-	}, [chartTheme, byModel]);
+	const sharedPlugins = useMemo(
+		() =>
+			buildSharedPlugins({
+				chartTheme,
+				showLegend: byModel,
+				defaultLabel: "API-equivalent estimate",
+				formatValue: v => `$${v.toFixed(2)}`,
+				footer: items => {
+					if (!byModel || items.length < 2) return undefined;
+					const total = items.reduce((s, item) => s + (item.parsed.y ?? 0), 0);
+					return `Total: $${total.toFixed(2)}`;
+				},
+			}),
+		[chartTheme, byModel],
+	);
 
-	const { sharedScaleBase, yScale } = useMemo(() => {
-		return buildSharedScales({
-			chartTheme,
-			formatY: v => `$${Math.round(v)}`,
-		});
-	}, [chartTheme]);
-
-	const barLabelPlugin = useMemo(() => {
-		return makeBarLabelPlugin(BAR_LABEL_COLORS[theme]);
-	}, [theme]);
+	const { sharedScaleBase, yScale } = useMemo(
+		() => buildSharedScales({ chartTheme, formatY: v => `$${Math.round(v)}` }),
+		[chartTheme],
+	);
 
 	const lineData = useMemo(() => {
 		if (!byModel) return null;
@@ -185,17 +180,6 @@ function CostTrendPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
 			datasets: styleDatasets(chartData, i => lineDatasetStyle(MODEL_COLORS[i % MODEL_COLORS.length])),
 		};
 	}, [chartData, byModel]);
-
-	const lineOptions = useMemo(() => {
-		return {
-			responsive: true,
-			maintainAspectRatio: false,
-			interaction: { mode: "index" as const, intersect: false },
-			plugins: sharedPlugins,
-			scales: { x: sharedScaleBase, y: yScale },
-		};
-	}, [sharedPlugins, sharedScaleBase, yScale]);
-
 	const barData = useMemo(() => {
 		if (byModel) return null;
 		return {
@@ -204,49 +188,69 @@ function CostTrendPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
 		};
 	}, [chartData, byModel]);
 
-	const barOptions = useMemo(() => {
-		return {
+	const lineOptions = useMemo(
+		() => ({
 			responsive: true,
 			maintainAspectRatio: false,
 			interaction: { mode: "index" as const, intersect: false },
-			plugins: {
-				...sharedPlugins,
-				costBarLabels: {},
-			},
-			scales: {
-				x: { ...sharedScaleBase, stacked: true },
-				y: { ...yScale, stacked: true },
-			},
-			layout: { padding: { top: 24 } },
-		};
-	}, [sharedPlugins, sharedScaleBase, yScale]);
-
-	const toggleOptions = [
-		{ value: false, label: "All Models" },
-		{ value: true, label: "By Model" },
-	];
+			plugins: sharedPlugins,
+			scales: { x: sharedScaleBase, y: yScale },
+		}),
+		[sharedPlugins, sharedScaleBase, yScale],
+	);
+	const barOptions = useMemo(
+		() => ({
+			responsive: true,
+			maintainAspectRatio: false,
+			interaction: { mode: "index" as const, intersect: false },
+			plugins: { ...sharedPlugins },
+			scales: { x: { ...sharedScaleBase, stacked: true }, y: { ...yScale, stacked: true } },
+		}),
+		[sharedPlugins, sharedScaleBase, yScale],
+	);
 
 	return (
-		<Panel
-			title="Daily API-equivalent estimate"
-			subtitle={
-				unpricedRequests > 0
-					? `Public API rate-card value over time; excludes ${unpricedRequests.toLocaleString()} unpriced subscription request${unpricedRequests === 1 ? "" : "s"}`
-					: "Public API rate-card value over time"
-			}
-			actions={<SegmentedControl options={toggleOptions} value={byModel} onChange={setByModel} />}
-		>
-			<div className="h-[300px]">
-				{chartData.labels.length === 0 ? (
-					<div className="h-full flex items-center justify-center text-stats-muted text-sm">
-						No API-equivalent estimate data available
-					</div>
-				) : byModel && lineData ? (
-					<Line data={lineData} options={lineOptions} />
-				) : barData ? (
-					<Bar data={barData} options={barOptions} plugins={[barLabelPlugin]} />
-				) : null}
+		<div className="omp-section">
+			<div className="omp-section-head">
+				<div>
+					<div className="omp-section-title">Daily cost</div>
+					<p className="omp-section-desc">
+						{unpricedRequests > 0
+							? `Excludes ${unpricedRequests.toLocaleString()} unpriced subscription requests`
+							: "Rate-card value over time"}
+					</p>
+				</div>
+				<div className="stats-segmented-control">
+					<button
+						type="button"
+						className="stats-segmented-control-btn"
+						data-active={!byModel ? "true" : "false"}
+						onClick={() => setByModel(false)}
+					>
+						All
+					</button>
+					<button
+						type="button"
+						className="stats-segmented-control-btn"
+						data-active={byModel ? "true" : "false"}
+						onClick={() => setByModel(true)}
+					>
+						By model
+					</button>
+				</div>
 			</div>
-		</Panel>
+			<div className="omp-section-rule" />
+			<div className="omp-section-body">
+				<div style={{ height: 280 }}>
+					{chartData.labels.length === 0 ? (
+						<div className="stats-table-empty">No cost data in range</div>
+					) : byModel && lineData ? (
+						<Line data={lineData as never} options={lineOptions as never} />
+					) : barData ? (
+						<Bar data={barData as never} options={barOptions as never} />
+					) : null}
+				</div>
+			</div>
+		</div>
 	);
 }

--- a/packages/stats/src/client/routes/CostsRoute.tsx
+++ b/packages/stats/src/client/routes/CostsRoute.tsx
@@ -43,7 +43,9 @@ export function CostsRoute({ active, range, refreshTrigger }: CostsRouteProps) {
 						Costs <span>{range} · api-equivalent</span>
 					</h2>
 					<span className="omp-hero-range">
-						{costStats ? `${costStats.costSeries.length} days · rate-card value` : "loading"}
+						{costStats
+							? `${new Set(costStats.costSeries.map(pt => pt.timestamp)).size} days · rate-card value`
+							: "loading"}
 					</span>
 				</div>
 				<p
@@ -103,7 +105,7 @@ function CostSummaryPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] })
 							{formatEstimatedCost(summary.avgDailyCost, summary.unpricedRequests)}
 						</div>
 						<div style={{ fontFamily: "var(--font-sans)", fontSize: 11, color: "var(--muted)" }}>
-							{costSeries.length} buckets
+							{new Set(costSeries.map(p => p.timestamp)).size} days
 						</div>
 					</div>
 					<div className="omp-token-item">
@@ -117,7 +119,7 @@ function CostSummaryPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] })
 					</div>
 					<div className="omp-token-item">
 						<div className="omp-token-label">Days</div>
-						<div className="omp-token-value">{costSeries.length}</div>
+						<div className="omp-token-value">{new Set(costSeries.map(p => p.timestamp)).size}</div>
 						<div style={{ fontFamily: "var(--font-sans)", fontSize: 11, color: "var(--muted)" }}>in window</div>
 					</div>
 				</div>

--- a/packages/stats/src/client/routes/CostsRoute.tsx
+++ b/packages/stats/src/client/routes/CostsRoute.tsx
@@ -44,7 +44,7 @@ export function CostsRoute({ active, range, refreshTrigger }: CostsRouteProps) {
 					</h2>
 					<span className="omp-hero-range">
 						{costStats
-							? `${new Set(costStats.costSeries.map(pt => pt.timestamp)).size} days · rate-card value`
+							? `${new Set(costStats.costSeries.map(pt => new Date(pt.timestamp).toDateString())).size} days · rate-card value`
 							: "loading"}
 					</span>
 				</div>
@@ -105,7 +105,7 @@ function CostSummaryPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] })
 							{formatEstimatedCost(summary.avgDailyCost, summary.unpricedRequests)}
 						</div>
 						<div style={{ fontFamily: "var(--font-sans)", fontSize: 11, color: "var(--muted)" }}>
-							{new Set(costSeries.map(p => p.timestamp)).size} days
+							{new Set(costSeries.map(p => new Date(p.timestamp).toDateString())).size} days
 						</div>
 					</div>
 					<div className="omp-token-item">
@@ -119,7 +119,9 @@ function CostSummaryPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] })
 					</div>
 					<div className="omp-token-item">
 						<div className="omp-token-label">Days</div>
-						<div className="omp-token-value">{new Set(costSeries.map(p => p.timestamp)).size}</div>
+						<div className="omp-token-value">
+							{new Set(costSeries.map(p => new Date(p.timestamp).toDateString())).size}
+						</div>
 						<div style={{ fontFamily: "var(--font-sans)", fontSize: 11, color: "var(--muted)" }}>in window</div>
 					</div>
 				</div>

--- a/packages/stats/src/client/routes/ErrorsRoute.tsx
+++ b/packages/stats/src/client/routes/ErrorsRoute.tsx
@@ -1,9 +1,10 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { getRecentErrors } from "../api";
-import { formatInteger, formatMessageCost, formatRelativeTime } from "../data/formatters";
+import { formatDurationMs, formatInteger } from "../data/formatters";
 import { useResource } from "../data/useResource";
+import { type ErrorGroupBy, groupErrors, normalizeErrorMessage } from "../data/view-models";
 import type { MessageStats, TimeRange } from "../types";
-import { AsyncBoundary, DataTable, Panel, StatusPill } from "../ui";
+import { AsyncBoundary } from "../ui";
 
 export interface ErrorsRouteProps {
 	active: boolean;
@@ -21,98 +22,292 @@ export function ErrorsRoute({ active, range, refreshTrigger, onRequestClick }: E
 		pollMs: 30000,
 		enabled: active,
 	});
-
-	const columns = useMemo(
-		() => [
-			{
-				key: "model",
-				header: "Model",
-				render: (item: MessageStats) => (
-					<div>
-						<div className="stats-font-medium stats-text-primary">{item.model}</div>
-						<div className="stats-text-xs stats-text-muted">{item.provider}</div>
-					</div>
-				),
-			},
-			{
-				key: "timestamp",
-				header: "Time",
-				render: (item: MessageStats) => formatRelativeTime(item.timestamp),
-			},
-			{
-				key: "errorMessage",
-				header: "Error Message",
-				render: (item: MessageStats) => (
-					<div
-						className="stats-text-xs stats-text-danger stats-truncate stats-max-w-md stats-font-mono"
-						title={item.errorMessage || ""}
-					>
-						{item.errorMessage || "Unknown error"}
-					</div>
-				),
-			},
-			{
-				key: "tokens",
-				header: "Tokens",
-				numeric: true,
-				render: (item: MessageStats) => formatInteger(item.usage.totalTokens),
-			},
-			{
-				key: "cost",
-				header: "API-equivalent estimate",
-				numeric: true,
-				render: (item: MessageStats) => formatMessageCost(item, 4),
-			},
-		],
-		[],
-	);
-
-	const renderMobileCard = (item: MessageStats, onClick?: () => void) => (
-		<div className="stats-mobile-card stats-border-danger" onClick={onClick}>
-			<div className="stats-mobile-card-header">
-				<div>
-					<div className="stats-font-semibold stats-text-primary">{item.model}</div>
-					<div className="stats-text-xs stats-text-muted">{item.provider}</div>
-				</div>
-				<StatusPill variant="danger">Failed</StatusPill>
-			</div>
-			<div className="stats-mobile-card-grid">
-				<div>
-					<div className="stats-mobile-card-label">Time</div>
-					<div className="stats-mobile-card-value">{formatRelativeTime(item.timestamp)}</div>
-				</div>
-				<div>
-					<div className="stats-mobile-card-label">API-equivalent estimate</div>
-					<div className="stats-mobile-card-value">{formatMessageCost(item, 4)}</div>
-				</div>
-				<div>
-					<div className="stats-mobile-card-label">Tokens</div>
-					<div className="stats-mobile-card-value">{formatInteger(item.usage.totalTokens)}</div>
-				</div>
-			</div>
-			{item.errorMessage && <div className="stats-mobile-card-error mt-2 stats-font-mono">{item.errorMessage}</div>}
-		</div>
-	);
-
 	return (
 		<div className="stats-route-container">
-			<Panel title="Recent Errors" subtitle="Up to 50 most recent failed requests in the stats database">
-				<AsyncBoundary
-					loading={loading}
-					error={error}
-					data={recentErrors}
-					emptyText="No recent failures in the local stats database"
+			<div className="omp-hero">
+				<div className="omp-hero-head">
+					<h2 className="omp-hero-title">
+						Errors <span>{range} · grouped explorer</span>
+					</h2>
+					<span className="omp-hero-range">
+						{recentErrors ? `${recentErrors.length} failures · grouped by signature` : "loading"}
+					</span>
+				</div>
+				<p
+					style={{
+						fontFamily: "var(--font-sans)",
+						fontSize: 12,
+						color: "var(--muted)",
+						margin: 0,
+						maxWidth: 720,
+						lineHeight: 1.5,
+					}}
 				>
-					<DataTable
-						columns={columns}
-						data={recentErrors || []}
-						keyExtractor={item => item.id || `${item.sessionFile}-${item.entryId}`}
-						onRowClick={item => item.id && onRequestClick(item.id)}
-						renderMobileCard={renderMobileCard}
-						emptyText="No recent failures in the local stats database"
-					/>
-				</AsyncBoundary>
-			</Panel>
+					Repeated failures collapse into one row per provider + signature — e.g. “Key limit exceeded · OpenRouter
+					· 31 occurrences” — with expandable occurrences. Filters refine without losing context.
+				</p>
+			</div>
+
+			<AsyncBoundary loading={loading} error={error} data={recentErrors}>
+				{recentErrors && <ErrorsExplorer errors={recentErrors} onRequestClick={onRequestClick} />}
+			</AsyncBoundary>
+		</div>
+	);
+}
+
+function ErrorsExplorer({ errors, onRequestClick }: { errors: MessageStats[]; onRequestClick: (id: number) => void }) {
+	const [groupBy, setGroupBy] = useState<ErrorGroupBy>("error");
+	const [providerFilter, setProviderFilter] = useState<string>("all");
+	const [modelFilter, setModelFilter] = useState<string>("all");
+	const [expanded, setExpanded] = useState<string | null>(null);
+
+	const providers = useMemo(
+		() => [...new Set(errors.filter(e => e.errorMessage).map(e => e.provider))].sort(),
+		[errors],
+	);
+	const models = useMemo(() => [...new Set(errors.filter(e => e.errorMessage).map(e => e.model))].sort(), [errors]);
+
+	const filtered = useMemo(() => {
+		return errors.filter(e => {
+			if (!e.errorMessage) return false;
+			if (providerFilter !== "all" && e.provider !== providerFilter) return false;
+			if (modelFilter !== "all" && e.model !== modelFilter) return false;
+			return true;
+		});
+	}, [errors, providerFilter, modelFilter]);
+
+	const groups = useMemo(() => groupErrors(filtered, groupBy), [filtered, groupBy]);
+
+	return (
+		<div className="omp-section">
+			<div className="omp-section-head">
+				<div>
+					<div className="omp-section-title">Error groups</div>
+					<p className="omp-section-desc">
+						{groups.length} groups · {filtered.length} occurrences · group-by controls signature. Occurrence list
+						shows timestamp, model and latency per event.
+					</p>
+				</div>
+				<div className="omp-error-controls">
+					<div className="stats-segmented-control" role="group" aria-label="Group by">
+						{(["error", "provider", "model"] as const).map(v => (
+							<button
+								key={v}
+								type="button"
+								className="stats-segmented-control-btn"
+								data-active={groupBy === v ? "true" : "false"}
+								onClick={() => {
+									setGroupBy(v);
+									setExpanded(null);
+								}}
+							>
+								{v}
+							</button>
+						))}
+					</div>
+				</div>
+			</div>
+			<div className="omp-section-rule" />
+			<div className="omp-section-body" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+				<div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
+					<div style={{ display: "flex", gap: 4, alignItems: "center", flexWrap: "wrap" }}>
+						<span
+							style={{
+								fontFamily: "var(--font-sans)",
+								fontSize: 11,
+								fontWeight: 600,
+								color: "var(--dim)",
+								textTransform: "uppercase",
+								letterSpacing: "0.04em",
+							}}
+						>
+							Provider
+						</span>
+						<div className="stats-segmented-control" style={{ display: "inline-flex", flexWrap: "wrap" }}>
+							<button
+								type="button"
+								className="stats-segmented-control-btn"
+								data-active={providerFilter === "all" ? "true" : "false"}
+								onClick={() => setProviderFilter("all")}
+							>
+								All
+							</button>
+							{providers.slice(0, 8).map(p => (
+								<button
+									key={p}
+									type="button"
+									className="stats-segmented-control-btn"
+									data-active={providerFilter === p ? "true" : "false"}
+									onClick={() => setProviderFilter(p)}
+									title={p}
+								>
+									{p}
+								</button>
+							))}
+						</div>
+					</div>
+					<div style={{ display: "flex", gap: 4, alignItems: "center", flexWrap: "wrap" }}>
+						<span
+							style={{
+								fontFamily: "var(--font-sans)",
+								fontSize: 11,
+								fontWeight: 600,
+								color: "var(--dim)",
+								textTransform: "uppercase",
+								letterSpacing: "0.04em",
+							}}
+						>
+							Model
+						</span>
+						<div className="stats-segmented-control" style={{ display: "inline-flex", flexWrap: "wrap" }}>
+							<button
+								type="button"
+								className="stats-segmented-control-btn"
+								data-active={modelFilter === "all" ? "true" : "false"}
+								onClick={() => setModelFilter("all")}
+							>
+								All
+							</button>
+							{models.slice(0, 6).map(m => (
+								<button
+									key={m}
+									type="button"
+									className="stats-segmented-control-btn"
+									data-active={modelFilter === m ? "true" : "false"}
+									onClick={() => setModelFilter(m)}
+									title={m}
+									style={{ maxWidth: 140, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+								>
+									{m}
+								</button>
+							))}
+						</div>
+					</div>
+					<span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--dim)", marginLeft: "auto" }}>
+						{filtered.length} / {errors.filter(e => e.errorMessage).length} shown
+					</span>
+				</div>
+				{groups.length === 0 ? (
+					<div className="stats-table-empty">No failures matching filters in this window.</div>
+				) : (
+					<div>
+						{groups.map(g => {
+							const isExpanded = expanded === g.key;
+							return (
+								<div key={g.key} className="omp-error-group" data-expanded={isExpanded ? "true" : "false"}>
+									<div style={{ minWidth: 0, flex: 1, display: "flex", flexDirection: "column", gap: 4 }}>
+										<div className="omp-error-sig" title={g.representativeMessage}>
+											{g.signature}
+											{groupBy === "error" && (
+												<span
+													style={{
+														fontWeight: 400,
+														color: "var(--dim)",
+														fontFamily: "var(--font-mono)",
+														fontSize: 11,
+														marginLeft: 6,
+													}}
+												>
+													· {g.provider}
+												</span>
+											)}
+										</div>
+										<div className="omp-error-meta">
+											<span>
+												<strong>{g.count}</strong> occurrence{g.count === 1 ? "" : "s"}
+											</span>
+											<span>· {g.provider}</span>
+											<span>· {g.model}</span>
+											<span>· last {new Date(g.latestTimestamp).toLocaleString()}</span>
+										</div>
+										{isExpanded && (
+											<div className="omp-error-occ">
+												{g.items.map(item => (
+													<div
+														key={item.id ?? `${item.entryId}-${item.timestamp}`}
+														className="omp-error-occ-row"
+														role="button"
+														tabIndex={0}
+														onClick={() => item.id && onRequestClick(item.id)}
+														onKeyDown={e => {
+															if ((e.key === "Enter" || e.key === " ") && item.id) {
+																e.preventDefault();
+																onRequestClick(item.id);
+															}
+														}}
+														style={{ cursor: item.id ? "pointer" : undefined }}
+													>
+														<span>{new Date(item.timestamp).toLocaleString()}</span>
+														<span
+															className="hide-sm"
+															style={{
+																fontFamily: "var(--font-mono)",
+																color: "var(--text)",
+																overflow: "hidden",
+																textOverflow: "ellipsis",
+																whiteSpace: "nowrap",
+															}}
+															title={item.model}
+														>
+															{item.model}
+														</span>
+														<span>{formatDurationMs(item.duration)}</span>
+														<span
+															className="hide-sm"
+															style={{
+																color: "var(--dim)",
+																overflow: "hidden",
+																textOverflow: "ellipsis",
+																whiteSpace: "nowrap",
+															}}
+															title={normalizeErrorMessage(item.errorMessage)}
+														>
+															{normalizeErrorMessage(item.errorMessage).slice(0, 80)}
+														</span>
+													</div>
+												))}
+											</div>
+										)}
+									</div>
+									<div
+										style={{
+											display: "flex",
+											flexDirection: "column",
+											gap: 6,
+											alignItems: "flex-end",
+											justifyContent: "flex-start",
+										}}
+									>
+										<span
+											style={{
+												fontFamily: "var(--font-mono)",
+												fontSize: 11,
+												color: "var(--text)",
+												background: "var(--surface-2)",
+												border: "1px solid var(--border)",
+												borderRadius: "var(--radius-sm)",
+												padding: "3px 7px",
+												fontVariantNumeric: "tabular-nums",
+											}}
+										>
+											{formatInteger(g.count)}×
+										</span>
+										<button
+											type="button"
+											className="omp-ranked-expand"
+											aria-label={isExpanded ? "Collapse" : "Expand"}
+											onClick={() => setExpanded(isExpanded ? null : g.key)}
+											style={{ width: 28, height: 28 }}
+										>
+											{isExpanded ? "−" : "+"}
+										</button>
+									</div>
+								</div>
+							);
+						})}
+					</div>
+				)}
+			</div>
 		</div>
 	);
 }

--- a/packages/stats/src/client/routes/GainRoute.tsx
+++ b/packages/stats/src/client/routes/GainRoute.tsx
@@ -1,11 +1,11 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { Line } from "react-chartjs-2";
 import { getGainDashboardStats } from "../api";
-import { buildSharedPlugins, buildSharedScales, CHART_THEMES, lineDatasetStyle } from "../components/chart-shared";
+import { CHART_THEMES } from "../components/chart-shared";
 import { formatBytes, formatCompact, formatInteger, formatPercent } from "../data/formatters";
 import { useResource } from "../data/useResource";
-import type { GainDashboardStats, GainSourceTotals, GainTimeSeriesPoint, TimeRange } from "../types";
-import { AsyncBoundary, Panel } from "../ui";
+import type { GainDashboardStats, TimeRange } from "../types";
+import { AsyncBoundary } from "../ui";
 import { useSystemTheme } from "../useSystemTheme";
 
 export interface GainRouteProps {
@@ -15,212 +15,244 @@ export interface GainRouteProps {
 }
 
 export function GainRoute({ active, range, refreshTrigger }: GainRouteProps) {
-	const [project, setProject] = useState<string | null>(null);
-
 	const {
 		data: stats,
 		error,
 		loading,
-	} = useResource(["gain", range, refreshTrigger, project], signal => getGainDashboardStats(range, project, signal), {
-		pollMs: 30_000,
+	} = useResource(["gain", range, refreshTrigger], signal => getGainDashboardStats(range, null, signal), {
+		pollMs: 30000,
 		enabled: active,
 	});
 
 	return (
-		<div className="stats-route-container space-y-6">
+		<div className="stats-route-container">
+			<div className="omp-hero">
+				<div className="omp-hero-head">
+					<h2 className="omp-hero-title">
+						Gain <span>{range} · efficiency</span>
+					</h2>
+					<span className="omp-hero-range">
+						{stats
+							? `${formatInteger(stats.overall.hits)} hits · ${formatCompact(stats.overall.savedTokens)} tokens saved`
+							: "loading"}
+					</span>
+				</div>
+				<p
+					style={{
+						fontFamily: "var(--font-sans)",
+						fontSize: 12,
+						color: "var(--muted)",
+						margin: 0,
+						maxWidth: 760,
+						lineHeight: 1.5,
+					}}
+				>
+					First-class efficiency — only defensible “saved” numbers. Snapcompact savings are measured bytes not
+					re-sent. Methodology below; no hand-wavy “estimated savings” without basis.
+				</p>
+			</div>
+
 			<AsyncBoundary loading={loading} error={error} data={stats}>
-				{stats && (
-					<>
-						<GainProjectSelector projects={stats.projects} selected={project} onChange={setProject} />
-						<GainOverallPanel overall={stats.overall} />
-						<GainBySourcePanel bySource={stats.bySource} />
-						<GainTimeSeriesPanel timeSeries={stats.timeSeries} />
-					</>
-				)}
+				{stats && <GainBody stats={stats} />}
 			</AsyncBoundary>
 		</div>
 	);
 }
 
-// ---------------------------------------------------------------------------
-// Project selector
-// ---------------------------------------------------------------------------
-
-function GainProjectSelector({
-	projects,
-	selected,
-	onChange,
-}: {
-	projects: string[];
-	selected: string | null;
-	onChange: (p: string | null) => void;
-}) {
-	if (projects.length === 0) return null;
+function GainBody({ stats }: { stats: GainDashboardStats }) {
 	return (
-		<div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
-			<span className="stats-text-secondary" style={{ fontSize: "0.875rem", whiteSpace: "nowrap" }}>
-				Project
-			</span>
-			<select
-				className="stats-select"
-				value={selected ?? ""}
-				onChange={e => onChange(e.target.value || null)}
-				style={{ maxWidth: "480px", flex: 1 }}
-			>
-				<option value="">All projects</option>
-				{projects.map(p => (
-					<option key={p} value={p}>
-						{p}
-					</option>
-				))}
-			</select>
-		</div>
-	);
-}
-
-// ---------------------------------------------------------------------------
-// Overall metrics panel
-// ---------------------------------------------------------------------------
-
-function GainOverallPanel({ overall }: { overall: GainSourceTotals }) {
-	return (
-		<Panel title="Overall Gain" subtitle="Aggregate snapcompact savings">
-			<div className="stats-metric-primary-grid">
-				<div className="stats-metric-card primary">
-					<div className="stats-metric-label">Saved Tokens</div>
-					<div className="stats-metric-value">{formatCompact(overall.savedTokens)}</div>
-				</div>
-				<div className="stats-metric-card primary">
-					<div className="stats-metric-label">Saved Bytes</div>
-					<div className="stats-metric-value">{formatBytes(overall.savedBytes)}</div>
-				</div>
-				<div className="stats-metric-card primary">
-					<div className="stats-metric-label">Reduction</div>
-					<div className="stats-metric-value">
-						{overall.reductionPercent !== null ? formatPercent(overall.reductionPercent) : "—"}
+		<>
+			<div className="omp-section">
+				<div className="omp-section-head">
+					<div>
+						<div className="omp-section-title">Overall savings</div>
+						<p className="omp-section-desc">
+							Snapcompact — context compression that avoids re-sending unchanged prefix.
+						</p>
 					</div>
 				</div>
-				<div className="stats-metric-card primary">
-					<div className="stats-metric-label">Total Hits</div>
-					<div className="stats-metric-value">{formatInteger(overall.hits)}</div>
-				</div>
-			</div>
-		</Panel>
-	);
-}
+				<div className="omp-section-rule" />
+				<div className="omp-section-body">
+					<div className="omp-token-grid">
+						<div className="omp-token-item">
+							<div className="omp-token-label">Saved tokens</div>
+							<div className="omp-token-value">{formatCompact(stats.overall.savedTokens)}</div>
+							<div style={{ fontFamily: "var(--font-sans)", fontSize: 11, color: "var(--muted)" }}>
+								≈ {formatBytes(stats.overall.savedBytes)} not re-sent
+							</div>
+						</div>
+						<div className="omp-token-item">
+							<div className="omp-token-label">Hits</div>
+							<div className="omp-token-value">{formatInteger(stats.overall.hits)}</div>
+							<div style={{ fontFamily: "var(--font-sans)", fontSize: 11, color: "var(--muted)" }}>
+								compactions that saved
+							</div>
+						</div>
+						<div className="omp-token-item">
+							<div className="omp-token-label">Reduction</div>
+							<div className="omp-token-value">
+								{stats.overall.reductionPercent !== null ? formatPercent(stats.overall.reductionPercent) : "—"}
+							</div>
+							<div style={{ fontFamily: "var(--font-sans)", fontSize: 11, color: "var(--muted)" }}>
+								saved vs original
+							</div>
+						</div>
+						<div className="omp-token-item">
+							<div className="omp-token-label">Avg saved / hit</div>
+							<div className="omp-token-value">
+								{stats.overall.hits
+									? formatCompact(Math.round(stats.overall.savedTokens / stats.overall.hits))
+									: "—"}
+							</div>
+							<div style={{ fontFamily: "var(--font-sans)", fontSize: 11, color: "var(--muted)" }}>tokens</div>
+						</div>
+					</div>
 
-// ---------------------------------------------------------------------------
-// By-source breakdown panel
-// ---------------------------------------------------------------------------
-
-function SourceCard({ title, totals }: { title: string; totals: GainSourceTotals }) {
-	return (
-		<div className="stats-metric-card secondary" style={{ flex: 1 }}>
-			<div className="stats-metric-label" style={{ fontWeight: 600, marginBottom: 8 }}>
-				{title}
-			</div>
-			<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
-				<div>
-					<div className="stats-metric-label">Saved Tokens</div>
-					<div className="stats-metric-value" style={{ fontSize: "1rem" }}>
-						{formatCompact(totals.savedTokens)}
-					</div>
-				</div>
-				<div>
-					<div className="stats-metric-label">Saved Bytes</div>
-					<div className="stats-metric-value" style={{ fontSize: "1rem" }}>
-						{formatBytes(totals.savedBytes)}
-					</div>
-				</div>
-				<div>
-					<div className="stats-metric-label">Hits</div>
-					<div className="stats-metric-value" style={{ fontSize: "1rem" }}>
-						{formatInteger(totals.hits)}
-					</div>
-				</div>
-				<div>
-					<div className="stats-metric-label">Reduction</div>
-					<div className="stats-metric-value" style={{ fontSize: "1rem" }}>
-						{totals.reductionPercent !== null ? formatPercent(totals.reductionPercent) : "—"}
+					<div className="omp-method" style={{ marginTop: 12 }}>
+						<strong>Methodology:</strong> Snapcompact records are read from the session store; each record’s{" "}
+						<span style={{ fontFamily: "var(--font-mono)" }}>savedTokens = originalTokens − compactedTokens</span>{" "}
+						and <span style={{ fontFamily: "var(--font-mono)" }}>savedBytes = originalBytes − outputBytes</span>.
+						“Reduction %” is <span style={{ fontFamily: "var(--font-mono)" }}>saved / original</span>. No
+						model-pricing extrapolation; tokens are real tokenizer deltas.
 					</div>
 				</div>
 			</div>
-		</div>
+
+			<GainChart timeSeries={stats.timeSeries} />
+
+			<GainProjects stats={stats} />
+		</>
 	);
 }
 
-function GainBySourcePanel({ bySource }: { bySource: GainDashboardStats["bySource"] }) {
-	return (
-		<Panel title="By Source" subtitle="Savings breakdown per subsystem">
-			<div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
-				<SourceCard title="Snapcompact" totals={bySource.snapcompact} />
-			</div>
-		</Panel>
-	);
-}
-
-// ---------------------------------------------------------------------------
-// Time series chart (stacked area, daily)
-// ---------------------------------------------------------------------------
-
-const GAIN_COLORS = {
-	snapcompact: "rgb(34, 197, 94)",
-} as const;
-
-function GainTimeSeriesPanel({ timeSeries }: { timeSeries: GainTimeSeriesPoint[] }) {
+function GainChart({ timeSeries }: { timeSeries: GainDashboardStats["timeSeries"] }) {
 	const theme = useSystemTheme();
 	const chartTheme = CHART_THEMES[theme];
 
-	const { data, options } = useMemo(() => {
-		const labelFormatter = new Intl.DateTimeFormat(undefined, {
-			month: "short",
-			day: "numeric",
-			timeZone: "UTC",
-		});
-		const labels = timeSeries.map(p => labelFormatter.format(new Date(`${p.date}T00:00:00.000Z`)));
-		const chartData = {
+	const data = useMemo(() => {
+		const labels = timeSeries.map(p => p.date);
+		return {
 			labels,
 			datasets: [
 				{
-					label: "Snapcompact",
+					label: "Saved tokens",
 					data: timeSeries.map(p => p.snapcompact),
-					...lineDatasetStyle(GAIN_COLORS.snapcompact),
+					borderColor: theme === "dark" ? "oklch(0.74 0.13 150)" : "oklch(0.55 0.13 150)",
+					backgroundColor: theme === "dark" ? "oklch(0.74 0.13 150 / 0.08)" : "oklch(0.55 0.13 150 / 0.06)",
+					tension: 0.32,
+					borderWidth: 1.6,
+					pointRadius: timeSeries.length <= 12 ? 3 : 0,
+					fill: true,
 				},
 			],
 		};
+	}, [timeSeries, theme]);
 
-		const { sharedScaleBase, yScale } = buildSharedScales({
-			chartTheme,
-			formatY: n => formatCompact(n),
-		});
-
-		const chartOptions = {
+	const options = useMemo(
+		() => ({
 			responsive: true,
 			maintainAspectRatio: false,
-			plugins: buildSharedPlugins({
-				chartTheme,
-				showLegend: true,
-				defaultLabel: "Tokens Saved",
-				formatValue: formatCompact,
-			}),
-			scales: {
-				x: { ...sharedScaleBase, stacked: true },
-				y: { ...yScale, stacked: true },
+			interaction: { mode: "index" as const, intersect: false },
+			plugins: {
+				legend: { display: false },
+				tooltip: {
+					backgroundColor: chartTheme.tooltipBackground,
+					titleColor: chartTheme.tooltipTitle,
+					bodyColor: chartTheme.tooltipBody,
+					borderColor: chartTheme.tooltipBorder,
+					borderWidth: 1,
+					cornerRadius: 8,
+					padding: 8,
+				},
 			},
-		};
-
-		return { data: chartData, options: chartOptions };
-	}, [timeSeries, chartTheme]);
+			scales: {
+				x: {
+					grid: { color: chartTheme.grid, drawBorder: false },
+					ticks: {
+						color: chartTheme.tick,
+						font: { size: 10, family: "var(--font-mono)" },
+						maxTicksLimit: 8,
+						maxRotation: 0,
+					},
+					border: { display: false },
+				},
+				y: {
+					grid: { color: chartTheme.grid, drawBorder: false },
+					ticks: {
+						color: chartTheme.tick,
+						font: { size: 10, family: "var(--font-mono)" },
+						callback: (v: number | string) => formatCompact(Number(v)),
+					},
+					min: 0,
+					border: { display: false },
+				},
+			},
+		}),
+		[chartTheme],
+	);
 
 	return (
-		<Panel title="Savings Over Time" subtitle="Daily token savings">
-			<div style={{ height: 240 }}>
-				{timeSeries.length === 0 ? (
-					<div className="stats-table-empty">No time series data yet</div>
-				) : (
-					<Line data={data} options={options as Parameters<typeof Line>[0]["options"]} />
-				)}
+		<div className="omp-section">
+			<div className="omp-section-head">
+				<div>
+					<div className="omp-section-title">Savings over time</div>
+					<p className="omp-section-desc">
+						Daily buckets — snapcompact tokens saved per day. One source is enough to be honest.
+					</p>
+				</div>
 			</div>
-		</Panel>
+			<div className="omp-section-rule" />
+			<div className="omp-section-body">
+				<div style={{ height: 220 }}>
+					{timeSeries.length === 0 ? (
+						<div className="stats-table-empty">No savings yet</div>
+					) : (
+						<Line data={data as never} options={options as never} />
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function GainProjects({ stats }: { stats: GainDashboardStats }) {
+	if (!stats.projects || stats.projects.length === 0) return null;
+	return (
+		<div className="omp-section">
+			<div className="omp-section-head">
+				<div>
+					<div className="omp-section-title">Projects observed</div>
+					<p className="omp-section-desc">
+						Distinct project roots with snapcompact activity — filter via Gain API project param.
+					</p>
+				</div>
+			</div>
+			<div className="omp-section-rule" />
+			<div className="omp-section-body">
+				<div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+					{stats.projects.slice(0, 12).map(p => (
+						<div
+							key={p}
+							style={{
+								fontFamily: "var(--font-mono)",
+								fontSize: 11,
+								color: "var(--muted)",
+								overflow: "hidden",
+								textOverflow: "ellipsis",
+								whiteSpace: "nowrap",
+								borderBottom: "1px solid var(--border)",
+								padding: "6px 0",
+							}}
+						>
+							{p}
+						</div>
+					))}
+				</div>
+				<div className="omp-method" style={{ marginTop: 10 }}>
+					<strong>Scope:</strong> Counts and savings respect the active time range and optional project filter. No
+					cross-project double-counting — each compact record is attributed to the project that emitted it.
+				</div>
+			</div>
+		</div>
 	);
 }

--- a/packages/stats/src/client/routes/ModelsRoute.tsx
+++ b/packages/stats/src/client/routes/ModelsRoute.tsx
@@ -1,34 +1,36 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Line } from "react-chartjs-2";
 import { getModelDashboardStats } from "../api";
-import { buildModelColorLookup, CHART_THEMES, MODEL_COLORS } from "../components/chart-shared";
-import {
-	DetailChartEmpty,
-	detailChartPlugins,
-	detailChartScalesDualAxis,
-	ExpandableModelRow,
-	lineSeriesStyle,
-	MiniSparkline,
-	ModelNameCell,
-	ModelTableBody,
-	ModelTableHeader,
-	ModelTableShell,
-	TABLE_CHART_THEMES,
-	type TableChartTheme,
-	TrendEmpty,
-} from "../components/models-table-shared";
-import { formatRangeTick, rangeMeta } from "../components/range-meta";
-import { formatEstimatedCost } from "../data/formatters";
+import { CHART_THEMES } from "../components/chart-shared";
+import { formatRangeTick } from "../components/range-meta";
+import { formatCompact, formatEstimatedCost, formatInteger, formatPercent } from "../data/formatters";
 import { useResource } from "../data/useResource";
-import { buildModelPerformanceLookup } from "../data/view-models";
-import type { ModelPerformancePoint, ModelStats, ModelTimeSeriesPoint, TimeRange } from "../types";
-import { AsyncBoundary, Panel } from "../ui";
+import { buildModelRows, type ModelSortKey, type SortDir, sortModelRows } from "../data/view-models";
+import type { ModelStats, ModelTimeSeriesPoint, TimeRange } from "../types";
+import { AsyncBoundary } from "../ui";
 import { useSystemTheme } from "../useSystemTheme";
 
 export interface ModelsRouteProps {
 	active: boolean;
 	range: TimeRange;
 	refreshTrigger: number;
+}
+
+const SORT_STORAGE_KEY = "omp-stats:models-sort";
+type StoredSort = { key: ModelSortKey; dir: SortDir };
+
+function loadSort(): StoredSort {
+	try {
+		const raw = sessionStorage.getItem(SORT_STORAGE_KEY);
+		if (raw) return JSON.parse(raw) as StoredSort;
+	} catch {}
+	return { key: "requests", dir: "desc" };
+}
+
+function saveSort(v: StoredSort) {
+	try {
+		sessionStorage.setItem(SORT_STORAGE_KEY, JSON.stringify(v));
+	} catch {}
 }
 
 export function ModelsRoute({ active, range, refreshTrigger }: ModelsRouteProps) {
@@ -40,428 +42,406 @@ export function ModelsRoute({ active, range, refreshTrigger }: ModelsRouteProps)
 		pollMs: 30000,
 		enabled: active,
 	});
-	const modelColorLookup = useMemo(() => buildModelColorLookup(modelStats?.byModel ?? []), [modelStats?.byModel]);
 
 	return (
-		<div className="stats-route-container space-y-6">
+		<div className="stats-route-container">
+			<div className="omp-hero">
+				<div className="omp-hero-head">
+					<h2 className="omp-hero-title">
+						Models <span>{range} · ranked by share</span>
+					</h2>
+					<span className="omp-hero-range">
+						{modelStats
+							? `${modelStats.byModel.length} models · ${formatInteger(modelStats.byModel.reduce((s, m) => s + m.totalRequests, 0))} requests`
+							: "loading"}
+					</span>
+				</div>
+				{modelStats && modelStats.byModel.length > 0 && (
+					<div className="omp-token-grid" style={{ marginTop: 4 }}>
+						<div className="omp-token-item">
+							<div className="omp-token-label">Top model share</div>
+							<div className="omp-token-value">
+								{formatPercent(
+									modelStats.byModel[0].totalRequests /
+										modelStats.byModel.reduce((s, m) => s + m.totalRequests, 0),
+								)}
+							</div>
+							<div className="omp-token-bar">
+								<div
+									className="omp-token-bar-fill"
+									style={{
+										width: `${(modelStats.byModel[0].totalRequests / modelStats.byModel.reduce((s, m) => s + m.totalRequests, 0)) * 100}%`,
+										background: "var(--text)",
+									}}
+								/>
+							</div>
+						</div>
+						<div className="omp-token-item">
+							<div className="omp-token-label">Total tokens</div>
+							<div className="omp-token-value">
+								{formatCompact(
+									modelStats.byModel.reduce(
+										(s, m) =>
+											s +
+											m.totalInputTokens +
+											m.totalOutputTokens +
+											m.totalCacheReadTokens +
+											m.totalCacheWriteTokens,
+										0,
+									),
+								)}
+							</div>
+							<div className="omp-token-label" style={{ textTransform: "none", letterSpacing: "0" }}>
+								in {formatCompact(modelStats.byModel.reduce((s, m) => s + m.totalInputTokens, 0))} · out{" "}
+								{formatCompact(modelStats.byModel.reduce((s, m) => s + m.totalOutputTokens, 0))}
+							</div>
+						</div>
+						<div className="omp-token-item">
+							<div className="omp-token-label">Est. cost</div>
+							<div className="omp-token-value">
+								{formatEstimatedCost(
+									modelStats.byModel.reduce((s, m) => s + m.totalCost, 0),
+									modelStats.byModel.reduce((s, m) => s + m.unpricedRequests, 0),
+								)}
+							</div>
+							<div className="omp-token-label" style={{ textTransform: "none", letterSpacing: "0" }}>
+								api-equivalent · excludes unpriced
+							</div>
+						</div>
+						<div className="omp-token-item">
+							<div className="omp-token-label">Avg cache hit</div>
+							<div className="omp-token-value">
+								{formatPercent(
+									modelStats.byModel.reduce((s, m) => s + m.cacheRate * m.totalRequests, 0) /
+										Math.max(
+											1,
+											modelStats.byModel.reduce((s, m) => s + m.totalRequests, 0),
+										),
+								)}
+							</div>
+							<div className="omp-token-label" style={{ textTransform: "none", letterSpacing: "0" }}>
+								prompt cache · weighted
+							</div>
+						</div>
+					</div>
+				)}
+			</div>
+
 			<AsyncBoundary loading={loading} error={error} data={modelStats}>
 				{modelStats && (
-					<>
-						<ModelShareChart
-							modelSeries={modelStats.modelSeries}
-							timeRange={range}
-							colorLookup={modelColorLookup}
-						/>
-						<ModelsTable
-							models={modelStats.byModel}
-							performanceSeries={modelStats.modelPerformanceSeries}
-							timeRange={range}
-							colorLookup={modelColorLookup}
-						/>
-					</>
+					<ModelsRanked byModel={modelStats.byModel} modelSeries={modelStats.modelSeries} timeRange={range} />
 				)}
 			</AsyncBoundary>
 		</div>
 	);
 }
 
-function ModelShareChart({
+function ModelsRanked({
+	byModel,
 	modelSeries,
 	timeRange,
-	colorLookup,
 }: {
+	byModel: ModelStats[];
 	modelSeries: ModelTimeSeriesPoint[];
 	timeRange: TimeRange;
-	colorLookup: ReadonlyMap<string, string>;
+}) {
+	const [sort, setSort] = useState<StoredSort>(() => loadSort());
+	const [expanded, setExpanded] = useState<string | null>(null);
+	useEffect(() => saveSort(sort), [sort]);
+
+	const rows = useMemo(() => {
+		const base = buildModelRows(byModel);
+		return sortModelRows(base, sort.key, sort.dir);
+	}, [byModel, sort]);
+
+	const toggle = (key: ModelSortKey) => {
+		setSort(prev => {
+			if (prev.key === key) return { key, dir: prev.dir === "asc" ? "desc" : "asc" };
+			return { key, dir: "desc" };
+		});
+	};
+
+	const headerBtn = (label: string, key: ModelSortKey, alignRight = true) => {
+		const active = sort.key === key;
+		return (
+			<button
+				type="button"
+				data-active={active ? "true" : "false"}
+				onClick={() => toggle(key)}
+				style={{ justifyContent: alignRight ? "flex-end" : "flex-start" }}
+			>
+				{label}
+				<span aria-hidden style={{ fontSize: 10, opacity: active ? 1 : 0.35 }}>
+					{active ? (sort.dir === "asc" ? "↑" : "↓") : "↕"}
+				</span>
+			</button>
+		);
+	};
+
+	return (
+		<div className="omp-section">
+			<div className="omp-section-head">
+				<div>
+					<div className="omp-section-title">Ranked models</div>
+					<p className="omp-section-desc">
+						Click a row for usage-over-time, cost and error detail — mono values, share bars encode dominance
+						without extra cards.
+					</p>
+				</div>
+				<div className="omp-error-controls" style={{ fontSize: 11 }}>
+					<span style={{ fontFamily: "var(--font-mono)", color: "var(--dim)" }}>{rows.length} models</span>
+				</div>
+			</div>
+			<div className="omp-section-rule" />
+			<div className="omp-section-body">
+				<div
+					className="omp-ranked-head"
+					style={{
+						display: "grid",
+						gridTemplateColumns: "22px minmax(0, 1.6fr) 84px repeat(4, 82px) minmax(0, 0.8fr) 28px",
+						gap: 10,
+					}}
+					role="row"
+				>
+					<span style={{ textAlign: "right" }}>#</span>
+					<span>{headerBtn("Model", "model", false)}</span>
+					<span style={{ textAlign: "center" }}>Share</span>
+					<span style={{ textAlign: "right" }}>{headerBtn("Requests", "requests")}</span>
+					<span style={{ textAlign: "right" }}>{headerBtn("Tokens", "tokens")}</span>
+					<span style={{ textAlign: "right" }}>{headerBtn("Est. cost", "cost")}</span>
+					<span style={{ textAlign: "right" }}>{headerBtn("Cache", "cache")}</span>
+					<span className="omp-ranked-hide-sm" style={{ textAlign: "right" }}>
+						{headerBtn("Errors", "errorRate")}
+					</span>
+					<span />
+				</div>
+
+				<div className="omp-ranked-list">
+					{rows.map((m, idx) => {
+						const key = `${m.model}::${m.provider}`;
+						const isExpanded = expanded === key;
+						const totalTokens = m.totalTokens;
+						return (
+							<div
+								key={key}
+								className="omp-ranked-row"
+								data-expanded={isExpanded ? "true" : "false"}
+								role="button"
+								tabIndex={0}
+								onClick={() => setExpanded(isExpanded ? null : key)}
+								onKeyDown={e => {
+									if (e.key === "Enter" || e.key === " ") {
+										e.preventDefault();
+										setExpanded(isExpanded ? null : key);
+									}
+								}}
+							>
+								<span className="omp-ranked-row-rank">{idx + 1}</span>
+								<span className="omp-ranked-row-main">
+									<span className="omp-ranked-row-title" title={m.model}>
+										{m.model}
+									</span>
+									<span className="omp-ranked-row-sub">{m.provider}</span>
+								</span>
+								<span className="omp-ranked-bar" aria-hidden>
+									<span className="omp-ranked-bar-fill" style={{ width: `${m.share * 100}%` }} />
+								</span>
+								<span className="omp-ranked-metric">
+									<strong>{formatInteger(m.totalRequests)}</strong>
+									<small>{formatPercent(m.share, 1)} share</small>
+								</span>
+								<span className="omp-ranked-metric">
+									<strong>{formatCompact(totalTokens)}</strong>
+									<small>
+										{formatCompact(m.totalInputTokens)}/{formatCompact(m.totalOutputTokens)}
+									</small>
+								</span>
+								<span className="omp-ranked-metric">
+									{formatEstimatedCost(m.totalCost, m.unpricedRequests, 2)}
+								</span>
+								<span className="omp-ranked-metric">{formatPercent(m.cacheRate)}</span>
+								<span
+									className="omp-ranked-metric omp-ranked-hide-sm"
+									style={{
+										color:
+											m.errorRate > 0.05
+												? "var(--danger)"
+												: m.errorRate > 0
+													? "var(--amber)"
+													: "var(--muted)",
+									}}
+								>
+									{formatPercent(m.errorRate, 1)}
+								</span>
+								<button
+									type="button"
+									className="omp-ranked-expand"
+									aria-label={isExpanded ? "Collapse" : "Expand"}
+									onClick={e => {
+										e.stopPropagation();
+										setExpanded(isExpanded ? null : key);
+									}}
+								>
+									{isExpanded ? "−" : "+"}
+								</button>
+
+								{isExpanded && (
+									<div className="omp-ranked-detail" onClick={e => e.stopPropagation()}>
+										<div className="omp-ranked-detail-grid">
+											<div>
+												<div className="omp-ranked-detail-label">Requests</div>
+												<div className="omp-ranked-detail-value">{formatInteger(m.totalRequests)}</div>
+												<div style={{ fontSize: 11, color: "var(--muted)" }}>
+													{formatInteger(m.successfulRequests)} ok · {formatInteger(m.failedRequests)} fail
+													· {formatPercent(m.errorRate)} error
+												</div>
+											</div>
+											<div>
+												<div className="omp-ranked-detail-label">Tokens · in / out</div>
+												<div className="omp-ranked-detail-value">{formatCompact(totalTokens)}</div>
+												<div
+													style={{ fontSize: 11, color: "var(--muted)", fontFamily: "var(--font-mono)" }}
+												>
+													in {formatCompact(m.totalInputTokens)} · out {formatCompact(m.totalOutputTokens)}{" "}
+													· cache {formatCompact(m.totalCacheReadTokens)}
+												</div>
+											</div>
+											<div>
+												<div className="omp-ranked-detail-label">Est. cost</div>
+												<div className="omp-ranked-detail-value">
+													{formatEstimatedCost(m.totalCost, m.unpricedRequests, 4)}
+												</div>
+												<div style={{ fontSize: 11, color: "var(--muted)" }}>
+													{m.avgDuration ? `${(m.avgDuration / 1000).toFixed(2)}s avg` : "no latency"} ·{" "}
+													{m.avgTokensPerSecond ? `${m.avgTokensPerSecond.toFixed(1)} tok/s` : ""}
+												</div>
+											</div>
+											<div>
+												<div className="omp-ranked-detail-label">Provider</div>
+												<div className="omp-ranked-detail-value" style={{ fontSize: 12 }}>
+													{m.provider}
+												</div>
+												<div style={{ fontSize: 11, color: "var(--muted)" }}>
+													cache {formatPercent(m.cacheRate)} · savings {formatPercent(m.cacheSavings)}
+												</div>
+											</div>
+										</div>
+										<ModelSpark
+											model={m.model}
+											provider={m.provider}
+											series={modelSeries}
+											timeRange={timeRange}
+										/>
+									</div>
+								)}
+							</div>
+						);
+					})}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function ModelSpark({
+	model,
+	provider,
+	series,
+	timeRange,
+}: {
+	model: string;
+	provider: string;
+	series: ModelTimeSeriesPoint[];
+	timeRange: TimeRange;
 }) {
 	const theme = useSystemTheme();
 	const chartTheme = CHART_THEMES[theme];
-	const meta = rangeMeta(timeRange);
-
-	const chartData = useMemo(() => buildModelPreferenceSeries(modelSeries), [modelSeries]);
-
+	const filtered = useMemo(
+		() => series.filter(s => s.model === model && s.provider === provider).sort((a, b) => a.timestamp - b.timestamp),
+		[series, model, provider],
+	);
 	const data = useMemo(() => {
+		const labels = filtered.map(p => formatRangeTick(p.timestamp, timeRange));
 		return {
-			labels: chartData.data.map(d => formatRangeTick(d.timestamp, timeRange)),
-			datasets: chartData.series.map((series, index) => {
-				const fallbackColor = MODEL_COLORS[index % MODEL_COLORS.length];
-				const color = series.key ? (colorLookup.get(series.key) ?? fallbackColor) : fallbackColor;
-				const dataKey = series.key ?? series.label;
-
-				return {
-					label: series.label,
-					data: chartData.data.map(d => d[dataKey] ?? 0),
-					borderColor: color,
-					backgroundColor: `${color}20`,
-					fill: true,
-					tension: 0.4,
-					pointRadius: 0,
+			labels,
+			datasets: [
+				{
+					label: "Requests",
+					data: filtered.map(p => p.requests),
+					borderColor: theme === "dark" ? "oklch(0.85 0.02 307)" : "oklch(0.35 0.02 307)",
+					backgroundColor: theme === "dark" ? "oklch(0.85 0.02 307 / 0.08)" : "oklch(0.35 0.02 307 / 0.06)",
+					tension: 0.32,
+					borderWidth: 1.6,
+					pointRadius: filtered.length <= 8 ? 3 : 0,
 					pointHoverRadius: 4,
-					borderWidth: 2,
-				};
-			}),
+					fill: true,
+				},
+			],
 		};
-	}, [chartData, colorLookup, timeRange]);
+	}, [filtered, timeRange, theme]);
 
-	const options = useMemo(() => {
-		return {
+	const options = useMemo(
+		() => ({
 			responsive: true,
 			maintainAspectRatio: false,
-			interaction: {
-				mode: "index" as const,
-				intersect: false,
-			},
+			interaction: { mode: "index" as const, intersect: false },
 			plugins: {
-				legend: {
-					position: "top" as const,
-					align: "start" as const,
-					labels: {
-						color: chartTheme.legendLabel,
-						usePointStyle: true,
-						padding: 16,
-						font: { size: 12 },
-						boxWidth: 8,
-					},
-				},
+				legend: { display: false },
 				tooltip: {
 					backgroundColor: chartTheme.tooltipBackground,
 					titleColor: chartTheme.tooltipTitle,
 					bodyColor: chartTheme.tooltipBody,
 					borderColor: chartTheme.tooltipBorder,
 					borderWidth: 1,
-					padding: 12,
 					cornerRadius: 8,
-					callbacks: {
-						label: (context: { dataset: { label?: string }; parsed: { y: number | null } }) => {
-							const label = context.dataset.label ?? "";
-							const value = context.parsed.y;
-							return `${label}: ${(value ?? 0).toFixed(1)}%`;
-						},
-					},
+					padding: 8,
 				},
 			},
 			scales: {
 				x: {
-					grid: {
-						color: chartTheme.grid,
-						drawBorder: false,
-					},
+					grid: { color: chartTheme.grid, drawBorder: false },
 					ticks: {
 						color: chartTheme.tick,
-						font: { size: 11 },
+						font: { size: 10, family: "var(--font-mono)" },
+						maxTicksLimit: 6,
+						maxRotation: 0,
 					},
+					border: { display: false },
 				},
 				y: {
-					grid: {
-						color: chartTheme.grid,
-						drawBorder: false,
-					},
-					ticks: {
-						color: chartTheme.tick,
-						font: { size: 11 },
-						callback: (value: number | string) => `${value}%`,
-					},
+					grid: { color: chartTheme.grid, drawBorder: false },
+					ticks: { color: chartTheme.tick, font: { size: 10, family: "var(--font-mono)" } },
 					min: 0,
-					max: 100,
+					border: { display: false },
 				},
 			},
-		};
-	}, [chartTheme]);
+		}),
+		[chartTheme],
+	);
 
-	return (
-		<Panel title="Model Preference" subtitle={`Share of requests over ${meta.windowLabel}`}>
-			<div className="h-[280px]">
-				{chartData.data.length === 0 ? (
-					<div className="h-full flex items-center justify-center text-stats-muted text-sm">No data available</div>
-				) : (
-					<Line data={data} options={options} />
-				)}
+	if (filtered.length === 0) {
+		return (
+			<div style={{ fontSize: 11, color: "var(--muted)", fontFamily: "var(--font-mono)", padding: "8px 0" }}>
+				No time-series for this model in range.
 			</div>
-		</Panel>
-	);
-}
-
-function buildModelPreferenceSeries(
-	points: ModelTimeSeriesPoint[],
-	topN = 5,
-): {
-	data: Array<Record<string, number>>;
-	series: Array<{ key?: string; label: string }>;
-} {
-	if (points.length === 0) return { data: [], series: [] };
-
-	const totals = new Map<string, { model: string; provider: string; total: number }>();
-	for (const point of points) {
-		const key = `${point.model}::${point.provider}`;
-		const existing = totals.get(key);
-		if (existing) {
-			existing.total += point.requests;
-		} else {
-			totals.set(key, {
-				model: point.model,
-				provider: point.provider,
-				total: point.requests,
-			});
-		}
-	}
-
-	const sorted = [...totals.entries()].map(([key, value]) => ({ key, ...value })).sort((a, b) => b.total - a.total);
-	const topEntries = sorted.slice(0, topN);
-	const topKeys = new Set(topEntries.map(entry => entry.key));
-
-	const topModelCounts = new Map<string, number>();
-	for (const entry of topEntries) {
-		topModelCounts.set(entry.model, (topModelCounts.get(entry.model) ?? 0) + 1);
-	}
-
-	const labelByKey = new Map<string, string>();
-	for (const entry of topEntries) {
-		const showProvider = (topModelCounts.get(entry.model) ?? 0) > 1;
-		labelByKey.set(entry.key, showProvider ? `${entry.model} (${entry.provider})` : entry.model);
-	}
-
-	const dataMap = new Map<number, Record<string, number>>();
-
-	for (const point of points) {
-		const key = `${point.model}::${point.provider}`;
-		const bucket = dataMap.get(point.timestamp) ?? {
-			timestamp: point.timestamp,
-			total: 0,
-		};
-		bucket.total += point.requests;
-		const seriesKey = topKeys.has(key) ? key : "Other";
-		bucket[seriesKey] = (bucket[seriesKey] ?? 0) + point.requests;
-		dataMap.set(point.timestamp, bucket);
-	}
-
-	const series: Array<{ key?: string; label: string }> = topEntries.map(entry => ({
-		key: entry.key,
-		label: labelByKey.get(entry.key) ?? entry.model,
-	}));
-	if ([...dataMap.values()].some(row => (row.Other ?? 0) > 0)) {
-		series.push({ label: "Other" });
-	}
-
-	const data = [...dataMap.values()]
-		.sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0))
-		.map(row => {
-			const total = row.total ?? 0;
-			for (const seriesItem of series) {
-				const seriesKey = seriesItem.key ?? seriesItem.label;
-				row[seriesKey] = total > 0 ? ((row[seriesKey] ?? 0) / total) * 100 : 0;
-			}
-			return row;
-		});
-
-	return { data, series };
-}
-
-const GRID_TEMPLATE = "2fr 0.9fr 0.9fr 1fr 0.8fr 0.8fr 140px 40px";
-
-function ModelsTable({
-	models,
-	performanceSeries,
-	timeRange,
-	colorLookup,
-}: {
-	models: ModelStats[];
-	performanceSeries: ModelPerformancePoint[];
-	timeRange: TimeRange;
-	colorLookup: ReadonlyMap<string, string>;
-}) {
-	const [expandedKey, setExpandedKey] = useState<string | null>(null);
-	const meta = rangeMeta(timeRange);
-
-	const performanceSeriesByKey = useMemo(
-		() => buildModelPerformanceLookup(performanceSeries, timeRange),
-		[performanceSeries, timeRange],
-	);
-
-	const theme = useSystemTheme();
-	const chartTheme = TABLE_CHART_THEMES[theme];
-
-	const sortedModels = useMemo(() => {
-		return [...models].sort(
-			(a, b) => b.totalInputTokens + b.totalOutputTokens - (a.totalInputTokens + a.totalOutputTokens),
 		);
-	}, [models]);
-
+	}
 	return (
-		<ModelTableShell title="Model Statistics">
-			<ModelTableHeader
-				gridTemplate={GRID_TEMPLATE}
-				columns={[
-					{ label: "Model" },
-					{ label: "Requests", align: "right" },
-					{ label: "API-equivalent estimate", align: "right" },
-					{ label: "Tokens", align: "right" },
-					{ label: "Tokens/s", align: "right" },
-					{ label: "TTFT", align: "right" },
-					{ label: meta.trendLabel, align: "center" },
-				]}
-			/>
-
-			<ModelTableBody>
-				{sortedModels.map((model, index) => {
-					const key = `${model.model}::${model.provider}`;
-					const performance = performanceSeriesByKey.get(key);
-					const trendData = performance?.data ?? [];
-					const trendColor = colorLookup.get(key) ?? MODEL_COLORS[index % MODEL_COLORS.length];
-					const isExpanded = expandedKey === key;
-					const errorRate = model.errorRate * 100;
-
-					return (
-						<ExpandableModelRow
-							key={key}
-							gridTemplate={GRID_TEMPLATE}
-							isExpanded={isExpanded}
-							onToggle={() => setExpandedKey(isExpanded ? null : key)}
-							cells={[
-								<ModelNameCell key="name" model={model.model} provider={model.provider} />,
-								<div key="requests" className="text-right text-[var(--text-secondary)] font-mono text-sm">
-									{model.totalRequests.toLocaleString()}
-								</div>,
-								<div key="cost" className="text-right text-[var(--text-secondary)] font-mono text-sm">
-									{formatEstimatedCost(model.totalCost, model.unpricedRequests)}
-								</div>,
-								<div key="tokens" className="text-right text-[var(--text-secondary)] font-mono text-sm">
-									{(model.totalInputTokens + model.totalOutputTokens).toLocaleString()}
-								</div>,
-								<div key="tps" className="text-right text-[var(--text-secondary)] font-mono text-sm">
-									{model.avgTokensPerSecond?.toFixed(1) ?? "-"}
-								</div>,
-								<div key="ttft" className="text-right text-[var(--text-secondary)] font-mono text-sm">
-									{model.avgTtft ? `${(model.avgTtft / 1000).toFixed(2)}s` : "-"}
-								</div>,
-							]}
-							trendCell={
-								trendData.length === 0 ? (
-									<TrendEmpty />
-								) : (
-									<MiniSparkline
-										timestamps={trendData.map(d => d.timestamp)}
-										values={trendData.map(d => d.avgTokensPerSecond ?? 0)}
-										color={trendColor}
-									/>
-								)
-							}
-							expandedContent={
-								<div className="grid gap-4" style={{ gridTemplateColumns: "200px 1fr" }}>
-									<div className="space-y-4 text-sm">
-										<div>
-											<div className="text-[var(--text-primary)] font-medium mb-2">Efficiency</div>
-											<div className="space-y-1 text-[var(--text-secondary)]">
-												<div className="flex items-center justify-between">
-													<span>Error rate</span>
-													<span
-														className={
-															errorRate > 5 ? "text-[var(--accent-red)]" : "text-[var(--accent-green)]"
-														}
-													>
-														{errorRate.toFixed(1)}%
-													</span>
-												</div>
-												<div className="flex items-center justify-between">
-													<span>Cache rate</span>
-													<span className="font-mono">{(model.cacheRate * 100).toFixed(1)}%</span>
-												</div>
-												<div className="flex items-center justify-between">
-													<span>Cache savings</span>
-													<span
-														className={
-															model.cacheSavings < 0
-																? "text-[var(--accent-red)]"
-																: "text-[var(--accent-green)]"
-														}
-													>
-														{(model.cacheSavings * 100).toFixed(1)}%
-													</span>
-												</div>
-											</div>
-										</div>
-										<div>
-											<div className="text-[var(--text-primary)] font-medium mb-2">Latency</div>
-											<div className="space-y-1 text-[var(--text-secondary)]">
-												<div className="flex items-center justify-between">
-													<span>Avg duration</span>
-													<span className="font-mono">
-														{model.avgDuration ? `${(model.avgDuration / 1000).toFixed(2)}s` : "-"}
-													</span>
-												</div>
-												<div className="flex items-center justify-between">
-													<span>Avg TTFT</span>
-													<span className="font-mono">
-														{model.avgTtft ? `${(model.avgTtft / 1000).toFixed(2)}s` : "-"}
-													</span>
-												</div>
-											</div>
-										</div>
-									</div>
-									<div className="h-[200px]">
-										{trendData.length === 0 ? (
-											<DetailChartEmpty />
-										) : (
-											<PerformanceChart
-												data={trendData}
-												color={trendColor}
-												chartTheme={chartTheme}
-												timeRange={timeRange}
-											/>
-										)}
-									</div>
-								</div>
-							}
-						/>
-					);
-				})}
-			</ModelTableBody>
-		</ModelTableShell>
+		<div>
+			<div
+				style={{
+					fontFamily: "var(--font-sans)",
+					fontSize: 11,
+					fontWeight: 600,
+					color: "var(--text)",
+					marginBottom: 6,
+				}}
+			>
+				Usage over time · {filtered.length} buckets
+			</div>
+			<div style={{ height: 140 }}>
+				<Line data={data as never} options={options as never} />
+			</div>
+		</div>
 	);
-}
-
-function PerformanceChart({
-	data,
-	color,
-	chartTheme,
-	timeRange,
-}: {
-	data: Array<{
-		timestamp: number;
-		avgTtftSeconds: number | null;
-		avgTokensPerSecond: number | null;
-	}>;
-	color: string;
-	chartTheme: TableChartTheme;
-	timeRange: TimeRange;
-}) {
-	const chartData = useMemo(() => {
-		return {
-			labels: data.map(d => formatRangeTick(d.timestamp, timeRange)),
-			datasets: [
-				{
-					label: "TTFT",
-					data: data.map(d => d.avgTtftSeconds ?? null),
-					...lineSeriesStyle("#5ad8e6"),
-					yAxisID: "y" as const,
-				},
-				{
-					label: "Tokens/s",
-					data: data.map(d => d.avgTokensPerSecond ?? null),
-					...lineSeriesStyle(color),
-					yAxisID: "y1" as const,
-				},
-			],
-		};
-	}, [data, color, timeRange]);
-
-	const options = useMemo(() => {
-		return {
-			responsive: true,
-			maintainAspectRatio: false,
-			plugins: detailChartPlugins(chartTheme),
-			scales: detailChartScalesDualAxis(chartTheme),
-		};
-	}, [chartTheme]);
-
-	return <Line data={chartData} options={options} />;
 }

--- a/packages/stats/src/client/routes/OverviewRoute.tsx
+++ b/packages/stats/src/client/routes/OverviewRoute.tsx
@@ -114,7 +114,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 		enabled: active,
 		pollMs: 30000,
 	});
-	const recentRes = useResource(["recent-requests", refreshTrigger], s => getRecentRequests(12, s), {
+	const recentRes = useResource(["recent-requests", range, refreshTrigger], s => getRecentRequests(12, range, s), {
 		enabled: active,
 		pollMs: 30000,
 	});
@@ -438,7 +438,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 						/>
 						Elevated error rate — {formatPercent(overview!.overall.errorRate)} ·{" "}
 						{formatInteger(overview!.overall.failedRequests)} failures in this window.{" "}
-						<a href="#/errors?range=today" style={{ color: "var(--danger)", textDecoration: "underline" }}>
+						<a href={`#/errors?range=${range}`} style={{ color: "var(--danger)", textDecoration: "underline" }}>
 							Inspect errors
 						</a>
 					</div>
@@ -923,9 +923,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 								{providerRes.data && (
 									<ProvidersMini
 										providers={providerRes.data.providers.slice(0, 4)}
-										totalTokens={providerRes.data.providers
-											.slice(0, 4)
-											.reduce((sum, pr) => sum + pr.totalTokens, 0)}
+										totalTokens={providerRes.data.providers.reduce((sum, pr) => sum + pr.totalTokens, 0)}
 									/>
 								)}
 							</AsyncBoundary>

--- a/packages/stats/src/client/routes/OverviewRoute.tsx
+++ b/packages/stats/src/client/routes/OverviewRoute.tsx
@@ -1,4 +1,5 @@
 import { format } from "@oh-my-pi/pi-utils/dates";
+import type { ChartData, ChartDataset, ChartOptions } from "chart.js";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Line } from "react-chartjs-2";
 import {
@@ -13,7 +14,14 @@ import {
 import { AgentTokenShare } from "../components/AgentTokenShare";
 import { CHART_THEMES } from "../components/chart-shared";
 import { formatRangeTick } from "../components/range-meta";
-import { formatCompact, formatDurationMs, formatEstimatedCost, formatInteger, formatPercent } from "../data/formatters";
+import {
+	formatCompact,
+	formatDurationMs,
+	formatEstimatedCost,
+	formatInteger,
+	formatMessageCost,
+	formatPercent,
+} from "../data/formatters";
 import {
 	activeDaysFromSeries,
 	createDashboard,
@@ -34,6 +42,7 @@ import {
 	updateDashboardVisible,
 } from "../data/overview-prefs";
 import { useResource } from "../data/useResource";
+import { sumConversationTokens } from "../data/view-models";
 import type {
 	AggregatedStats,
 	FolderStats,
@@ -44,6 +53,7 @@ import type {
 	ToolUsageStats,
 } from "../types";
 import { AsyncBoundary, DataTable, Skeleton, StatusPill } from "../ui";
+import type { DataTableColumn } from "../ui/DataTable";
 import { useSystemTheme } from "../useSystemTheme";
 
 function useDashboardPrefs() {
@@ -125,11 +135,11 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 		return { req, err };
 	}, [theme]);
 
-	const chartData = useMemo(() => {
-		if (!timeSeries) return { labels: [], datasets: [] as unknown[] };
+	const chartData = useMemo<ChartData<"line">>(() => {
+		if (!timeSeries) return { labels: [], datasets: [] };
 		const labels = timeSeries.map(pt => formatRangeTick(pt.timestamp, range));
 		const pointRadius = timeSeries.length <= 2 ? 3 : 0;
-		const datasets: unknown[] = [
+		const datasets: ChartDataset<"line", number[]>[] = [
 			{
 				label: "Requests",
 				data: timeSeries.map(pt => pt.requests),
@@ -158,7 +168,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 		return { labels, datasets };
 	}, [timeSeries, range, chartColors, hasChartErrors]);
 
-	const chartOptions = useMemo(
+	const chartOptions = useMemo<ChartOptions<"line">>(
 		() => ({
 			responsive: true,
 			maintainAspectRatio: false,
@@ -202,7 +212,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 		[chartTheme],
 	);
 
-	const columns = useMemo(
+	const columns = useMemo<DataTableColumn<MessageStats>[]>(
 		() => [
 			{
 				key: "model",
@@ -301,7 +311,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 				<div>
 					<div className="stats-mobile-card-label">Cost</div>
 					<div className="stats-mobile-card-value" style={{ color: "var(--amber)" }}>
-						{formatEstimatedCost(item.usage.cost.total, 0, 4)}
+						{formatMessageCost(item, 4)}
 					</div>
 				</div>
 				<div>
@@ -498,7 +508,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 						<div className="omp-scope-body">
 							<AsyncBoundary loading={overviewRes.loading} error={overviewRes.error} data={overview}>
 								{timeSeries && timeSeries.length > 0 ? (
-									<Line data={chartData as never} options={chartOptions as never} />
+									<Line data={chartData} options={chartOptions} />
 								) : (
 									<div
 										style={{
@@ -534,7 +544,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 						</div>
 					</div>
 					<div className="omp-scope-side">
-						{v.errors && (
+						{v.errors && !(errorsRes.data && errorsRes.data.length === 0) && (
 							<div
 								className="omp-section"
 								style={{
@@ -559,18 +569,25 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 								</div>
 								<div className="omp-section-rule" />
 								<div className="omp-section-body">
-									<AsyncBoundary
-										loading={errorsRes.loading}
-										error={errorsRes.error}
-										data={errorsRes.data}
-										emptyText="No usage in selected period."
-									>
-										{errorsRes.data && errorsRes.data.length > 0 ? (
+									<AsyncBoundary loading={errorsRes.loading} error={errorsRes.error} data={errorsRes.data}>
+										{errorsRes.data && (
 											<div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
 												{errorsRes.data.slice(0, 5).map(err => (
 													<div
 														key={err.id ?? `${err.sessionFile}-${err.entryId}`}
+														role={err.id ? "button" : undefined}
+														tabIndex={err.id ? 0 : undefined}
 														onClick={() => err.id && onRequestClick(err.id)}
+														onKeyDown={
+															err.id
+																? e => {
+																		if (e.key === "Enter" || e.key === " ") {
+																			e.preventDefault();
+																			err.id && onRequestClick(err.id);
+																		}
+																	}
+																: undefined
+														}
 														style={{
 															display: "flex",
 															gap: 10,
@@ -644,150 +661,156 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 													</div>
 												))}
 											</div>
-										) : (
-											<div className="stats-empty-state-message">
-												No failures — system healthy in this window.
-											</div>
 										)}
 									</AsyncBoundary>
 								</div>
 							</div>
 						)}
-						<div
-							className="omp-section"
-							style={{
-								background: "var(--surface)",
-								border: "1px solid var(--border)",
-								borderRadius: "var(--radius-lg)",
-								padding: 12,
-							}}
-						>
-							<div className="omp-section-head">
-								<div>
-									<div className="omp-section-title">Live feed</div>
-									<p className="omp-section-desc">Newest requests</p>
+						{v.liveFeed && !(recentRes.data && recentRes.data.length === 0) && (
+							<div
+								className="omp-section"
+								style={{
+									background: "var(--surface)",
+									border: "1px solid var(--border)",
+									borderRadius: "var(--radius-lg)",
+									padding: 12,
+								}}
+							>
+								<div className="omp-section-head">
+									<div>
+										<div className="omp-section-title">Live feed</div>
+										<p className="omp-section-desc">Newest requests</p>
+									</div>
+								</div>
+								<div className="omp-section-rule" />
+								<div className="omp-section-body">
+									<AsyncBoundary
+										loading={recentRes.loading}
+										error={recentRes.error}
+										data={recentRes.data}
+										fallback={
+											<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+												{Array.from({ length: 4 }).map((_, i) => (
+													<div key={i} style={{ display: "flex", gap: 10, alignItems: "center" }}>
+														<Skeleton variant="circle" width={8} height={8} />
+														<div style={{ flex: 1 }}>
+															<Skeleton variant="text" width="60%" height={14} />
+															<Skeleton variant="text" width="40%" height={10} />
+														</div>
+													</div>
+												))}
+											</div>
+										}
+									>
+										<div style={{ display: "flex", flexDirection: "column" }}>
+											{previewRequests.map(req => {
+												const isError = !!req.errorMessage;
+												const openDetails = () => req.id && onRequestClick(req.id);
+												return (
+													<div
+														key={req.id ?? `${req.sessionFile}-${req.entryId}`}
+														role={req.id ? "button" : undefined}
+														tabIndex={req.id ? 0 : undefined}
+														onClick={openDetails}
+														onKeyDown={
+															req.id
+																? e => {
+																		if (e.key === "Enter" || e.key === " ") {
+																			e.preventDefault();
+																			openDetails();
+																		}
+																	}
+																: undefined
+														}
+														style={{
+															display: "flex",
+															gap: 10,
+															padding: "8px 2px",
+															borderBottom: "1px solid var(--border)",
+															cursor: req.id ? "pointer" : undefined,
+														}}
+													>
+														<span
+															style={{
+																width: 6,
+																height: 6,
+																borderRadius: 999,
+																background: isError ? "var(--danger)" : "var(--success)",
+																marginTop: 7,
+																flexShrink: 0,
+															}}
+														/>
+														<div style={{ minWidth: 0, flex: 1 }}>
+															<div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
+																<span
+																	style={{
+																		fontSize: 12,
+																		fontWeight: 600,
+																		color: "var(--text)",
+																		whiteSpace: "nowrap",
+																		overflow: "hidden",
+																		textOverflow: "ellipsis",
+																	}}
+																>
+																	{req.model}
+																</span>
+																<span
+																	style={{
+																		fontFamily: "var(--font-mono)",
+																		fontSize: 11,
+																		color: "var(--dim)",
+																		flexShrink: 0,
+																	}}
+																>
+																	{format(new Date(req.timestamp), "HH:mm:ss")}
+																</span>
+															</div>
+															<div
+																style={{
+																	display: "flex",
+																	justifyContent: "space-between",
+																	gap: 8,
+																	fontSize: 11,
+																	color: "var(--muted)",
+																}}
+															>
+																<span
+																	style={{
+																		fontFamily: "var(--font-mono)",
+																		whiteSpace: "nowrap",
+																		overflow: "hidden",
+																		textOverflow: "ellipsis",
+																	}}
+																>
+																	{req.provider}
+																</span>
+																<span
+																	style={{
+																		fontFamily: "var(--font-mono)",
+																		fontVariantNumeric: "tabular-nums",
+																		whiteSpace: "nowrap",
+																	}}
+																>
+																	{req.usage.totalTokens > 0
+																		? `${formatCompact(req.usage.totalTokens)} tok`
+																		: ""}{" "}
+																	{req.usage.totalTokens > 0 ? `· ${formatMessageCost(req, 2)}` : ""}
+																</span>
+															</div>
+														</div>
+													</div>
+												);
+											})}
+										</div>
+									</AsyncBoundary>
 								</div>
 							</div>
-							<div className="omp-section-rule" />
-							<div className="omp-section-body">
-								<AsyncBoundary
-									loading={recentRes.loading}
-									error={recentRes.error}
-									data={recentRes.data}
-									fallback={
-										<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-											{Array.from({ length: 4 }).map((_, i) => (
-												<div key={i} style={{ display: "flex", gap: 10, alignItems: "center" }}>
-													<Skeleton variant="circle" width={8} height={8} />
-													<div style={{ flex: 1 }}>
-														<Skeleton variant="text" width="60%" height={14} />
-														<Skeleton variant="text" width="40%" height={10} />
-													</div>
-												</div>
-											))}
-										</div>
-									}
-								>
-									<div style={{ display: "flex", flexDirection: "column" }}>
-										{previewRequests.map(req => {
-											const isError = !!req.errorMessage;
-											return (
-												<div
-													key={req.id ?? `${req.sessionFile}-${req.entryId}`}
-													onClick={() => req.id && onRequestClick(req.id)}
-													style={{
-														display: "flex",
-														gap: 10,
-														padding: "8px 2px",
-														borderBottom: "1px solid var(--border)",
-														cursor: req.id ? "pointer" : undefined,
-													}}
-												>
-													<span
-														style={{
-															width: 6,
-															height: 6,
-															borderRadius: 999,
-															background: isError ? "var(--danger)" : "var(--success)",
-															marginTop: 7,
-															flexShrink: 0,
-														}}
-													/>
-													<div style={{ minWidth: 0, flex: 1 }}>
-														<div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
-															<span
-																style={{
-																	fontSize: 12,
-																	fontWeight: 600,
-																	color: "var(--text)",
-																	whiteSpace: "nowrap",
-																	overflow: "hidden",
-																	textOverflow: "ellipsis",
-																}}
-															>
-																{req.model}
-															</span>
-															<span
-																style={{
-																	fontFamily: "var(--font-mono)",
-																	fontSize: 11,
-																	color: "var(--dim)",
-																	flexShrink: 0,
-																}}
-															>
-																{format(new Date(req.timestamp), "HH:mm:ss")}
-															</span>
-														</div>
-														<div
-															style={{
-																display: "flex",
-																justifyContent: "space-between",
-																gap: 8,
-																fontSize: 11,
-																color: "var(--muted)",
-															}}
-														>
-															<span
-																style={{
-																	fontFamily: "var(--font-mono)",
-																	whiteSpace: "nowrap",
-																	overflow: "hidden",
-																	textOverflow: "ellipsis",
-																}}
-															>
-																{req.provider}
-															</span>
-															<span
-																style={{
-																	fontFamily: "var(--font-mono)",
-																	fontVariantNumeric: "tabular-nums",
-																	whiteSpace: "nowrap",
-																}}
-															>
-																{req.usage.totalTokens > 0
-																	? `${formatCompact(req.usage.totalTokens)} tok`
-																	: ""}{" "}
-																{req.usage.cost.total > 0
-																	? `· ${formatEstimatedCost(req.usage.cost.total, 0, 2)}`
-																	: ""}
-															</span>
-														</div>
-													</div>
-												</div>
-											);
-										})}
-										{previewRequests.length === 0 && (
-											<div className="stats-empty-state-message">No recent requests.</div>
-										)}
-									</div>
-								</AsyncBoundary>
-							</div>
-						</div>
+						)}
 					</div>
 				</div>
 			)}
 
-			{v.tokens && (
+			{v.tokens && !(overview && sumConversationTokens(overview.overall) === 0) && (
 				<div className="omp-section">
 					<div className="omp-section-head">
 						<div>
@@ -807,17 +830,13 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 					<div className="omp-section-rule" />
 					<div className="omp-section-body">
 						<AsyncBoundary loading={overviewRes.loading} error={overviewRes.error} data={overview}>
-							{overview ? (
-								<TokenBreakdownPanel stats={overview.overall} />
-							) : (
-								<div className="stats-empty-state-message">No usage in selected period.</div>
-							)}
+							{overview && <TokenBreakdownPanel stats={overview.overall} />}
 						</AsyncBoundary>
 					</div>
 				</div>
 			)}
 
-			{v.agents && (
+			{v.agents && !(overview && overview.byAgentType.length === 0) && (
 				<div className="omp-section">
 					<div className="omp-section-head">
 						<div>
@@ -843,7 +862,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 				</div>
 			)}
 
-			{v.models && (
+			{v.models && !(modelRes.data && modelRes.data.byModel.length === 0) && (
 				<div className="omp-section">
 					<div className="omp-section-head">
 						<div>
@@ -863,13 +882,11 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 					<div className="omp-section-rule" />
 					<div className="omp-section-body">
 						<AsyncBoundary loading={modelRes.loading} error={modelRes.error} data={modelRes.data}>
-							{modelRes.data && modelRes.data.byModel.length > 0 ? (
+							{modelRes.data && (
 								<ModelsMini
 									models={modelRes.data.byModel.slice(0, 6)}
 									totalRequests={overview?.overall.totalRequests ?? 0}
 								/>
-							) : (
-								<div className="stats-empty-state-message">No usage in selected period.</div>
 							)}
 						</AsyncBoundary>
 					</div>
@@ -877,7 +894,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 			)}
 
 			<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
-				{v.providers && (
+				{v.providers && !(providerRes.data && providerRes.data.providers.length === 0) && (
 					<div
 						className="omp-section"
 						style={{
@@ -903,16 +920,19 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 						<div className="omp-section-rule" />
 						<div className="omp-section-body">
 							<AsyncBoundary loading={providerRes.loading} error={providerRes.error} data={providerRes.data}>
-								{providerRes.data && providerRes.data.providers.length > 0 ? (
-									<ProvidersMini providers={providerRes.data.providers.slice(0, 4)} />
-								) : (
-									<div className="stats-empty-state-message">No usage in selected period.</div>
+								{providerRes.data && (
+									<ProvidersMini
+										providers={providerRes.data.providers.slice(0, 4)}
+										totalTokens={providerRes.data.providers
+											.slice(0, 4)
+											.reduce((sum, pr) => sum + pr.totalTokens, 0)}
+									/>
 								)}
 							</AsyncBoundary>
 						</div>
 					</div>
 				)}
-				{v.tools && (
+				{v.tools && !(toolRes.data && toolRes.data.byTool.length === 0) && (
 					<div
 						className="omp-section"
 						style={{
@@ -938,13 +958,11 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 						<div className="omp-section-rule" />
 						<div className="omp-section-body">
 							<AsyncBoundary loading={toolRes.loading} error={toolRes.error} data={toolRes.data}>
-								{toolRes.data && toolRes.data.byTool.length > 0 ? (
+								{toolRes.data && (
 									<ToolsMini
 										tools={toolRes.data.byTool.slice(0, 5)}
 										totalCalls={toolRes.data.byTool.reduce((s, t) => s + t.calls, 0)}
 									/>
-								) : (
-									<div className="stats-empty-state-message">No usage in selected period.</div>
 								)}
 							</AsyncBoundary>
 						</div>
@@ -952,7 +970,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 				)}
 			</div>
 
-			{v.projects && (
+			{v.projects && !(folderRes.data && folderRes.data.length === 0) && (
 				<div className="omp-section">
 					<div className="omp-section-head">
 						<div>
@@ -970,55 +988,55 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 					<div className="omp-section-rule" />
 					<div className="omp-section-body">
 						<AsyncBoundary loading={folderRes.loading} error={folderRes.error} data={folderRes.data}>
-							{folderRes.data && folderRes.data.length > 0 ? (
+							{folderRes.data && (
 								<ProjectsMini
 									folders={folderRes.data.slice(0, 6)}
 									totalRequests={overview?.overall.totalRequests ?? 0}
 								/>
-							) : (
-								<div className="stats-empty-state-message">No usage in selected period.</div>
 							)}
 						</AsyncBoundary>
 					</div>
 				</div>
 			)}
 
-			<div
-				className="omp-section"
-				style={{
-					background: "var(--surface)",
-					border: "1px solid var(--border)",
-					borderRadius: "var(--radius-lg)",
-					padding: 14,
-				}}
-			>
-				<div className="omp-section-head">
-					<div>
-						<div className="omp-section-title">Recent requests</div>
-						<p className="omp-section-desc">Latest transactions · tap a row for detail</p>
+			{v.recentRequests && !(recentRes.data && recentRes.data.length === 0) && (
+				<div
+					className="omp-section"
+					style={{
+						background: "var(--surface)",
+						border: "1px solid var(--border)",
+						borderRadius: "var(--radius-lg)",
+						padding: 14,
+					}}
+				>
+					<div className="omp-section-head">
+						<div>
+							<div className="omp-section-title">Recent requests</div>
+							<p className="omp-section-desc">Latest transactions · tap a row for detail</p>
+						</div>
+						<a
+							href={`#/requests?range=${range}`}
+							className="stats-button stats-button-secondary"
+							style={{ fontSize: 11, padding: "5px 9px" }}
+						>
+							View all
+						</a>
 					</div>
-					<a
-						href={`#/requests?range=${range}`}
-						className="stats-button stats-button-secondary"
-						style={{ fontSize: 11, padding: "5px 9px" }}
-					>
-						View all
-					</a>
+					<div className="omp-section-rule" />
+					<div className="omp-section-body">
+						<AsyncBoundary loading={recentRes.loading} error={recentRes.error} data={recentRes.data}>
+							<DataTable
+								columns={columns}
+								data={previewRequests}
+								keyExtractor={item => String(item.id ?? `${item.sessionFile}-${item.entryId}`)}
+								onRowClick={item => item.id && onRequestClick(item.id)}
+								renderMobileCard={renderMobileCard}
+								emptyText="No usage in selected period."
+							/>
+						</AsyncBoundary>
+					</div>
 				</div>
-				<div className="omp-section-rule" />
-				<div className="omp-section-body">
-					<AsyncBoundary loading={recentRes.loading} error={recentRes.error} data={recentRes.data}>
-						<DataTable
-							columns={columns as never}
-							data={previewRequests}
-							keyExtractor={item => String(item.id ?? `${item.sessionFile}-${item.entryId}`)}
-							onRowClick={item => item.id && onRequestClick(item.id)}
-							renderMobileCard={renderMobileCard as never}
-							emptyText="No usage in selected period."
-						/>
-					</AsyncBoundary>
-				</div>
-			</div>
+			)}
 		</div>
 	);
 }
@@ -1236,7 +1254,7 @@ function ManageDisclosure({
 								<input
 									type="checkbox"
 									checked={!!v[key]}
-									onChange={() => toggle(key as OverviewSectionKey)}
+									onChange={() => toggle(key)}
 									style={{ accentColor: "var(--text)" }}
 								/>
 							</label>
@@ -1341,11 +1359,12 @@ function ModelsMini({ models, totalRequests }: { models: ModelStats[]; totalRequ
 	);
 }
 
-function ProvidersMini({ providers }: { providers: ProviderAggregate[] }) {
+function ProvidersMini({ providers, totalTokens }: { providers: ProviderAggregate[]; totalTokens: number }) {
 	return (
 		<div className="omp-provider-grid">
 			{providers.map(p => {
 				const errorRate = p.totalRequests > 0 ? p.failedRequests / p.totalRequests : 0;
+				const tokenShare = totalTokens > 0 ? p.totalTokens / totalTokens : 0;
 				return (
 					<div key={p.provider} className="omp-provider-item">
 						<div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
@@ -1371,8 +1390,18 @@ function ProvidersMini({ providers }: { providers: ProviderAggregate[] }) {
 							<span>{formatInteger(p.totalRequests)} req</span>
 							<span>{formatCompact(p.totalTokens)} tok</span>
 						</div>
-						<div style={{ height: 3, borderRadius: 999, background: "var(--surface-3)", overflow: "hidden" }}>
-							<div style={{ width: "100%", height: "100%", background: "var(--link)", opacity: 0.9 }} />
+						<div
+							title={`${formatPercent(tokenShare)} of provider tokens`}
+							style={{ height: 3, borderRadius: 999, background: "var(--surface-3)", overflow: "hidden" }}
+						>
+							<div
+								style={{
+									width: `${tokenShare * 100}%`,
+									height: "100%",
+									background: "var(--link)",
+									opacity: 0.9,
+								}}
+							/>
 						</div>
 						<div
 							style={{
@@ -1470,7 +1499,7 @@ function ToolsMini({ tools, totalCalls }: { tools: ToolUsageStats[]; totalCalls:
 								fontVariantNumeric: "tabular-nums",
 							}}
 						>
-							{formatEstimatedCost(t.costShare, 0, 2)}
+							{formatEstimatedCost(t.costShare, t.unpricedRequestsShare, 2)}
 						</span>
 					</div>
 				);

--- a/packages/stats/src/client/routes/OverviewRoute.tsx
+++ b/packages/stats/src/client/routes/OverviewRoute.tsx
@@ -1,14 +1,62 @@
 import { format } from "@oh-my-pi/pi-utils/dates";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Line } from "react-chartjs-2";
-import { getOverviewStats, getRecentRequests } from "../api";
+import {
+	getFolderStats,
+	getModelDashboardStats,
+	getOverviewStats,
+	getProviderDashboardStats,
+	getRecentErrors,
+	getRecentRequests,
+	getToolDashboardStats,
+} from "../api";
 import { AgentTokenShare } from "../components/AgentTokenShare";
 import { CHART_THEMES } from "../components/chart-shared";
-import { formatDurationMs, formatInteger, formatMessageCost, formatRelativeTime } from "../data/formatters";
+import { formatRangeTick } from "../components/range-meta";
+import { formatCompact, formatDurationMs, formatEstimatedCost, formatInteger, formatPercent } from "../data/formatters";
+import {
+	activeDaysFromSeries,
+	loadPrefs,
+	nextPrefsOnToggle,
+	type OverviewSectionKey,
+	PRESET_DEFS,
+	type PrefsState,
+	type PresetId,
+	prefsForPreset,
+	SECTION_LABELS,
+	SECTION_ORDER,
+	STORAGE_KEY,
+} from "../data/overview-prefs";
 import { useResource } from "../data/useResource";
-import type { MessageStats, TimeRange } from "../types";
-import { AsyncBoundary, DataTable, MetricCluster, Panel, Skeleton, StatusPill } from "../ui";
+import type {
+	AggregatedStats,
+	FolderStats,
+	MessageStats,
+	ModelStats,
+	ProviderAggregate,
+	TimeRange,
+	ToolUsageStats,
+} from "../types";
+import { AsyncBoundary, DataTable, Panel, Skeleton, StatusPill } from "../ui";
 import { useSystemTheme } from "../useSystemTheme";
+
+function useOverviewPrefs() {
+	const [prefs, setPrefs] = useState<PrefsState>(() => loadPrefs());
+	useEffect(() => {
+		try {
+			localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+		} catch {
+			// ignore quota
+		}
+	}, [prefs]);
+	const setPreset = (id: PresetId) => setPrefs(prefsForPreset(id));
+	const toggle = (key: OverviewSectionKey) => setPrefs(prev => nextPrefsOnToggle(prev, key));
+	return { prefs, setPreset, toggle };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
 
 export interface OverviewRouteProps {
 	active: boolean;
@@ -18,84 +66,93 @@ export interface OverviewRouteProps {
 }
 
 export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }: OverviewRouteProps) {
-	const {
-		data: overview,
-		error: overviewError,
-		loading: overviewLoading,
-	} = useResource(["overview", range, refreshTrigger], signal => getOverviewStats(range, signal), {
-		pollMs: 30000,
+	const { prefs, setPreset, toggle } = useOverviewPrefs();
+
+	const overviewRes = useResource(["overview", range, refreshTrigger], s => getOverviewStats(range, s), {
 		enabled: active,
+		pollMs: 30000,
+	});
+	const modelRes = useResource(["overview-models", range, refreshTrigger], s => getModelDashboardStats(range, s), {
+		enabled: active,
+		pollMs: 30000,
+	});
+	const providerRes = useResource(
+		["overview-providers", range, refreshTrigger],
+		s => getProviderDashboardStats(range, s),
+		{ enabled: active, pollMs: 30000 },
+	);
+	const toolRes = useResource(["overview-tools", range, refreshTrigger], s => getToolDashboardStats(range, s), {
+		enabled: active,
+		pollMs: 30000,
+	});
+	const folderRes = useResource(["overview-folders", range, refreshTrigger], s => getFolderStats(range, s), {
+		enabled: active,
+		pollMs: 30000,
+	});
+	const errorsRes = useResource(["overview-errors", range, refreshTrigger], s => getRecentErrors(range, 8, s), {
+		enabled: active,
+		pollMs: 30000,
+	});
+	const recentRes = useResource(["recent-requests", refreshTrigger], s => getRecentRequests(12, s), {
+		enabled: active,
+		pollMs: 30000,
 	});
 
-	const {
-		data: recentRequests,
-		error: requestsError,
-		loading: requestsLoading,
-	} = useResource(["recent-requests", refreshTrigger], signal => getRecentRequests(50, signal), {
-		pollMs: 30000,
-		enabled: active,
-	});
+	const overview = overviewRes.data;
+	const timeSeries = overview?.timeSeries;
+	const activeDays = useMemo(() => activeDaysFromSeries(timeSeries), [timeSeries]);
+	const hasChartErrors = useMemo(() => !!timeSeries?.some(pt => pt.errors > 0), [timeSeries]);
 
 	const theme = useSystemTheme();
 	const chartTheme = CHART_THEMES[theme];
 
-	const chartData = useMemo(() => {
-		if (!overview?.timeSeries) return { labels: [], datasets: [] };
-		const labels = overview.timeSeries.map(pt =>
-			format(new Date(pt.timestamp), range === "1h" || range === "24h" ? "HH:mm" : "MMM d"),
-		);
-		// Show point markers when the series is sparse (e.g. a quiet 1h window)
-		// so a 1-2 point line is still visible instead of an empty plot.
-		const pointRadius = overview.timeSeries.length <= 2 ? 3 : 0;
-		return {
-			labels,
-			datasets: [
-				{
-					label: "Requests",
-					data: overview.timeSeries.map(pt => pt.requests),
-					borderColor: "#5ad8e6",
-					backgroundColor: "rgba(90, 216, 230, 0.12)",
-					tension: 0.2,
-					borderWidth: 2,
-					pointRadius,
-					pointHoverRadius: 4,
-					fill: true,
-				},
-				{
-					label: "Errors",
-					data: overview.timeSeries.map(pt => pt.errors),
-					borderColor: "#ff6b7d",
-					backgroundColor: "rgba(255, 107, 125, 0.12)",
-					tension: 0.2,
-					borderWidth: 2,
-					pointRadius,
-					pointHoverRadius: 4,
-					fill: true,
-				},
-			],
-		};
-	}, [overview?.timeSeries, range]);
+	const chartColors = useMemo(() => {
+		const style =
+			typeof document !== "undefined" ? getComputedStyle(document.body) : (null as unknown as CSSStyleDeclaration);
+		const req = style?.getPropertyValue("--chart-req").trim() || "oklch(0.817 0.112 205)";
+		const err = style?.getPropertyValue("--chart-err").trim() || "oklch(0.66 0.19 25)";
+		return { req, err };
+	}, [theme]);
 
-	const chartOptions = useMemo(() => {
-		return {
+	const chartData = useMemo(() => {
+		if (!timeSeries) return { labels: [], datasets: [] as unknown[] };
+		const labels = timeSeries.map(pt => formatRangeTick(pt.timestamp, range));
+		const pointRadius = timeSeries.length <= 2 ? 3 : 0;
+		const datasets: unknown[] = [
+			{
+				label: "Requests",
+				data: timeSeries.map(pt => pt.requests),
+				borderColor: chartColors.req,
+				backgroundColor: `color-mix(in oklab, ${chartColors.req} 8%, transparent)`,
+				tension: 0.32,
+				borderWidth: 1.5,
+				pointRadius,
+				pointHoverRadius: 4,
+				fill: true,
+			},
+		];
+		if (hasChartErrors) {
+			datasets.push({
+				label: "Errors",
+				data: timeSeries.map(pt => pt.errors),
+				borderColor: chartColors.err,
+				backgroundColor: `color-mix(in oklab, ${chartColors.err} 6%, transparent)`,
+				tension: 0.32,
+				borderWidth: 1,
+				pointRadius,
+				pointHoverRadius: 4,
+				fill: false,
+			});
+		}
+		return { labels, datasets };
+	}, [timeSeries, range, chartColors, hasChartErrors]);
+	const chartOptions = useMemo(
+		() => ({
 			responsive: true,
 			maintainAspectRatio: false,
-			interaction: {
-				mode: "index" as const,
-				intersect: false,
-			},
+			interaction: { mode: "index" as const, intersect: false },
 			plugins: {
-				legend: {
-					display: true,
-					position: "top" as const,
-					align: "end" as const,
-					labels: {
-						color: chartTheme.legendLabel,
-						boxWidth: 8,
-						usePointStyle: true,
-						font: { size: 11 },
-					},
-				},
+				legend: { display: false },
 				tooltip: {
 					backgroundColor: chartTheme.tooltipBackground,
 					titleColor: chartTheme.tooltipTitle,
@@ -104,33 +161,34 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 					borderWidth: 1,
 					cornerRadius: 8,
 					padding: 10,
+					displayColors: true,
+					callbacks: {
+						title: (items: { label: string }[]) => items[0]?.label ?? "",
+					},
 				},
 			},
 			scales: {
 				x: {
-					grid: {
-						color: chartTheme.grid,
-						drawBorder: false,
-					},
+					grid: { color: chartTheme.grid, drawBorder: false },
 					ticks: {
 						color: chartTheme.tick,
-						font: { size: 10 },
+						font: { size: 10, family: "ui-monospace" },
+						maxRotation: 0,
+						autoSkip: true,
+						maxTicksLimit: 8,
 					},
+					border: { display: false },
 				},
 				y: {
-					grid: {
-						color: chartTheme.grid,
-						drawBorder: false,
-					},
-					ticks: {
-						color: chartTheme.tick,
-						font: { size: 10 },
-					},
+					grid: { color: chartTheme.grid, drawBorder: false },
+					ticks: { color: chartTheme.tick, font: { size: 10 } },
 					min: 0,
+					border: { display: false },
 				},
 			},
-		};
-	}, [chartTheme]);
+		}),
+		[chartTheme],
+	);
 
 	const columns = useMemo(
 		() => [
@@ -139,33 +197,60 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 				header: "Model",
 				render: (item: MessageStats) => (
 					<div>
-						<div className="stats-font-medium stats-text-primary">{item.model}</div>
-						<div className="stats-text-xs stats-text-muted">{item.provider}</div>
+						<div className="stats-font-medium stats-text-primary" style={{ fontSize: 12.5 }}>
+							{item.model}
+						</div>
+						<div
+							className="stats-text-xs stats-text-muted"
+							style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
+						>
+							{item.provider}
+						</div>
 					</div>
 				),
 			},
 			{
 				key: "timestamp",
 				header: "Time",
-				render: (item: MessageStats) => formatRelativeTime(item.timestamp),
+				render: (item: MessageStats) => (
+					<span style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}>
+						{format(new Date(item.timestamp), "HH:mm:ss")}
+					</span>
+				),
 			},
 			{
 				key: "tokens",
 				header: "Tokens",
 				numeric: true,
-				render: (item: MessageStats) => formatInteger(item.usage.totalTokens),
+				render: (item: MessageStats) => (
+					<span style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
+						{formatInteger(item.usage.totalTokens)}
+					</span>
+				),
 			},
 			{
 				key: "cost",
-				header: "API-equivalent estimate",
+				header: "Est. cost",
 				numeric: true,
-				render: (item: MessageStats) => formatMessageCost(item, 4),
+				render: (item: MessageStats) => (
+					<span
+						style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums", color: "var(--amber)" }}
+					>
+						{formatEstimatedCost(
+							item.usage.cost.total,
+							item.usage.cost.total === 0 && item.usage.totalTokens > 0 && item.provider === "xai-oauth" ? 1 : 0,
+							4,
+						)}
+					</span>
+				),
 			},
 			{
 				key: "duration",
-				header: "Duration",
+				header: "Latency",
 				numeric: true,
-				render: (item: MessageStats) => formatDurationMs(item.duration),
+				render: (item: MessageStats) => (
+					<span style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}>{formatDurationMs(item.duration)}</span>
+				),
 			},
 			{
 				key: "status",
@@ -173,7 +258,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 				className: "stats-text-center",
 				render: (item: MessageStats) => (
 					<StatusPill variant={item.errorMessage ? "danger" : "success"}>
-						{item.errorMessage ? "Failed" : "Success"}
+						{item.errorMessage ? "Failed" : "OK"}
 					</StatusPill>
 				),
 			},
@@ -182,31 +267,37 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 	);
 
 	const renderMobileCard = (item: MessageStats, onClick?: () => void) => (
-		<div className="stats-mobile-card" onClick={onClick}>
+		<div className="stats-mobile-card" onClick={onClick} style={{ cursor: onClick ? "pointer" : undefined }}>
 			<div className="stats-mobile-card-header">
 				<div>
-					<div className="stats-font-semibold stats-text-primary">{item.model}</div>
-					<div className="stats-text-xs stats-text-muted">{item.provider}</div>
+					<div className="stats-font-semibold stats-text-primary" style={{ fontSize: 13 }}>
+						{item.model}
+					</div>
+					<div className="stats-text-xs stats-text-muted" style={{ fontFamily: "var(--font-mono)" }}>
+						{item.provider}
+					</div>
 				</div>
 				<StatusPill variant={item.errorMessage ? "danger" : "success"}>
-					{item.errorMessage ? "Failed" : "Success"}
+					{item.errorMessage ? "Failed" : "OK"}
 				</StatusPill>
 			</div>
 			<div className="stats-mobile-card-grid">
 				<div>
 					<div className="stats-mobile-card-label">Time</div>
-					<div className="stats-mobile-card-value">{formatRelativeTime(item.timestamp)}</div>
+					<div className="stats-mobile-card-value">{format(new Date(item.timestamp), "MMM d, HH:mm")}</div>
 				</div>
 				<div>
-					<div className="stats-mobile-card-label">API-equivalent estimate</div>
-					<div className="stats-mobile-card-value">{formatMessageCost(item, 4)}</div>
+					<div className="stats-mobile-card-label">Cost</div>
+					<div className="stats-mobile-card-value" style={{ color: "var(--amber)" }}>
+						{formatEstimatedCost(item.usage.cost.total, 0, 4)}
+					</div>
 				</div>
 				<div>
 					<div className="stats-mobile-card-label">Tokens</div>
 					<div className="stats-mobile-card-value">{formatInteger(item.usage.totalTokens)}</div>
 				</div>
 				<div>
-					<div className="stats-mobile-card-label">Duration</div>
+					<div className="stats-mobile-card-label">Latency</div>
 					<div className="stats-mobile-card-value">{formatDurationMs(item.duration)}</div>
 				</div>
 			</div>
@@ -214,102 +305,470 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 		</div>
 	);
 
-	const previewRequests = useMemo(() => {
-		if (!recentRequests) return [];
-		return recentRequests.slice(0, 10);
-	}, [recentRequests]);
+	const previewRequests = useMemo(() => recentRes.data?.slice(0, 8) ?? [], [recentRes.data]);
+
+	const v = prefs.visible;
 
 	return (
-		<div className="stats-route-container space-y-6">
-			<AsyncBoundary loading={overviewLoading} error={overviewError} data={overview}>
-				{overview && <MetricCluster stats={overview.overall} />}
-			</AsyncBoundary>
-
-			<Panel
-				title="Conversation Tokens by Agent"
-				subtitle="Uncached input + cache reads + cache writes + output, grouped by agent type"
-			>
-				<AsyncBoundary loading={overviewLoading} error={overviewError} data={overview}>
-					{overview && <AgentTokenShare stats={overview.byAgentType} />}
-				</AsyncBoundary>
-			</Panel>
-
-			<div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-				<div className="lg:col-span-2">
-					<Panel title="System Throughput" subtitle="Request volume and errors over time">
-						<AsyncBoundary loading={overviewLoading} error={overviewError} data={overview}>
-							<div className="h-[280px]">
-								{overview?.timeSeries && overview.timeSeries.length > 0 ? (
-									<Line data={chartData} options={chartOptions} />
-								) : (
-									<div className="h-full flex items-center justify-center text-stats-muted text-sm">
-										No time-series data available
-									</div>
-								)}
-							</div>
-						</AsyncBoundary>
-					</Panel>
+		<div className="stats-route-container space-y-4">
+			{/* Range-aware subtitle + preset bar */}
+			<div className="stats-overview-toolbar">
+				<div className="flex items-center gap-2 flex-wrap">
+					<span className="stats-panel-eyebrow" style={{ margin: 0 }}>
+						Overview
+					</span>
+					<span
+						style={{
+							fontFamily: "var(--font-mono)",
+							fontSize: 11,
+							color: "var(--muted)",
+							background: "var(--surface)",
+							border: "1px solid var(--border)",
+							borderRadius: 2,
+							padding: "3px 8px",
+						}}
+					>
+						{range === "today" ? "today · since 00:00" : range}
+					</span>
+					{overview?.overall && (
+						<span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--dim)" }}>
+							· {formatInteger(overview.overall.totalRequests)} req
+							{activeDays > 0 ? ` · ${activeDays} active day${activeDays === 1 ? "" : "s"}` : ""}
+						</span>
+					)}
 				</div>
 
-				<div>
-					<Panel title="Operational Feed" subtitle="Real-time request log">
+				<div className="flex items-center gap-2 flex-wrap">
+					<div className="stats-preset-group" role="group" aria-label="Overview preset">
+						{(Object.keys(PRESET_DEFS) as PresetId[]).map(pid => (
+							<button
+								key={pid}
+								type="button"
+								className="stats-preset-btn"
+								data-active={prefs.preset === pid ? "true" : "false"}
+								onClick={() => setPreset(pid)}
+							>
+								{PRESET_DEFS[pid].label}
+							</button>
+						))}
+					</div>
+					<details className="group" style={{ position: "relative" }}>
+						<summary
+							className="stats-button stats-button-ghost"
+							style={{
+								listStyle: "none",
+								cursor: "pointer",
+								fontFamily: "var(--font-mono)",
+								fontSize: 11,
+								padding: "5px 10px",
+							}}
+						>
+							Customize ▾
+						</summary>
+						<div
+							className="stats-panel"
+							style={{
+								position: "absolute",
+								right: 0,
+								top: "calc(100% + 8px)",
+								width: 260,
+								zIndex: 5,
+								boxShadow: "0 12px 32px rgba(0,0,0,0.28)",
+							}}
+						>
+							<div className="stats-panel-header" style={{ padding: "10px 12px" }}>
+								<span
+									className="stats-panel-title"
+									style={{
+										fontSize: 11,
+										fontFamily: "var(--font-mono)",
+										letterSpacing: "0.06em",
+										textTransform: "uppercase",
+									}}
+								>
+									Visible sections
+								</span>
+							</div>
+							<div style={{ padding: 10, display: "flex", flexDirection: "column", gap: 6 }}>
+								{SECTION_ORDER.map(key => (
+									<label
+										key={key}
+										className="stats-customize-chip"
+										data-on={v[key] ? "true" : "false"}
+										style={{ justifyContent: "space-between", cursor: "pointer" }}
+									>
+										<span>{SECTION_LABELS[key]}</span>
+										<input
+											type="checkbox"
+											checked={v[key]}
+											onChange={() => toggle(key)}
+											style={{ width: 14, height: 14 }}
+										/>
+									</label>
+								))}
+								<div
+									style={{ fontSize: 11, color: "var(--dim)", fontFamily: "var(--font-mono)", marginTop: 4 }}
+								>
+									Persisted in localStorage · {STORAGE_KEY}
+								</div>
+							</div>
+						</div>
+					</details>
+				</div>
+			</div>
+
+			{/* KPI Tape */}
+			{v.tape && (
+				<AsyncBoundary loading={overviewRes.loading} error={overviewRes.error} data={overview}>
+					{overview && (
+						<div className="stats-overview-tape" role="region" aria-label="Key metrics">
+							<div className="stats-tape-cell" style={{ ["--tape-accent" as string]: "var(--accent)" }}>
+								<div className="stats-tape-label">Requests</div>
+								<div className="stats-tape-value">{formatInteger(overview.overall.totalRequests)}</div>
+								<div className="stats-tape-sub">
+									{formatInteger(overview.overall.successfulRequests)} ok ·{" "}
+									{formatInteger(overview.overall.failedRequests)} fail
+								</div>
+							</div>
+							<div className="stats-tape-cell" style={{ ["--tape-accent" as string]: "var(--link)" }}>
+								<div className="stats-tape-label">Conversation tokens</div>
+								<div className="stats-tape-value">
+									{formatCompact(
+										overview.overall.totalInputTokens +
+											overview.overall.totalOutputTokens +
+											overview.overall.totalCacheReadTokens +
+											overview.overall.totalCacheWriteTokens,
+									)}
+								</div>
+								<div className="stats-tape-sub">
+									in {formatCompact(overview.overall.totalInputTokens)} · out{" "}
+									{formatCompact(overview.overall.totalOutputTokens)}
+								</div>
+							</div>
+							<div className="stats-tape-cell" style={{ ["--tape-accent" as string]: "var(--amber)" }}>
+								<div className="stats-tape-label">Est. cost</div>
+								<div className="stats-tape-value" style={{ color: "var(--amber)" }}>
+									{formatEstimatedCost(
+										overview.overall.totalCost,
+										overview.overall.unpricedRequests,
+										overview.overall.totalCost > 0 && overview.overall.totalCost < 0.01 ? 4 : 2,
+									)}
+								</div>
+								<div className="stats-tape-sub">
+									{overview.overall.unpricedRequests > 0
+										? `${overview.overall.unpricedRequests} unpriced`
+										: "API-equivalent"}
+								</div>
+							</div>
+							<div
+								className="stats-tape-cell"
+								style={{
+									["--tape-accent" as string]:
+										overview.overall.errorRate > 0.05 ? "var(--danger)" : "var(--success)",
+								}}
+							>
+								<div className="stats-tape-label">Error rate</div>
+								<div className="stats-tape-value">{formatPercent(overview.overall.errorRate)}</div>
+								<div className="stats-tape-sub">
+									<span
+										className="stats-tape-badge"
+										data-tone={overview.overall.errorRate > 0.05 ? "danger" : "success"}
+									>
+										{overview.overall.failedRequests} errors
+									</span>
+								</div>
+							</div>
+							<div className="stats-tape-cell" style={{ ["--tape-accent" as string]: "var(--success)" }}>
+								<div className="stats-tape-label">Cache rate</div>
+								<div className="stats-tape-value">{formatPercent(overview.overall.cacheRate)}</div>
+								<div className="stats-tape-sub">savings {formatPercent(overview.overall.cacheSavings)}</div>
+							</div>
+							<div className="stats-tape-cell" style={{ ["--tape-accent" as string]: "var(--dim)" }}>
+								<div className="stats-tape-label">Active days</div>
+								<div className="stats-tape-value">{activeDays}</div>
+								<div className="stats-tape-sub">
+									{overview.timeSeries.length} buckets · {range === "today" ? "since midnight" : range}
+								</div>
+							</div>
+						</div>
+					)}
+				</AsyncBoundary>
+			)}
+
+			{/* Scope row: oscilloscope chart + errors/feed */}
+			<div className="stats-overview-grid">
+				{v.scope && (
+					<div className="stats-scope-wrap">
+						<div className="stats-scope-grid" aria-hidden />
+						<div className="stats-scope-header">
+							<div className="stats-scope-title">
+								<span className="stats-scope-dot" aria-hidden />
+								Usage over time
+								<span
+									style={{
+										fontFamily: "var(--font-mono)",
+										fontSize: 11,
+										color: "var(--muted)",
+										fontWeight: 500,
+									}}
+								>
+									{range === "today" ? "today" : range} · {timeSeries?.length ?? 0} buckets
+								</span>
+							</div>
+							<div className="stats-scope-legend" aria-hidden>
+								<span>
+									<i style={{ background: "var(--chart-req)" }} /> req
+								</span>
+								{hasChartErrors && (
+									<span>
+										<i style={{ background: "var(--chart-err)" }} /> err
+									</span>
+								)}
+							</div>
+						</div>
+						<div
+							className="stats-scope-body"
+							style={{
+								flex: 1,
+								minHeight: 272,
+								maxHeight: 480,
+								display: "flex",
+								flexDirection: "column",
+							}}
+						>
+							<AsyncBoundary loading={overviewRes.loading} error={overviewRes.error} data={overview}>
+								{timeSeries && timeSeries.length > 0 ? (
+									<Line data={chartData as never} options={chartOptions as never} />
+								) : (
+									<div
+										className="h-full flex items-center justify-center"
+										style={{ color: "var(--muted)", fontFamily: "var(--font-mono)", fontSize: 12 }}
+									>
+										No usage in selected period.
+									</div>
+								)}
+							</AsyncBoundary>
+						</div>
+					</div>
+				)}
+
+				<div className="stats-overview-stack">
+					{v.errors && (
+						<Panel
+							title="Recent errors"
+							subtitle="Latest failures in this window"
+							actions={
+								<a
+									href={`#/errors?range=${range}`}
+									className="stats-button stats-button-secondary"
+									style={{ fontSize: 11, padding: "5px 9px" }}
+								>
+									View all →
+								</a>
+							}
+						>
+							<AsyncBoundary
+								loading={errorsRes.loading}
+								error={errorsRes.error}
+								data={errorsRes.data}
+								emptyText="No usage in selected period."
+							>
+								{errorsRes.data && errorsRes.data.length > 0 ? (
+									<div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+										{errorsRes.data.slice(0, 5).map(err => (
+											<div
+												key={err.id ?? `${err.sessionFile}-${err.entryId}`}
+												onClick={() => err.id && onRequestClick(err.id)}
+												style={{
+													display: "flex",
+													gap: 10,
+													padding: "9px 10px",
+													border: "1px solid var(--border)",
+													borderRadius: "var(--radius-md)",
+													background: "var(--surface-2)",
+													cursor: err.id ? "pointer" : undefined,
+												}}
+											>
+												<span
+													style={{
+														width: 7,
+														height: 7,
+														borderRadius: 999,
+														background: "var(--danger)",
+														marginTop: 6,
+														flexShrink: 0,
+													}}
+												/>
+												<div style={{ minWidth: 0, flex: 1 }}>
+													<div
+														style={{
+															fontSize: 12,
+															fontWeight: 600,
+															color: "var(--text)",
+															whiteSpace: "nowrap",
+															overflow: "hidden",
+															textOverflow: "ellipsis",
+														}}
+													>
+														{err.model}
+														<span
+															style={{
+																fontWeight: 400,
+																color: "var(--dim)",
+																fontFamily: "var(--font-mono)",
+																fontSize: 11,
+																marginLeft: 6,
+															}}
+														>
+															{err.provider}
+														</span>
+													</div>
+													<div
+														style={{
+															fontSize: 11,
+															color: "var(--danger)",
+															fontFamily: "var(--font-mono)",
+															whiteSpace: "nowrap",
+															overflow: "hidden",
+															textOverflow: "ellipsis",
+															marginTop: 2,
+														}}
+														title={err.errorMessage ?? ""}
+													>
+														{err.errorMessage ?? "Unknown error"}
+													</div>
+													<div
+														style={{
+															fontSize: 11,
+															color: "var(--dim)",
+															fontFamily: "var(--font-mono)",
+															marginTop: 2,
+														}}
+													>
+														{format(new Date(err.timestamp), "MMM d, HH:mm")} ·{" "}
+														{formatDurationMs(err.duration)}
+													</div>
+												</div>
+											</div>
+										))}
+									</div>
+								) : (
+									<div className="stats-empty-state-message">No usage in selected period.</div>
+								)}
+							</AsyncBoundary>
+						</Panel>
+					)}
+
+					{/* Operational feed compact */}
+					<Panel title="Live feed" subtitle="Newest requests">
 						<AsyncBoundary
-							loading={requestsLoading}
-							error={requestsError}
-							data={recentRequests}
+							loading={recentRes.loading}
+							error={recentRes.error}
+							data={recentRes.data}
 							fallback={
-								<div className="space-y-4">
-									{Array.from({ length: 5 }).map((_, i) => (
-										<div key={i} className="flex items-center gap-3">
-											<Skeleton variant="circle" width={10} height={10} />
-											<div className="flex-1">
-												<Skeleton variant="text" width="60%" height={16} />
-												<Skeleton variant="text" width="40%" height={12} />
+								<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+									{Array.from({ length: 4 }).map((_, i) => (
+										<div key={i} style={{ display: "flex", gap: 10, alignItems: "center" }}>
+											<Skeleton variant="circle" width={8} height={8} />
+											<div style={{ flex: 1 }}>
+												<Skeleton variant="text" width="60%" height={14} />
+												<Skeleton variant="text" width="40%" height={10} />
 											</div>
 										</div>
 									))}
 								</div>
 							}
 						>
-							<div className="stats-feed-ledger overflow-y-auto max-h-[280px] pr-2">
+							<div style={{ display: "flex", flexDirection: "column" }}>
 								{previewRequests.map(req => {
 									const isError = !!req.errorMessage;
 									return (
 										<div
-											key={req.id || `${req.sessionFile}-${req.entryId}`}
-											className="stats-feed-item flex items-start gap-3 p-2 rounded hover:bg-stats-surface-2 cursor-pointer transition-colors"
+											key={req.id ?? `${req.sessionFile}-${req.entryId}`}
 											onClick={() => req.id && onRequestClick(req.id)}
+											style={{
+												display: "flex",
+												gap: 10,
+												padding: "8px 2px",
+												borderBottom: "1px solid var(--border)",
+												cursor: req.id ? "pointer" : undefined,
+											}}
 										>
-											<div
-												className={`w-2 h-2 mt-1.5 rounded-full flex-shrink-0 ${
-													isError ? "bg-stats-danger" : "bg-stats-success"
-												}`}
+											<span
+												style={{
+													width: 6,
+													height: 6,
+													borderRadius: 999,
+													background: isError ? "var(--danger)" : "var(--success)",
+													marginTop: 7,
+													flexShrink: 0,
+												}}
 											/>
-											<div className="flex-1 min-w-0">
-												<div className="flex justify-between items-baseline gap-2">
-													<div className="stats-font-medium stats-text-primary text-sm truncate">
+											<div style={{ minWidth: 0, flex: 1 }}>
+												<div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
+													<span
+														style={{
+															fontSize: 12,
+															fontWeight: 600,
+															color: "var(--text)",
+															whiteSpace: "nowrap",
+															overflow: "hidden",
+															textOverflow: "ellipsis",
+														}}
+													>
 														{req.model}
-													</div>
-													<div className="stats-text-xs stats-text-muted whitespace-nowrap">
-														{formatRelativeTime(req.timestamp)}
-													</div>
+													</span>
+													<span
+														style={{
+															fontFamily: "var(--font-mono)",
+															fontSize: 11,
+															color: "var(--dim)",
+															flexShrink: 0,
+														}}
+													>
+														{format(new Date(req.timestamp), "HH:mm:ss")}
+													</span>
 												</div>
-												<div className="flex justify-between items-center text-xs stats-text-muted mt-0.5">
-													<div>{req.provider}</div>
-													<div>
-														{req.duration ? formatDurationMs(req.duration) : ""}{" "}
-														{req.usage.totalTokens > 0 ? `· ${formatMessageCost(req, 4)}` : ""}
-													</div>
+												<div
+													style={{
+														display: "flex",
+														justifyContent: "space-between",
+														gap: 8,
+														fontSize: 11,
+														color: "var(--muted)",
+													}}
+												>
+													<span
+														style={{
+															fontFamily: "var(--font-mono)",
+															whiteSpace: "nowrap",
+															overflow: "hidden",
+															textOverflow: "ellipsis",
+														}}
+													>
+														{req.provider}
+													</span>
+													<span
+														style={{
+															fontFamily: "var(--font-mono)",
+															fontVariantNumeric: "tabular-nums",
+															whiteSpace: "nowrap",
+														}}
+													>
+														{req.usage.totalTokens > 0
+															? `${formatCompact(req.usage.totalTokens)} tok`
+															: ""}{" "}
+														{req.usage.cost.total > 0
+															? `· ${formatEstimatedCost(req.usage.cost.total, 0, 2)}`
+															: ""}
+													</span>
 												</div>
-												{isError && (
-													<div className="text-xs text-stats-danger truncate mt-1">{req.errorMessage}</div>
-												)}
 											</div>
 										</div>
 									);
 								})}
 								{previewRequests.length === 0 && (
-									<div className="py-8 text-center stats-text-muted text-sm">No recent requests found</div>
+									<div className="stats-empty-state-message">No recent requests.</div>
 								)}
 							</div>
 						</AsyncBoundary>
@@ -317,26 +776,517 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 				</div>
 			</div>
 
+			{/* Token breakdown (4-way) */}
+			{v.tokens && (
+				<Panel
+					title="Token breakdown"
+					subtitle="Input · output · cache read · cache write — the conversation total"
+					actions={
+						<a
+							href={`#/costs?range=${range}`}
+							className="stats-button stats-button-ghost"
+							style={{ fontSize: 11 }}
+						>
+							Costs →
+						</a>
+					}
+				>
+					<AsyncBoundary loading={overviewRes.loading} error={overviewRes.error} data={overview}>
+						{overview ? (
+							<TokenBreakdownPanel stats={overview.overall} />
+						) : (
+							<div className="stats-empty-state-message">No usage in selected period.</div>
+						)}
+					</AsyncBoundary>
+				</Panel>
+			)}
+
+			{/* Agents */}
+			{v.agents && (
+				<Panel
+					title="Token usage by agent"
+					subtitle="Main · subagents · advisor — share of the displayed conversation total"
+					actions={
+						<a
+							href={`#/models?range=${range}`}
+							className="stats-button stats-button-ghost"
+							style={{ fontSize: 11 }}
+						>
+							Models →
+						</a>
+					}
+				>
+					<AsyncBoundary loading={overviewRes.loading} error={overviewRes.error} data={overview}>
+						{overview && <AgentTokenShare stats={overview.byAgentType} />}
+					</AsyncBoundary>
+				</Panel>
+			)}
+
+			{/* Models — share bars + input/output splits */}
+			{v.models && (
+				<Panel
+					title="Models"
+					subtitle="Share of requests + token mix per model · click through for detail"
+					actions={
+						<a
+							href={`#/models?range=${range}`}
+							className="stats-button stats-button-secondary"
+							style={{ fontSize: 11, padding: "5px 9px" }}
+						>
+							Open Models →
+						</a>
+					}
+				>
+					<AsyncBoundary loading={modelRes.loading} error={modelRes.error} data={modelRes.data}>
+						{modelRes.data && modelRes.data.byModel.length > 0 ? (
+							<ModelsMini
+								models={modelRes.data.byModel.slice(0, 6)}
+								totalRequests={overview?.overall.totalRequests ?? 0}
+							/>
+						) : (
+							<div className="stats-empty-state-message">No usage in selected period.</div>
+						)}
+					</AsyncBoundary>
+				</Panel>
+			)}
+
+			{/* Providers + Tools side-by-side */}
+			<div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+				{v.providers && (
+					<Panel
+						title="Providers"
+						subtitle="Cost and token share by provider"
+						actions={
+							<a
+								href={`#/providers?range=${range}`}
+								className="stats-button stats-button-ghost"
+								style={{ fontSize: 11 }}
+							>
+								Providers →
+							</a>
+						}
+					>
+						<AsyncBoundary loading={providerRes.loading} error={providerRes.error} data={providerRes.data}>
+							{providerRes.data && providerRes.data.providers.length > 0 ? (
+								<ProvidersMini providers={providerRes.data.providers.slice(0, 4)} />
+							) : (
+								<div className="stats-empty-state-message">No usage in selected period.</div>
+							)}
+						</AsyncBoundary>
+					</Panel>
+				)}
+				{v.tools && (
+					<Panel
+						title="Tools"
+						subtitle="Calls and error share · subagent + advisor attributed to caller"
+						actions={
+							<a
+								href={`#/tools?range=${range}`}
+								className="stats-button stats-button-ghost"
+								style={{ fontSize: 11 }}
+							>
+								Tools →
+							</a>
+						}
+					>
+						<AsyncBoundary loading={toolRes.loading} error={toolRes.error} data={toolRes.data}>
+							{toolRes.data && toolRes.data.byTool.length > 0 ? (
+								<ToolsMini
+									tools={toolRes.data.byTool.slice(0, 5)}
+									totalCalls={toolRes.data.byTool.reduce((s, t) => s + t.calls, 0)}
+								/>
+							) : (
+								<div className="stats-empty-state-message">No usage in selected period.</div>
+							)}
+						</AsyncBoundary>
+					</Panel>
+				)}
+			</div>
+
+			{/* Projects */}
+			{v.projects && (
+				<Panel
+					title="Projects"
+					subtitle="Requests per folder — where the agent spent its time"
+					actions={
+						<a
+							href={`#/projects?range=${range}`}
+							className="stats-button stats-button-ghost"
+							style={{ fontSize: 11 }}
+						>
+							Projects →
+						</a>
+					}
+				>
+					<AsyncBoundary loading={folderRes.loading} error={folderRes.error} data={folderRes.data}>
+						{folderRes.data && folderRes.data.length > 0 ? (
+							<ProjectsMini
+								folders={folderRes.data.slice(0, 6)}
+								totalRequests={overview?.overall.totalRequests ?? 0}
+							/>
+						) : (
+							<div className="stats-empty-state-message">No usage in selected period.</div>
+						)}
+					</AsyncBoundary>
+				</Panel>
+			)}
+
+			{/* Recent requests preview — tabular drilldown */}
 			<Panel
-				title="Recent Requests Preview"
-				subtitle="Latest transactions processed by the proxy"
+				title="Recent requests"
+				subtitle="Latest transactions · tap a row for detail"
 				actions={
-					<a href={`#/requests?range=${range}`} className="stats-button stats-button-secondary text-xs">
-						View All Requests
+					<a
+						href={`#/requests?range=${range}`}
+						className="stats-button stats-button-secondary"
+						style={{ fontSize: 11, padding: "5px 9px" }}
+					>
+						View all
 					</a>
 				}
 			>
-				<AsyncBoundary loading={requestsLoading} error={requestsError} data={recentRequests}>
+				<AsyncBoundary loading={recentRes.loading} error={recentRes.error} data={recentRes.data}>
 					<DataTable
-						columns={columns}
+						columns={columns as never}
 						data={previewRequests}
-						keyExtractor={item => item.id || `${item.sessionFile}-${item.entryId}`}
+						keyExtractor={item => String(item.id ?? `${item.sessionFile}-${item.entryId}`)}
 						onRowClick={item => item.id && onRequestClick(item.id)}
-						renderMobileCard={renderMobileCard}
-						emptyText="No recent requests found"
+						renderMobileCard={renderMobileCard as never}
+						emptyText="No usage in selected period."
 					/>
 				</AsyncBoundary>
 			</Panel>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Sub-panels (pure, per-widget)
+// ---------------------------------------------------------------------------
+
+function TokenBreakdownPanel({ stats }: { stats: AggregatedStats }) {
+	const total =
+		stats.totalInputTokens + stats.totalOutputTokens + stats.totalCacheReadTokens + stats.totalCacheWriteTokens;
+	const items = [
+		{
+			label: "Input",
+			value: stats.totalInputTokens,
+			color: "var(--tok-input)",
+			share: total ? stats.totalInputTokens / total : 0,
+		},
+		{
+			label: "Output",
+			value: stats.totalOutputTokens,
+			color: "var(--tok-output)",
+			share: total ? stats.totalOutputTokens / total : 0,
+		},
+		{
+			label: "Cache read",
+			value: stats.totalCacheReadTokens,
+			color: "var(--tok-read)",
+			share: total ? stats.totalCacheReadTokens / total : 0,
+		},
+		{
+			label: "Cache write",
+			value: stats.totalCacheWriteTokens,
+			color: "var(--tok-write)",
+			share: total ? stats.totalCacheWriteTokens / total : 0,
+		},
+	];
+	return (
+		<div className="stats-token-grid">
+			{items.map(it => (
+				<div key={it.label} className="stats-token-card">
+					<div className="stats-token-card-label">{it.label}</div>
+					<div className="stats-token-card-value">{formatCompact(it.value)}</div>
+					<div className="stats-token-card-share">
+						<div className="stats-token-bar">
+							<div
+								className="stats-token-bar-fill"
+								style={{ width: `${it.share * 100}%`, background: it.color }}
+							/>
+						</div>
+						<span className="stats-token-share-label">{formatPercent(it.share)}</span>
+					</div>
+				</div>
+			))}
+		</div>
+	);
+}
+
+function ModelsMini({ models, totalRequests }: { models: ModelStats[]; totalRequests: number }) {
+	return (
+		<div style={{ display: "flex", flexDirection: "column" }}>
+			{models.map((m, idx) => {
+				const share = totalRequests > 0 ? m.totalRequests / totalRequests : 0;
+				const tokens = m.totalInputTokens + m.totalOutputTokens + m.totalCacheReadTokens + m.totalCacheWriteTokens;
+				return (
+					<div key={`${m.model}-${m.provider}`} className="stats-model-row">
+						<span className="stats-model-rank">{String(idx + 1).padStart(2, "0")}</span>
+						<div className="stats-model-name">
+							<div className="stats-model-title">{m.model}</div>
+							<div className="stats-model-sub">{m.provider}</div>
+						</div>
+						<div className="stats-model-bar" title={`${formatPercent(share)} of requests`}>
+							<div className="stats-model-bar-fill" style={{ width: `${share * 100}%` }} />
+						</div>
+						<span className="stats-model-metric">{formatPercent(share)}</span>
+						<span className="stats-model-metric" title="Input · Output + cache">
+							<span style={{ color: "var(--dim)" }}>{formatCompact(m.totalInputTokens)}</span>
+							<span style={{ color: "var(--text)", marginLeft: 6 }}>{formatCompact(m.totalOutputTokens)}</span>
+						</span>
+						<span className="stats-model-metric" style={{ color: "var(--amber)", minWidth: 72 }}>
+							{formatEstimatedCost(m.totalCost, m.unpricedRequests, 2)}
+						</span>
+						<span
+							className="stats-model-metric"
+							style={{ color: "var(--dim)", minWidth: 48 }}
+							title="Conversation tokens"
+						>
+							{formatCompact(tokens)}
+						</span>
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+function ProvidersMini({ providers }: { providers: ProviderAggregate[] }) {
+	return (
+		<div className="stats-provider-grid">
+			{providers.map(p => {
+				const tokens = p.totalTokens;
+				const errorRate = p.totalRequests > 0 ? p.failedRequests / p.totalRequests : 0;
+				return (
+					<div key={p.provider} className="stats-provider-card">
+						<div className="stats-provider-head">
+							<span className="stats-provider-name">{p.provider}</span>
+							<span
+								className="stats-status-pill"
+								data-variant={errorRate > 0.05 ? "danger" : "success"}
+								style={{ fontSize: 10 }}
+							>
+								{formatPercent(errorRate)} err
+							</span>
+						</div>
+						<div
+							style={{
+								display: "flex",
+								gap: 10,
+								fontFamily: "var(--font-mono)",
+								fontSize: 11,
+								color: "var(--muted)",
+								fontVariantNumeric: "tabular-nums",
+							}}
+						>
+							<span>{formatInteger(p.totalRequests)} req</span>
+							<span>{formatCompact(tokens)} tok</span>
+						</div>
+						<div style={{ height: 4, borderRadius: 999, background: "var(--surface-3)", overflow: "hidden" }}>
+							<div style={{ width: "100%", height: "100%", background: "var(--link)", opacity: 0.9 }} />
+						</div>
+						<div
+							style={{
+								display: "flex",
+								justifyContent: "space-between",
+								alignItems: "center",
+								fontFamily: "var(--font-mono)",
+								fontSize: 11,
+							}}
+						>
+							<span style={{ color: "var(--amber)", fontWeight: 700 }}>
+								{formatEstimatedCost(p.totalCost, p.unpricedRequests, 2)}
+							</span>
+							<span style={{ color: "var(--dim)" }}>
+								{formatCompact(p.totalInputTokens)} in · {formatCompact(p.totalOutputTokens)} out
+							</span>
+						</div>
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+function ToolsMini({ tools, totalCalls }: { tools: ToolUsageStats[]; totalCalls: number }) {
+	return (
+		<div style={{ display: "flex", flexDirection: "column" }}>
+			{tools.map(t => {
+				const share = totalCalls > 0 ? t.calls / totalCalls : 0;
+				const errorRate = t.calls > 0 ? t.errors / t.calls : 0;
+				return (
+					<div
+						key={t.tool}
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: 10,
+							padding: "9px 0",
+							borderBottom: "1px solid var(--border)",
+						}}
+					>
+						<span
+							style={{
+								fontSize: 12,
+								fontWeight: 600,
+								color: "var(--text)",
+								minWidth: 0,
+								flex: 1,
+								whiteSpace: "nowrap",
+								overflow: "hidden",
+								textOverflow: "ellipsis",
+							}}
+						>
+							{t.tool}
+						</span>
+						<span
+							style={{
+								fontFamily: "var(--font-mono)",
+								fontSize: 11,
+								color: "var(--muted)",
+								minWidth: 52,
+								textAlign: "right",
+							}}
+						>
+							{formatInteger(t.calls)} calls
+						</span>
+						<span
+							style={{
+								fontFamily: "var(--font-mono)",
+								fontSize: 11,
+								color: errorRate > 0 ? "var(--danger)" : "var(--dim)",
+								minWidth: 44,
+								textAlign: "right",
+							}}
+						>
+							{formatPercent(errorRate)}
+						</span>
+						<div
+							style={{
+								width: 64,
+								height: 4,
+								borderRadius: 999,
+								background: "var(--surface-3)",
+								overflow: "hidden",
+								flexShrink: 0,
+							}}
+						>
+							<div
+								style={{
+									width: `${share * 100}%`,
+									height: "100%",
+									background: "var(--accent)",
+									borderRadius: 999,
+								}}
+							/>
+						</div>
+						<span
+							style={{
+								fontFamily: "var(--font-mono)",
+								fontSize: 11,
+								color: "var(--amber)",
+								minWidth: 56,
+								textAlign: "right",
+								fontVariantNumeric: "tabular-nums",
+							}}
+						>
+							{formatEstimatedCost(t.costShare, 0, 2)}
+						</span>
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+function ProjectsMini({ folders, totalRequests }: { folders: FolderStats[]; totalRequests: number }) {
+	return (
+		<div style={{ display: "flex", flexDirection: "column" }}>
+			{folders.map(f => {
+				const share = totalRequests > 0 ? f.totalRequests / totalRequests : 0;
+				const short = f.folder.split("/").pop() || f.folder;
+				return (
+					<div
+						key={f.folder}
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: 10,
+							padding: "8px 0",
+							borderBottom: "1px solid var(--border)",
+						}}
+					>
+						<span
+							style={{
+								fontFamily: "var(--font-mono)",
+								fontSize: 10,
+								color: "var(--dim)",
+								width: 22,
+								textAlign: "right",
+							}}
+						>
+							{formatPercent(share, 0)}
+						</span>
+						<div
+							style={{
+								width: 72,
+								height: 4,
+								borderRadius: 999,
+								background: "var(--surface-3)",
+								overflow: "hidden",
+								flexShrink: 0,
+							}}
+						>
+							<div
+								style={{
+									width: `${share * 100}%`,
+									height: "100%",
+									background: "var(--link)",
+									borderRadius: 999,
+								}}
+							/>
+						</div>
+						<span
+							title={f.folder}
+							style={{
+								fontSize: 12,
+								fontWeight: 500,
+								color: "var(--text)",
+								flex: 1,
+								minWidth: 0,
+								whiteSpace: "nowrap",
+								overflow: "hidden",
+								textOverflow: "ellipsis",
+							}}
+						>
+							{short}
+						</span>
+						<span
+							style={{
+								fontFamily: "var(--font-mono)",
+								fontSize: 11,
+								color: "var(--muted)",
+								minWidth: 48,
+								textAlign: "right",
+							}}
+						>
+							{formatInteger(f.totalRequests)} req
+						</span>
+						<span
+							style={{
+								fontFamily: "var(--font-mono)",
+								fontSize: 11,
+								color: "var(--amber)",
+								minWidth: 56,
+								textAlign: "right",
+							}}
+						>
+							{formatEstimatedCost(f.totalCost, f.unpricedRequests, 2)}
+						</span>
+					</div>
+				);
+			})}
 		</div>
 	);
 }

--- a/packages/stats/src/client/routes/OverviewRoute.tsx
+++ b/packages/stats/src/client/routes/OverviewRoute.tsx
@@ -1,5 +1,5 @@
 import { format } from "@oh-my-pi/pi-utils/dates";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Line } from "react-chartjs-2";
 import {
 	getFolderStats,
@@ -16,16 +16,22 @@ import { formatRangeTick } from "../components/range-meta";
 import { formatCompact, formatDurationMs, formatEstimatedCost, formatInteger, formatPercent } from "../data/formatters";
 import {
 	activeDaysFromSeries,
-	loadPrefs,
-	nextPrefsOnToggle,
+	createDashboard,
+	DASHBOARD_STORAGE_KEY,
+	type Dashboard,
+	type DashboardState,
+	deleteDashboard,
+	duplicateDashboard,
+	loadDashboardState,
 	type OverviewSectionKey,
-	PRESET_DEFS,
-	type PrefsState,
-	type PresetId,
-	prefsForPreset,
+	renameDashboard,
+	resetAllDashboards,
+	resetDashboard,
 	SECTION_LABELS,
 	SECTION_ORDER,
-	STORAGE_KEY,
+	saveDashboardState,
+	setActiveDashboard,
+	updateDashboardVisible,
 } from "../data/overview-prefs";
 import { useResource } from "../data/useResource";
 import type {
@@ -37,21 +43,18 @@ import type {
 	TimeRange,
 	ToolUsageStats,
 } from "../types";
-import { AsyncBoundary, DataTable, Panel, Skeleton, StatusPill } from "../ui";
+import { AsyncBoundary, DataTable, Skeleton, StatusPill } from "../ui";
 import { useSystemTheme } from "../useSystemTheme";
 
-function useOverviewPrefs() {
-	const [prefs, setPrefs] = useState<PrefsState>(() => loadPrefs());
+function useDashboardPrefs() {
+	const [state, setState] = useState(() => loadDashboardState());
 	useEffect(() => {
 		try {
-			localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
-		} catch {
-			// ignore quota
-		}
-	}, [prefs]);
-	const setPreset = (id: PresetId) => setPrefs(prefsForPreset(id));
-	const toggle = (key: OverviewSectionKey) => setPrefs(prev => nextPrefsOnToggle(prev, key));
-	return { prefs, setPreset, toggle };
+			localStorage.setItem(DASHBOARD_STORAGE_KEY, JSON.stringify(state));
+		} catch {}
+		saveDashboardState(state);
+	}, [state]);
+	return { state, setState } as const;
 }
 
 // ---------------------------------------------------------------------------
@@ -66,7 +69,15 @@ export interface OverviewRouteProps {
 }
 
 export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }: OverviewRouteProps) {
-	const { prefs, setPreset, toggle } = useOverviewPrefs();
+	const { state: dashState, setState: setDashState } = useDashboardPrefs();
+	const activeDash = useMemo(
+		() => dashState.dashboards.find(d => d.id === dashState.activeId) ?? dashState.dashboards[0],
+		[dashState],
+	);
+	const v = activeDash.visible;
+	const [newName, setNewName] = useState("");
+	const [renaming, setRenaming] = useState(false);
+	const [renameValue, setRenameValue] = useState("");
 
 	const overviewRes = useResource(["overview", range, refreshTrigger], s => getOverviewStats(range, s), {
 		enabled: active,
@@ -109,7 +120,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 	const chartColors = useMemo(() => {
 		const style =
 			typeof document !== "undefined" ? getComputedStyle(document.body) : (null as unknown as CSSStyleDeclaration);
-		const req = style?.getPropertyValue("--chart-req").trim() || "oklch(0.817 0.112 205)";
+		const req = style?.getPropertyValue("--chart-req").trim() || "oklch(0.68 0.015 307)";
 		const err = style?.getPropertyValue("--chart-err").trim() || "oklch(0.66 0.19 25)";
 		return { req, err };
 	}, [theme]);
@@ -125,7 +136,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 				borderColor: chartColors.req,
 				backgroundColor: `color-mix(in oklab, ${chartColors.req} 8%, transparent)`,
 				tension: 0.32,
-				borderWidth: 1.5,
+				borderWidth: 1.6,
 				pointRadius,
 				pointHoverRadius: 4,
 				fill: true,
@@ -146,6 +157,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 		}
 		return { labels, datasets };
 	}, [timeSeries, range, chartColors, hasChartErrors]);
+
 	const chartOptions = useMemo(
 		() => ({
 			responsive: true,
@@ -172,7 +184,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 					grid: { color: chartTheme.grid, drawBorder: false },
 					ticks: {
 						color: chartTheme.tick,
-						font: { size: 10, family: "ui-monospace" },
+						font: { size: 10, family: "var(--font-mono)" },
 						maxRotation: 0,
 						autoSkip: true,
 						maxTicksLimit: 8,
@@ -181,7 +193,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 				},
 				y: {
 					grid: { color: chartTheme.grid, drawBorder: false },
-					ticks: { color: chartTheme.tick, font: { size: 10 } },
+					ticks: { color: chartTheme.tick, font: { size: 10, family: "var(--font-mono)" } },
 					min: 0,
 					border: { display: false },
 				},
@@ -306,133 +318,38 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 	);
 
 	const previewRequests = useMemo(() => recentRes.data?.slice(0, 8) ?? [], [recentRes.data]);
-
-	const v = prefs.visible;
+	const showHealthBanner = (overview?.overall.errorRate ?? 0) > 0.05;
+	const toggle = (key: OverviewSectionKey) => setDashState(s => updateDashboardVisible(s, activeDash.id, key));
 
 	return (
-		<div className="stats-route-container space-y-4">
-			{/* Range-aware subtitle + preset bar */}
-			<div className="stats-overview-toolbar">
-				<div className="flex items-center gap-2 flex-wrap">
-					<span className="stats-panel-eyebrow" style={{ margin: 0 }}>
-						Overview
+		<div className="stats-route-container">
+			<div className="omp-hero">
+				<div className="omp-hero-head">
+					<h2 className="omp-hero-title">
+						Overview <span>{range === "today" ? "today · since midnight" : range}</span>
+					</h2>
+					<span className="omp-hero-range">
+						{overview?.overall
+							? `${formatInteger(overview.overall.totalRequests)} req · ${activeDays} active day${activeDays === 1 ? "" : "s"} · ${overview.timeSeries.length} buckets`
+							: `${range} · loading`}
 					</span>
-					<span
-						style={{
-							fontFamily: "var(--font-mono)",
-							fontSize: 11,
-							color: "var(--muted)",
-							background: "var(--surface)",
-							border: "1px solid var(--border)",
-							borderRadius: 2,
-							padding: "3px 8px",
-						}}
-					>
-						{range === "today" ? "today · since 00:00" : range}
-					</span>
-					{overview?.overall && (
-						<span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--dim)" }}>
-							· {formatInteger(overview.overall.totalRequests)} req
-							{activeDays > 0 ? ` · ${activeDays} active day${activeDays === 1 ? "" : "s"}` : ""}
-						</span>
-					)}
 				</div>
 
-				<div className="flex items-center gap-2 flex-wrap">
-					<div className="stats-preset-group" role="group" aria-label="Overview preset">
-						{(Object.keys(PRESET_DEFS) as PresetId[]).map(pid => (
-							<button
-								key={pid}
-								type="button"
-								className="stats-preset-btn"
-								data-active={prefs.preset === pid ? "true" : "false"}
-								onClick={() => setPreset(pid)}
-							>
-								{PRESET_DEFS[pid].label}
-							</button>
-						))}
-					</div>
-					<details className="group" style={{ position: "relative" }}>
-						<summary
-							className="stats-button stats-button-ghost"
-							style={{
-								listStyle: "none",
-								cursor: "pointer",
-								fontFamily: "var(--font-mono)",
-								fontSize: 11,
-								padding: "5px 10px",
-							}}
-						>
-							Customize ▾
-						</summary>
-						<div
-							className="stats-panel"
-							style={{
-								position: "absolute",
-								right: 0,
-								top: "calc(100% + 8px)",
-								width: 260,
-								zIndex: 5,
-								boxShadow: "0 12px 32px rgba(0,0,0,0.28)",
-							}}
-						>
-							<div className="stats-panel-header" style={{ padding: "10px 12px" }}>
-								<span
-									className="stats-panel-title"
-									style={{
-										fontSize: 11,
-										fontFamily: "var(--font-mono)",
-										letterSpacing: "0.06em",
-										textTransform: "uppercase",
-									}}
-								>
-									Visible sections
-								</span>
-							</div>
-							<div style={{ padding: 10, display: "flex", flexDirection: "column", gap: 6 }}>
-								{SECTION_ORDER.map(key => (
-									<label
-										key={key}
-										className="stats-customize-chip"
-										data-on={v[key] ? "true" : "false"}
-										style={{ justifyContent: "space-between", cursor: "pointer" }}
-									>
-										<span>{SECTION_LABELS[key]}</span>
-										<input
-											type="checkbox"
-											checked={v[key]}
-											onChange={() => toggle(key)}
-											style={{ width: 14, height: 14 }}
-										/>
-									</label>
-								))}
-								<div
-									style={{ fontSize: 11, color: "var(--dim)", fontFamily: "var(--font-mono)", marginTop: 4 }}
-								>
-									Persisted in localStorage · {STORAGE_KEY}
-								</div>
-							</div>
-						</div>
-					</details>
-				</div>
-			</div>
-
-			{/* KPI Tape */}
-			{v.tape && (
 				<AsyncBoundary loading={overviewRes.loading} error={overviewRes.error} data={overview}>
 					{overview && (
-						<div className="stats-overview-tape" role="region" aria-label="Key metrics">
-							<div className="stats-tape-cell" style={{ ["--tape-accent" as string]: "var(--accent)" }}>
-								<div className="stats-tape-label">Requests</div>
-								<div className="stats-tape-value">{formatInteger(overview.overall.totalRequests)}</div>
-								<div className="stats-tape-sub">
+						<div className="omp-metrics-herd" role="region" aria-label="Key metrics">
+							<div className="omp-kpi">
+								<div className="omp-kpi-label">Requests</div>
+								<div className="omp-kpi-value">{formatInteger(overview.overall.totalRequests)}</div>
+								<div className="omp-kpi-sub">
 									{formatInteger(overview.overall.successfulRequests)} ok ·{" "}
 									{formatInteger(overview.overall.failedRequests)} fail
 								</div>
+								<div className="omp-kpi-accent" />
 							</div>
-							<div className="stats-tape-cell" style={{ ["--tape-accent" as string]: "var(--link)" }}>
-								<div className="stats-tape-label">Conversation tokens</div>
-								<div className="stats-tape-value">
+							<div className="omp-kpi">
+								<div className="omp-kpi-label">Conversation tokens</div>
+								<div className="omp-kpi-value" data-mono="true">
 									{formatCompact(
 										overview.overall.totalInputTokens +
 											overview.overall.totalOutputTokens +
@@ -440,82 +357,134 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 											overview.overall.totalCacheWriteTokens,
 									)}
 								</div>
-								<div className="stats-tape-sub">
+								<div className="omp-kpi-sub">
 									in {formatCompact(overview.overall.totalInputTokens)} · out{" "}
 									{formatCompact(overview.overall.totalOutputTokens)}
 								</div>
+								<div className="omp-kpi-accent" />
 							</div>
-							<div className="stats-tape-cell" style={{ ["--tape-accent" as string]: "var(--amber)" }}>
-								<div className="stats-tape-label">Est. cost</div>
-								<div className="stats-tape-value" style={{ color: "var(--amber)" }}>
+							<div className="omp-kpi">
+								<div className="omp-kpi-label">Est. cost</div>
+								<div className="omp-kpi-value" data-mono="true" style={{ color: "var(--amber)" }}>
 									{formatEstimatedCost(
 										overview.overall.totalCost,
 										overview.overall.unpricedRequests,
 										overview.overall.totalCost > 0 && overview.overall.totalCost < 0.01 ? 4 : 2,
 									)}
 								</div>
-								<div className="stats-tape-sub">
+								<div className="omp-kpi-sub">
 									{overview.overall.unpricedRequests > 0
 										? `${overview.overall.unpricedRequests} unpriced`
 										: "API-equivalent"}
 								</div>
+								<div className="omp-kpi-accent" />
 							</div>
-							<div
-								className="stats-tape-cell"
-								style={{
-									["--tape-accent" as string]:
-										overview.overall.errorRate > 0.05 ? "var(--danger)" : "var(--success)",
-								}}
-							>
-								<div className="stats-tape-label">Error rate</div>
-								<div className="stats-tape-value">{formatPercent(overview.overall.errorRate)}</div>
-								<div className="stats-tape-sub">
-									<span
-										className="stats-tape-badge"
-										data-tone={overview.overall.errorRate > 0.05 ? "danger" : "success"}
-									>
-										{overview.overall.failedRequests} errors
-									</span>
+							<div className="omp-kpi" data-tone={overview.overall.errorRate > 0.05 ? "danger" : "success"}>
+								<div className="omp-kpi-label">Error rate</div>
+								<div className="omp-kpi-value" data-mono="true">
+									{formatPercent(overview.overall.errorRate)}
 								</div>
-							</div>
-							<div className="stats-tape-cell" style={{ ["--tape-accent" as string]: "var(--success)" }}>
-								<div className="stats-tape-label">Cache rate</div>
-								<div className="stats-tape-value">{formatPercent(overview.overall.cacheRate)}</div>
-								<div className="stats-tape-sub">savings {formatPercent(overview.overall.cacheSavings)}</div>
-							</div>
-							<div className="stats-tape-cell" style={{ ["--tape-accent" as string]: "var(--dim)" }}>
-								<div className="stats-tape-label">Active days</div>
-								<div className="stats-tape-value">{activeDays}</div>
-								<div className="stats-tape-sub">
-									{overview.timeSeries.length} buckets · {range === "today" ? "since midnight" : range}
+								<div className="omp-kpi-sub">
+									{formatInteger(overview.overall.failedRequests)} errors ·{" "}
+									{formatPercent(1 - overview.overall.errorRate)} ok
 								</div>
+								<div className="omp-kpi-accent" />
+							</div>
+							<div className="omp-kpi" data-tone="success">
+								<div className="omp-kpi-label">Cache efficiency</div>
+								<div className="omp-kpi-value" data-mono="true">
+									{formatPercent(overview.overall.cacheRate)}
+								</div>
+								<div className="omp-kpi-sub">savings {formatPercent(overview.overall.cacheSavings)}</div>
+								<div className="omp-kpi-accent" />
 							</div>
 						</div>
 					)}
 				</AsyncBoundary>
-			)}
 
-			{/* Scope row: oscilloscope chart + errors/feed */}
-			<div className="stats-overview-grid">
-				{v.scope && (
-					<div className="stats-scope-wrap">
-						<div className="stats-scope-grid" aria-hidden />
-						<div className="stats-scope-header">
-							<div className="stats-scope-title">
-								<span className="stats-scope-dot" aria-hidden />
-								Usage over time
+				{showHealthBanner && (
+					<div
+						style={{
+							display: "flex",
+							gap: 10,
+							alignItems: "center",
+							padding: "9px 12px",
+							background: "color-mix(in oklch, var(--danger) 10%, var(--surface))",
+							border: "1px solid color-mix(in oklch, var(--danger) 18%, transparent)",
+							borderRadius: "var(--radius-md)",
+							fontFamily: "var(--font-sans)",
+							fontSize: 12,
+							color: "var(--danger)",
+						}}
+					>
+						<span
+							style={{
+								width: 7,
+								height: 7,
+								borderRadius: 999,
+								background: "var(--danger)",
+								display: "inline-block",
+							}}
+						/>
+						Elevated error rate — {formatPercent(overview!.overall.errorRate)} ·{" "}
+						{formatInteger(overview!.overall.failedRequests)} failures in this window.{" "}
+						<a href="#/errors?range=today" style={{ color: "var(--danger)", textDecoration: "underline" }}>
+							Inspect errors
+						</a>
+					</div>
+				)}
+			</div>
+
+			<div className="omp-dashboard-bar" style={{ position: "relative" }}>
+				<div className="omp-dashboard-tabs" role="tablist" aria-label="Dashboards">
+					{dashState.dashboards.map(d => (
+						<button
+							key={d.id}
+							type="button"
+							role="tab"
+							aria-selected={d.id === activeDash.id}
+							className="omp-dashboard-tab"
+							data-active={d.id === activeDash.id ? "true" : "false"}
+							onClick={() => setDashState(s => setActiveDashboard(s, d.id))}
+						>
+							{d.name}
+						</button>
+					))}
+				</div>
+				<ManageDisclosure
+					newName={newName}
+					setNewName={setNewName}
+					renaming={renaming}
+					renameValue={renameValue}
+					setRenameValue={setRenameValue}
+					setRenaming={setRenaming}
+					activeDash={activeDash}
+					dashState={dashState}
+					setDashState={setDashState}
+					v={v}
+					toggle={toggle}
+				/>
+			</div>
+
+			{v.scope && (
+				<div className="omp-scope-wrap">
+					<div className="omp-scope-main">
+						<div className="omp-scope-header">
+							<div className="omp-scope-title">
+								<span className="omp-scope-dot" aria-hidden />
+								Usage over time{" "}
 								<span
 									style={{
 										fontFamily: "var(--font-mono)",
 										fontSize: 11,
 										color: "var(--muted)",
-										fontWeight: 500,
+										fontWeight: 400,
 									}}
 								>
 									{range === "today" ? "today" : range} · {timeSeries?.length ?? 0} buckets
 								</span>
 							</div>
-							<div className="stats-scope-legend" aria-hidden>
+							<div className="omp-scope-legend" aria-hidden>
 								<span>
 									<i style={{ background: "var(--chart-req)" }} /> req
 								</span>
@@ -526,262 +495,307 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 								)}
 							</div>
 						</div>
-						<div
-							className="stats-scope-body"
-							style={{
-								flex: 1,
-								minHeight: 272,
-								maxHeight: 480,
-								display: "flex",
-								flexDirection: "column",
-							}}
-						>
+						<div className="omp-scope-body">
 							<AsyncBoundary loading={overviewRes.loading} error={overviewRes.error} data={overview}>
 								{timeSeries && timeSeries.length > 0 ? (
 									<Line data={chartData as never} options={chartOptions as never} />
 								) : (
 									<div
-										className="h-full flex items-center justify-center"
-										style={{ color: "var(--muted)", fontFamily: "var(--font-mono)", fontSize: 12 }}
+										style={{
+											height: 220,
+											display: "grid",
+											placeItems: "center",
+											color: "var(--muted)",
+											fontFamily: "var(--font-mono)",
+											fontSize: 12,
+											border: "1px dashed var(--border)",
+											borderRadius: "var(--radius-md)",
+											background: "var(--surface-2)",
+										}}
 									>
-										No usage in selected period.
+										<div style={{ textAlign: "center" }}>
+											<div
+												style={{
+													fontFamily: "var(--font-sans)",
+													fontSize: 12,
+													fontWeight: 600,
+													color: "var(--text)",
+												}}
+											>
+												No usage in this window
+											</div>
+											<div style={{ fontSize: 11, marginTop: 4 }}>
+												Try a broader range or sync — this chart answers “when was OMP most active?”
+											</div>
+										</div>
 									</div>
 								)}
 							</AsyncBoundary>
 						</div>
 					</div>
-				)}
-
-				<div className="stats-overview-stack">
-					{v.errors && (
-						<Panel
-							title="Recent errors"
-							subtitle="Latest failures in this window"
-							actions={
-								<a
-									href={`#/errors?range=${range}`}
-									className="stats-button stats-button-secondary"
-									style={{ fontSize: 11, padding: "5px 9px" }}
-								>
-									View all →
-								</a>
-							}
-						>
-							<AsyncBoundary
-								loading={errorsRes.loading}
-								error={errorsRes.error}
-								data={errorsRes.data}
-								emptyText="No usage in selected period."
+					<div className="omp-scope-side">
+						{v.errors && (
+							<div
+								className="omp-section"
+								style={{
+									background: "var(--surface)",
+									border: "1px solid var(--border)",
+									borderRadius: "var(--radius-lg)",
+									padding: 12,
+								}}
 							>
-								{errorsRes.data && errorsRes.data.length > 0 ? (
-									<div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-										{errorsRes.data.slice(0, 5).map(err => (
-											<div
-												key={err.id ?? `${err.sessionFile}-${err.entryId}`}
-												onClick={() => err.id && onRequestClick(err.id)}
-												style={{
-													display: "flex",
-													gap: 10,
-													padding: "9px 10px",
-													border: "1px solid var(--border)",
-													borderRadius: "var(--radius-md)",
-													background: "var(--surface-2)",
-													cursor: err.id ? "pointer" : undefined,
-												}}
-											>
-												<span
-													style={{
-														width: 7,
-														height: 7,
-														borderRadius: 999,
-														background: "var(--danger)",
-														marginTop: 6,
-														flexShrink: 0,
-													}}
-												/>
-												<div style={{ minWidth: 0, flex: 1 }}>
+								<div className="omp-section-head">
+									<div>
+										<div className="omp-section-title">Health · Recent errors</div>
+										<p className="omp-section-desc">Latest failures — only prominent when unhealthy</p>
+									</div>
+									<a
+										href={`#/errors?range=${range}`}
+										className="stats-button stats-button-secondary"
+										style={{ fontSize: 11, padding: "5px 9px" }}
+									>
+										View all →
+									</a>
+								</div>
+								<div className="omp-section-rule" />
+								<div className="omp-section-body">
+									<AsyncBoundary
+										loading={errorsRes.loading}
+										error={errorsRes.error}
+										data={errorsRes.data}
+										emptyText="No usage in selected period."
+									>
+										{errorsRes.data && errorsRes.data.length > 0 ? (
+											<div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+												{errorsRes.data.slice(0, 5).map(err => (
 													<div
+														key={err.id ?? `${err.sessionFile}-${err.entryId}`}
+														onClick={() => err.id && onRequestClick(err.id)}
 														style={{
-															fontSize: 12,
-															fontWeight: 600,
-															color: "var(--text)",
-															whiteSpace: "nowrap",
-															overflow: "hidden",
-															textOverflow: "ellipsis",
+															display: "flex",
+															gap: 10,
+															padding: "8px 10px",
+															border: "1px solid var(--border)",
+															borderRadius: "var(--radius-md)",
+															background: "var(--surface-2)",
+															cursor: err.id ? "pointer" : undefined,
 														}}
 													>
-														{err.model}
 														<span
 															style={{
-																fontWeight: 400,
-																color: "var(--dim)",
-																fontFamily: "var(--font-mono)",
-																fontSize: 11,
-																marginLeft: 6,
+																width: 7,
+																height: 7,
+																borderRadius: 999,
+																background: "var(--danger)",
+																marginTop: 6,
+																flexShrink: 0,
 															}}
-														>
-															{err.provider}
-														</span>
+														/>
+														<div style={{ minWidth: 0, flex: 1 }}>
+															<div
+																style={{
+																	fontSize: 12,
+																	fontWeight: 600,
+																	color: "var(--text)",
+																	whiteSpace: "nowrap",
+																	overflow: "hidden",
+																	textOverflow: "ellipsis",
+																}}
+															>
+																{err.model}
+																<span
+																	style={{
+																		fontWeight: 400,
+																		color: "var(--dim)",
+																		fontFamily: "var(--font-mono)",
+																		fontSize: 11,
+																		marginLeft: 6,
+																	}}
+																>
+																	{err.provider}
+																</span>
+															</div>
+															<div
+																style={{
+																	fontSize: 11,
+																	color: "var(--danger)",
+																	fontFamily: "var(--font-mono)",
+																	whiteSpace: "nowrap",
+																	overflow: "hidden",
+																	textOverflow: "ellipsis",
+																	marginTop: 2,
+																}}
+																title={err.errorMessage ?? ""}
+															>
+																{err.errorMessage ?? "Unknown error"}
+															</div>
+															<div
+																style={{
+																	fontSize: 11,
+																	color: "var(--dim)",
+																	fontFamily: "var(--font-mono)",
+																	marginTop: 2,
+																}}
+															>
+																{format(new Date(err.timestamp), "MMM d, HH:mm")} ·{" "}
+																{formatDurationMs(err.duration)}
+															</div>
+														</div>
 													</div>
-													<div
-														style={{
-															fontSize: 11,
-															color: "var(--danger)",
-															fontFamily: "var(--font-mono)",
-															whiteSpace: "nowrap",
-															overflow: "hidden",
-															textOverflow: "ellipsis",
-															marginTop: 2,
-														}}
-														title={err.errorMessage ?? ""}
-													>
-														{err.errorMessage ?? "Unknown error"}
-													</div>
-													<div
-														style={{
-															fontSize: 11,
-															color: "var(--dim)",
-															fontFamily: "var(--font-mono)",
-															marginTop: 2,
-														}}
-													>
-														{format(new Date(err.timestamp), "MMM d, HH:mm")} ·{" "}
-														{formatDurationMs(err.duration)}
-													</div>
-												</div>
+												))}
 											</div>
-										))}
-									</div>
-								) : (
-									<div className="stats-empty-state-message">No usage in selected period.</div>
-								)}
-							</AsyncBoundary>
-						</Panel>
-					)}
-
-					{/* Operational feed compact */}
-					<Panel title="Live feed" subtitle="Newest requests">
-						<AsyncBoundary
-							loading={recentRes.loading}
-							error={recentRes.error}
-							data={recentRes.data}
-							fallback={
-								<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-									{Array.from({ length: 4 }).map((_, i) => (
-										<div key={i} style={{ display: "flex", gap: 10, alignItems: "center" }}>
-											<Skeleton variant="circle" width={8} height={8} />
-											<div style={{ flex: 1 }}>
-												<Skeleton variant="text" width="60%" height={14} />
-												<Skeleton variant="text" width="40%" height={10} />
+										) : (
+											<div className="stats-empty-state-message">
+												No failures — system healthy in this window.
 											</div>
-										</div>
-									))}
+										)}
+									</AsyncBoundary>
 								</div>
-							}
+							</div>
+						)}
+						<div
+							className="omp-section"
+							style={{
+								background: "var(--surface)",
+								border: "1px solid var(--border)",
+								borderRadius: "var(--radius-lg)",
+								padding: 12,
+							}}
 						>
-							<div style={{ display: "flex", flexDirection: "column" }}>
-								{previewRequests.map(req => {
-									const isError = !!req.errorMessage;
-									return (
-										<div
-											key={req.id ?? `${req.sessionFile}-${req.entryId}`}
-											onClick={() => req.id && onRequestClick(req.id)}
-											style={{
-												display: "flex",
-												gap: 10,
-												padding: "8px 2px",
-												borderBottom: "1px solid var(--border)",
-												cursor: req.id ? "pointer" : undefined,
-											}}
-										>
-											<span
-												style={{
-													width: 6,
-													height: 6,
-													borderRadius: 999,
-													background: isError ? "var(--danger)" : "var(--success)",
-													marginTop: 7,
-													flexShrink: 0,
-												}}
-											/>
-											<div style={{ minWidth: 0, flex: 1 }}>
-												<div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
-													<span
-														style={{
-															fontSize: 12,
-															fontWeight: 600,
-															color: "var(--text)",
-															whiteSpace: "nowrap",
-															overflow: "hidden",
-															textOverflow: "ellipsis",
-														}}
-													>
-														{req.model}
-													</span>
-													<span
-														style={{
-															fontFamily: "var(--font-mono)",
-															fontSize: 11,
-															color: "var(--dim)",
-															flexShrink: 0,
-														}}
-													>
-														{format(new Date(req.timestamp), "HH:mm:ss")}
-													</span>
+							<div className="omp-section-head">
+								<div>
+									<div className="omp-section-title">Live feed</div>
+									<p className="omp-section-desc">Newest requests</p>
+								</div>
+							</div>
+							<div className="omp-section-rule" />
+							<div className="omp-section-body">
+								<AsyncBoundary
+									loading={recentRes.loading}
+									error={recentRes.error}
+									data={recentRes.data}
+									fallback={
+										<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+											{Array.from({ length: 4 }).map((_, i) => (
+												<div key={i} style={{ display: "flex", gap: 10, alignItems: "center" }}>
+													<Skeleton variant="circle" width={8} height={8} />
+													<div style={{ flex: 1 }}>
+														<Skeleton variant="text" width="60%" height={14} />
+														<Skeleton variant="text" width="40%" height={10} />
+													</div>
 												</div>
+											))}
+										</div>
+									}
+								>
+									<div style={{ display: "flex", flexDirection: "column" }}>
+										{previewRequests.map(req => {
+											const isError = !!req.errorMessage;
+											return (
 												<div
+													key={req.id ?? `${req.sessionFile}-${req.entryId}`}
+													onClick={() => req.id && onRequestClick(req.id)}
 													style={{
 														display: "flex",
-														justifyContent: "space-between",
-														gap: 8,
-														fontSize: 11,
-														color: "var(--muted)",
+														gap: 10,
+														padding: "8px 2px",
+														borderBottom: "1px solid var(--border)",
+														cursor: req.id ? "pointer" : undefined,
 													}}
 												>
 													<span
 														style={{
-															fontFamily: "var(--font-mono)",
-															whiteSpace: "nowrap",
-															overflow: "hidden",
-															textOverflow: "ellipsis",
+															width: 6,
+															height: 6,
+															borderRadius: 999,
+															background: isError ? "var(--danger)" : "var(--success)",
+															marginTop: 7,
+															flexShrink: 0,
 														}}
-													>
-														{req.provider}
-													</span>
-													<span
-														style={{
-															fontFamily: "var(--font-mono)",
-															fontVariantNumeric: "tabular-nums",
-															whiteSpace: "nowrap",
-														}}
-													>
-														{req.usage.totalTokens > 0
-															? `${formatCompact(req.usage.totalTokens)} tok`
-															: ""}{" "}
-														{req.usage.cost.total > 0
-															? `· ${formatEstimatedCost(req.usage.cost.total, 0, 2)}`
-															: ""}
-													</span>
+													/>
+													<div style={{ minWidth: 0, flex: 1 }}>
+														<div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
+															<span
+																style={{
+																	fontSize: 12,
+																	fontWeight: 600,
+																	color: "var(--text)",
+																	whiteSpace: "nowrap",
+																	overflow: "hidden",
+																	textOverflow: "ellipsis",
+																}}
+															>
+																{req.model}
+															</span>
+															<span
+																style={{
+																	fontFamily: "var(--font-mono)",
+																	fontSize: 11,
+																	color: "var(--dim)",
+																	flexShrink: 0,
+																}}
+															>
+																{format(new Date(req.timestamp), "HH:mm:ss")}
+															</span>
+														</div>
+														<div
+															style={{
+																display: "flex",
+																justifyContent: "space-between",
+																gap: 8,
+																fontSize: 11,
+																color: "var(--muted)",
+															}}
+														>
+															<span
+																style={{
+																	fontFamily: "var(--font-mono)",
+																	whiteSpace: "nowrap",
+																	overflow: "hidden",
+																	textOverflow: "ellipsis",
+																}}
+															>
+																{req.provider}
+															</span>
+															<span
+																style={{
+																	fontFamily: "var(--font-mono)",
+																	fontVariantNumeric: "tabular-nums",
+																	whiteSpace: "nowrap",
+																}}
+															>
+																{req.usage.totalTokens > 0
+																	? `${formatCompact(req.usage.totalTokens)} tok`
+																	: ""}{" "}
+																{req.usage.cost.total > 0
+																	? `· ${formatEstimatedCost(req.usage.cost.total, 0, 2)}`
+																	: ""}
+															</span>
+														</div>
+													</div>
 												</div>
-											</div>
-										</div>
-									);
-								})}
-								{previewRequests.length === 0 && (
-									<div className="stats-empty-state-message">No recent requests.</div>
-								)}
+											);
+										})}
+										{previewRequests.length === 0 && (
+											<div className="stats-empty-state-message">No recent requests.</div>
+										)}
+									</div>
+								</AsyncBoundary>
 							</div>
-						</AsyncBoundary>
-					</Panel>
+						</div>
+					</div>
 				</div>
-			</div>
+			)}
 
-			{/* Token breakdown (4-way) */}
 			{v.tokens && (
-				<Panel
-					title="Token breakdown"
-					subtitle="Input · output · cache read · cache write — the conversation total"
-					actions={
+				<div className="omp-section">
+					<div className="omp-section-head">
+						<div>
+							<div className="omp-section-title">Token breakdown</div>
+							<p className="omp-section-desc">
+								Input · output · cache read · cache write — the conversation total
+							</p>
+						</div>
 						<a
 							href={`#/costs?range=${range}`}
 							className="stats-button stats-button-ghost"
@@ -789,24 +803,29 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 						>
 							Costs →
 						</a>
-					}
-				>
-					<AsyncBoundary loading={overviewRes.loading} error={overviewRes.error} data={overview}>
-						{overview ? (
-							<TokenBreakdownPanel stats={overview.overall} />
-						) : (
-							<div className="stats-empty-state-message">No usage in selected period.</div>
-						)}
-					</AsyncBoundary>
-				</Panel>
+					</div>
+					<div className="omp-section-rule" />
+					<div className="omp-section-body">
+						<AsyncBoundary loading={overviewRes.loading} error={overviewRes.error} data={overview}>
+							{overview ? (
+								<TokenBreakdownPanel stats={overview.overall} />
+							) : (
+								<div className="stats-empty-state-message">No usage in selected period.</div>
+							)}
+						</AsyncBoundary>
+					</div>
+				</div>
 			)}
 
-			{/* Agents */}
 			{v.agents && (
-				<Panel
-					title="Token usage by agent"
-					subtitle="Main · subagents · advisor — share of the displayed conversation total"
-					actions={
+				<div className="omp-section">
+					<div className="omp-section-head">
+						<div>
+							<div className="omp-section-title">Token usage by agent</div>
+							<p className="omp-section-desc">
+								Main · subagents · advisor — share of the displayed conversation total
+							</p>
+						</div>
 						<a
 							href={`#/models?range=${range}`}
 							className="stats-button stats-button-ghost"
@@ -814,20 +833,25 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 						>
 							Models →
 						</a>
-					}
-				>
-					<AsyncBoundary loading={overviewRes.loading} error={overviewRes.error} data={overview}>
-						{overview && <AgentTokenShare stats={overview.byAgentType} />}
-					</AsyncBoundary>
-				</Panel>
+					</div>
+					<div className="omp-section-rule" />
+					<div className="omp-section-body">
+						<AsyncBoundary loading={overviewRes.loading} error={overviewRes.error} data={overview}>
+							{overview && <AgentTokenShare stats={overview.byAgentType} />}
+						</AsyncBoundary>
+					</div>
+				</div>
 			)}
 
-			{/* Models — share bars + input/output splits */}
 			{v.models && (
-				<Panel
-					title="Models"
-					subtitle="Share of requests + token mix per model · click through for detail"
-					actions={
+				<div className="omp-section">
+					<div className="omp-section-head">
+						<div>
+							<div className="omp-section-title">Models — share of requests</div>
+							<p className="omp-section-desc">
+								Ranked by volume · input/output split · click through for detail
+							</p>
+						</div>
 						<a
 							href={`#/models?range=${range}`}
 							className="stats-button stats-button-secondary"
@@ -835,28 +859,39 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 						>
 							Open Models →
 						</a>
-					}
-				>
-					<AsyncBoundary loading={modelRes.loading} error={modelRes.error} data={modelRes.data}>
-						{modelRes.data && modelRes.data.byModel.length > 0 ? (
-							<ModelsMini
-								models={modelRes.data.byModel.slice(0, 6)}
-								totalRequests={overview?.overall.totalRequests ?? 0}
-							/>
-						) : (
-							<div className="stats-empty-state-message">No usage in selected period.</div>
-						)}
-					</AsyncBoundary>
-				</Panel>
+					</div>
+					<div className="omp-section-rule" />
+					<div className="omp-section-body">
+						<AsyncBoundary loading={modelRes.loading} error={modelRes.error} data={modelRes.data}>
+							{modelRes.data && modelRes.data.byModel.length > 0 ? (
+								<ModelsMini
+									models={modelRes.data.byModel.slice(0, 6)}
+									totalRequests={overview?.overall.totalRequests ?? 0}
+								/>
+							) : (
+								<div className="stats-empty-state-message">No usage in selected period.</div>
+							)}
+						</AsyncBoundary>
+					</div>
+				</div>
 			)}
 
-			{/* Providers + Tools side-by-side */}
-			<div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+			<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
 				{v.providers && (
-					<Panel
-						title="Providers"
-						subtitle="Cost and token share by provider"
-						actions={
+					<div
+						className="omp-section"
+						style={{
+							background: "var(--surface)",
+							border: "1px solid var(--border)",
+							borderRadius: "var(--radius-lg)",
+							padding: 14,
+						}}
+					>
+						<div className="omp-section-head">
+							<div>
+								<div className="omp-section-title">Providers</div>
+								<p className="omp-section-desc">Cost and token share</p>
+							</div>
 							<a
 								href={`#/providers?range=${range}`}
 								className="stats-button stats-button-ghost"
@@ -864,22 +899,34 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 							>
 								Providers →
 							</a>
-						}
-					>
-						<AsyncBoundary loading={providerRes.loading} error={providerRes.error} data={providerRes.data}>
-							{providerRes.data && providerRes.data.providers.length > 0 ? (
-								<ProvidersMini providers={providerRes.data.providers.slice(0, 4)} />
-							) : (
-								<div className="stats-empty-state-message">No usage in selected period.</div>
-							)}
-						</AsyncBoundary>
-					</Panel>
+						</div>
+						<div className="omp-section-rule" />
+						<div className="omp-section-body">
+							<AsyncBoundary loading={providerRes.loading} error={providerRes.error} data={providerRes.data}>
+								{providerRes.data && providerRes.data.providers.length > 0 ? (
+									<ProvidersMini providers={providerRes.data.providers.slice(0, 4)} />
+								) : (
+									<div className="stats-empty-state-message">No usage in selected period.</div>
+								)}
+							</AsyncBoundary>
+						</div>
+					</div>
 				)}
 				{v.tools && (
-					<Panel
-						title="Tools"
-						subtitle="Calls and error share · subagent + advisor attributed to caller"
-						actions={
+					<div
+						className="omp-section"
+						style={{
+							background: "var(--surface)",
+							border: "1px solid var(--border)",
+							borderRadius: "var(--radius-lg)",
+							padding: 14,
+						}}
+					>
+						<div className="omp-section-head">
+							<div>
+								<div className="omp-section-title">Tools</div>
+								<p className="omp-section-desc">Calls and error share</p>
+							</div>
 							<a
 								href={`#/tools?range=${range}`}
 								className="stats-button stats-button-ghost"
@@ -887,28 +934,31 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 							>
 								Tools →
 							</a>
-						}
-					>
-						<AsyncBoundary loading={toolRes.loading} error={toolRes.error} data={toolRes.data}>
-							{toolRes.data && toolRes.data.byTool.length > 0 ? (
-								<ToolsMini
-									tools={toolRes.data.byTool.slice(0, 5)}
-									totalCalls={toolRes.data.byTool.reduce((s, t) => s + t.calls, 0)}
-								/>
-							) : (
-								<div className="stats-empty-state-message">No usage in selected period.</div>
-							)}
-						</AsyncBoundary>
-					</Panel>
+						</div>
+						<div className="omp-section-rule" />
+						<div className="omp-section-body">
+							<AsyncBoundary loading={toolRes.loading} error={toolRes.error} data={toolRes.data}>
+								{toolRes.data && toolRes.data.byTool.length > 0 ? (
+									<ToolsMini
+										tools={toolRes.data.byTool.slice(0, 5)}
+										totalCalls={toolRes.data.byTool.reduce((s, t) => s + t.calls, 0)}
+									/>
+								) : (
+									<div className="stats-empty-state-message">No usage in selected period.</div>
+								)}
+							</AsyncBoundary>
+						</div>
+					</div>
 				)}
 			</div>
 
-			{/* Projects */}
 			{v.projects && (
-				<Panel
-					title="Projects"
-					subtitle="Requests per folder — where the agent spent its time"
-					actions={
+				<div className="omp-section">
+					<div className="omp-section-head">
+						<div>
+							<div className="omp-section-title">Projects</div>
+							<p className="omp-section-desc">Requests per folder — where the agent spent its time</p>
+						</div>
 						<a
 							href={`#/projects?range=${range}`}
 							className="stats-button stats-button-ghost"
@@ -916,26 +966,37 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 						>
 							Projects →
 						</a>
-					}
-				>
-					<AsyncBoundary loading={folderRes.loading} error={folderRes.error} data={folderRes.data}>
-						{folderRes.data && folderRes.data.length > 0 ? (
-							<ProjectsMini
-								folders={folderRes.data.slice(0, 6)}
-								totalRequests={overview?.overall.totalRequests ?? 0}
-							/>
-						) : (
-							<div className="stats-empty-state-message">No usage in selected period.</div>
-						)}
-					</AsyncBoundary>
-				</Panel>
+					</div>
+					<div className="omp-section-rule" />
+					<div className="omp-section-body">
+						<AsyncBoundary loading={folderRes.loading} error={folderRes.error} data={folderRes.data}>
+							{folderRes.data && folderRes.data.length > 0 ? (
+								<ProjectsMini
+									folders={folderRes.data.slice(0, 6)}
+									totalRequests={overview?.overall.totalRequests ?? 0}
+								/>
+							) : (
+								<div className="stats-empty-state-message">No usage in selected period.</div>
+							)}
+						</AsyncBoundary>
+					</div>
+				</div>
 			)}
 
-			{/* Recent requests preview — tabular drilldown */}
-			<Panel
-				title="Recent requests"
-				subtitle="Latest transactions · tap a row for detail"
-				actions={
+			<div
+				className="omp-section"
+				style={{
+					background: "var(--surface)",
+					border: "1px solid var(--border)",
+					borderRadius: "var(--radius-lg)",
+					padding: 14,
+				}}
+			>
+				<div className="omp-section-head">
+					<div>
+						<div className="omp-section-title">Recent requests</div>
+						<p className="omp-section-desc">Latest transactions · tap a row for detail</p>
+					</div>
 					<a
 						href={`#/requests?range=${range}`}
 						className="stats-button stats-button-secondary"
@@ -943,25 +1004,252 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 					>
 						View all
 					</a>
-				}
+				</div>
+				<div className="omp-section-rule" />
+				<div className="omp-section-body">
+					<AsyncBoundary loading={recentRes.loading} error={recentRes.error} data={recentRes.data}>
+						<DataTable
+							columns={columns as never}
+							data={previewRequests}
+							keyExtractor={item => String(item.id ?? `${item.sessionFile}-${item.entryId}`)}
+							onRowClick={item => item.id && onRequestClick(item.id)}
+							renderMobileCard={renderMobileCard as never}
+							emptyText="No usage in selected period."
+						/>
+					</AsyncBoundary>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function ManageDisclosure({
+	newName,
+	setNewName,
+	renaming,
+	renameValue,
+	setRenameValue,
+	setRenaming,
+	activeDash,
+	dashState,
+	setDashState,
+	v,
+	toggle,
+}: {
+	newName: string;
+	setNewName: (v: string) => void;
+	renaming: boolean;
+	renameValue: string;
+	setRenameValue: (v: string) => void;
+	setRenaming: (v: boolean) => void;
+	activeDash: Dashboard;
+	dashState: DashboardState;
+	setDashState: React.Dispatch<React.SetStateAction<DashboardState>>;
+	v: Record<OverviewSectionKey, boolean>;
+	toggle: (k: OverviewSectionKey) => void;
+}) {
+	const [open, setOpen] = useState(false);
+	const panelRef = useRef<HTMLDivElement>(null);
+	useEffect(() => {
+		if (!open) return;
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === "Escape") setOpen(false);
+		};
+		const onClick = (e: MouseEvent) => {
+			if (panelRef.current && !panelRef.current.contains(e.target as Node)) setOpen(false);
+		};
+		window.addEventListener("keydown", onKey);
+		window.addEventListener("mousedown", onClick);
+		return () => {
+			window.removeEventListener("keydown", onKey);
+			window.removeEventListener("mousedown", onClick);
+		};
+	}, [open]);
+	return (
+		<div style={{ position: "relative" }} ref={panelRef}>
+			<button
+				type="button"
+				className="stats-button stats-button-ghost"
+				style={{ fontSize: 11, padding: "5px 9px", fontFamily: "var(--font-sans)" }}
+				aria-expanded={open}
+				aria-haspopup="dialog"
+				onClick={() => setOpen(o => !o)}
 			>
-				<AsyncBoundary loading={recentRes.loading} error={recentRes.error} data={recentRes.data}>
-					<DataTable
-						columns={columns as never}
-						data={previewRequests}
-						keyExtractor={item => String(item.id ?? `${item.sessionFile}-${item.entryId}`)}
-						onRowClick={item => item.id && onRequestClick(item.id)}
-						renderMobileCard={renderMobileCard as never}
-						emptyText="No usage in selected period."
-					/>
-				</AsyncBoundary>
-			</Panel>
+				Manage ▾
+			</button>
+			{open && (
+				<div
+					role="dialog"
+					aria-label="Manage dashboards"
+					style={{
+						position: "absolute",
+						right: 0,
+						top: "calc(100% + 8px)",
+						width: 300,
+						background: "var(--surface)",
+						border: "1px solid var(--border-strong)",
+						borderRadius: "var(--radius-md)",
+						boxShadow: "0 16px 36px rgba(0,0,0,0.18)",
+						zIndex: 10,
+						padding: 10,
+						display: "flex",
+						flexDirection: "column",
+						gap: 10,
+					}}
+				>
+					<div style={{ display: "flex", gap: 6 }}>
+						<input
+							className="omp-dashboard-input"
+							placeholder="New dashboard name"
+							value={newName}
+							onChange={e => setNewName(e.target.value)}
+							onKeyDown={e => {
+								if (e.key === "Enter" && newName.trim()) {
+									setDashState(s => createDashboard(s, newName.trim()));
+									setNewName("");
+								}
+							}}
+							style={{ flex: 1 }}
+						/>
+						<button
+							type="button"
+							className="stats-button stats-button-secondary"
+							style={{ fontSize: 11, padding: "5px 8px" }}
+							disabled={!newName.trim()}
+							onClick={() => {
+								if (newName.trim()) {
+									setDashState(s => createDashboard(s, newName.trim()));
+									setNewName("");
+								}
+							}}
+						>
+							Create
+						</button>
+					</div>
+					<div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+						<button
+							type="button"
+							className="stats-button stats-button-ghost"
+							style={{ fontSize: 11, padding: "5px 8px" }}
+							onClick={() => setDashState(s => duplicateDashboard(s, activeDash.id))}
+						>
+							Duplicate
+						</button>
+						{renaming ? (
+							<>
+								<input
+									className="omp-dashboard-input"
+									value={renameValue}
+									onChange={e => setRenameValue(e.target.value)}
+									style={{ minWidth: 0, flex: 1 }}
+								/>
+								<button
+									type="button"
+									className="stats-button stats-button-secondary"
+									style={{ fontSize: 11, padding: "5px 8px" }}
+									onClick={() => {
+										if (renameValue.trim())
+											setDashState(s => renameDashboard(s, activeDash.id, renameValue.trim()));
+										setRenaming(false);
+									}}
+								>
+									Save
+								</button>
+								<button
+									type="button"
+									className="stats-button stats-button-ghost"
+									style={{ fontSize: 11, padding: "5px 8px" }}
+									onClick={() => setRenaming(false)}
+								>
+									Cancel
+								</button>
+							</>
+						) : (
+							<button
+								type="button"
+								className="stats-button stats-button-ghost"
+								style={{ fontSize: 11, padding: "5px 8px" }}
+								onClick={() => {
+									setRenameValue(activeDash.name);
+									setRenaming(true);
+								}}
+							>
+								Rename
+							</button>
+						)}
+						<button
+							type="button"
+							className="stats-button stats-button-ghost"
+							style={{ fontSize: 11, padding: "5px 8px" }}
+							onClick={() => setDashState(s => resetDashboard(s, activeDash.id, "default"))}
+						>
+							Reset
+						</button>
+						<button
+							type="button"
+							className="stats-button stats-button-ghost"
+							style={{ fontSize: 11, padding: "5px 8px" }}
+							onClick={() => setDashState(() => resetAllDashboards())}
+						>
+							Reset all
+						</button>
+						{dashState.dashboards.length > 1 && (
+							<button
+								type="button"
+								className="stats-button stats-button-ghost"
+								style={{ fontSize: 11, padding: "5px 8px", color: "var(--danger)" }}
+								onClick={() => setDashState(s => deleteDashboard(s, activeDash.id))}
+							>
+								Delete
+							</button>
+						)}
+					</div>
+					<div style={{ height: 1, background: "var(--border)" }} />
+					<div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+						<div
+							style={{
+								fontFamily: "var(--font-sans)",
+								fontSize: 11,
+								fontWeight: 600,
+								color: "var(--dim)",
+								letterSpacing: "0.04em",
+								textTransform: "uppercase",
+							}}
+						>
+							Visible sections
+						</div>
+						{SECTION_ORDER.map(key => (
+							<label
+								key={key}
+								style={{
+									display: "flex",
+									alignItems: "center",
+									justifyContent: "space-between",
+									gap: 8,
+									fontFamily: "var(--font-sans)",
+									fontSize: 12,
+									color: "var(--text)",
+									cursor: "pointer",
+								}}
+							>
+								<span>{SECTION_LABELS[key]}</span>
+								<input
+									type="checkbox"
+									checked={!!v[key]}
+									onChange={() => toggle(key as OverviewSectionKey)}
+									style={{ accentColor: "var(--text)" }}
+								/>
+							</label>
+						))}
+					</div>
+				</div>
+			)}
 		</div>
 	);
 }
 
 // ---------------------------------------------------------------------------
-// Sub-panels (pure, per-widget)
+// Sub-panels
 // ---------------------------------------------------------------------------
 
 function TokenBreakdownPanel({ stats }: { stats: AggregatedStats }) {
@@ -994,19 +1282,28 @@ function TokenBreakdownPanel({ stats }: { stats: AggregatedStats }) {
 		},
 	];
 	return (
-		<div className="stats-token-grid">
+		<div className="omp-token-grid">
 			{items.map(it => (
-				<div key={it.label} className="stats-token-card">
-					<div className="stats-token-card-label">{it.label}</div>
-					<div className="stats-token-card-value">{formatCompact(it.value)}</div>
-					<div className="stats-token-card-share">
-						<div className="stats-token-bar">
+				<div key={it.label} className="omp-token-item">
+					<div className="omp-token-label">{it.label}</div>
+					<div className="omp-token-value">{formatCompact(it.value)}</div>
+					<div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+						<div className="omp-token-bar" style={{ flex: 1 }}>
 							<div
-								className="stats-token-bar-fill"
+								className="omp-token-bar-fill"
 								style={{ width: `${it.share * 100}%`, background: it.color }}
 							/>
 						</div>
-						<span className="stats-token-share-label">{formatPercent(it.share)}</span>
+						<span
+							style={{
+								fontFamily: "var(--font-mono)",
+								fontSize: 11,
+								color: "var(--muted)",
+								fontVariantNumeric: "tabular-nums",
+							}}
+						>
+							{formatPercent(it.share)}
+						</span>
 					</div>
 				</div>
 			))}
@@ -1016,34 +1313,26 @@ function TokenBreakdownPanel({ stats }: { stats: AggregatedStats }) {
 
 function ModelsMini({ models, totalRequests }: { models: ModelStats[]; totalRequests: number }) {
 	return (
-		<div style={{ display: "flex", flexDirection: "column" }}>
+		<div className="omp-list">
 			{models.map((m, idx) => {
 				const share = totalRequests > 0 ? m.totalRequests / totalRequests : 0;
-				const tokens = m.totalInputTokens + m.totalOutputTokens + m.totalCacheReadTokens + m.totalCacheWriteTokens;
 				return (
-					<div key={`${m.model}-${m.provider}`} className="stats-model-row">
-						<span className="stats-model-rank">{String(idx + 1).padStart(2, "0")}</span>
-						<div className="stats-model-name">
-							<div className="stats-model-title">{m.model}</div>
-							<div className="stats-model-sub">{m.provider}</div>
+					<div key={`${m.model}-${m.provider}`} className="omp-row">
+						<span className="omp-row-rank">{String(idx + 1).padStart(2, "0")}</span>
+						<div className="omp-row-main">
+							<div className="omp-row-title">{m.model}</div>
+							<div className="omp-row-sub">{m.provider}</div>
 						</div>
-						<div className="stats-model-bar" title={`${formatPercent(share)} of requests`}>
-							<div className="stats-model-bar-fill" style={{ width: `${share * 100}%` }} />
+						<div className="omp-row-bar" title={`${formatPercent(share)} of requests`}>
+							<div className="omp-row-bar-fill" style={{ width: `${share * 100}%` }} />
 						</div>
-						<span className="stats-model-metric">{formatPercent(share)}</span>
-						<span className="stats-model-metric" title="Input · Output + cache">
+						<span className="omp-row-metric">{formatPercent(share)}</span>
+						<span className="omp-row-metric" title="Input · Output">
 							<span style={{ color: "var(--dim)" }}>{formatCompact(m.totalInputTokens)}</span>
 							<span style={{ color: "var(--text)", marginLeft: 6 }}>{formatCompact(m.totalOutputTokens)}</span>
 						</span>
-						<span className="stats-model-metric" style={{ color: "var(--amber)", minWidth: 72 }}>
+						<span className="omp-row-metric" style={{ color: "var(--amber)", minWidth: 72 }}>
 							{formatEstimatedCost(m.totalCost, m.unpricedRequests, 2)}
-						</span>
-						<span
-							className="stats-model-metric"
-							style={{ color: "var(--dim)", minWidth: 48 }}
-							title="Conversation tokens"
-						>
-							{formatCompact(tokens)}
 						</span>
 					</div>
 				);
@@ -1054,14 +1343,13 @@ function ModelsMini({ models, totalRequests }: { models: ModelStats[]; totalRequ
 
 function ProvidersMini({ providers }: { providers: ProviderAggregate[] }) {
 	return (
-		<div className="stats-provider-grid">
+		<div className="omp-provider-grid">
 			{providers.map(p => {
-				const tokens = p.totalTokens;
 				const errorRate = p.totalRequests > 0 ? p.failedRequests / p.totalRequests : 0;
 				return (
-					<div key={p.provider} className="stats-provider-card">
-						<div className="stats-provider-head">
-							<span className="stats-provider-name">{p.provider}</span>
+					<div key={p.provider} className="omp-provider-item">
+						<div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+							<span className="omp-provider-name">{p.provider}</span>
 							<span
 								className="stats-status-pill"
 								data-variant={errorRate > 0.05 ? "danger" : "success"}
@@ -1081,9 +1369,9 @@ function ProvidersMini({ providers }: { providers: ProviderAggregate[] }) {
 							}}
 						>
 							<span>{formatInteger(p.totalRequests)} req</span>
-							<span>{formatCompact(tokens)} tok</span>
+							<span>{formatCompact(p.totalTokens)} tok</span>
 						</div>
-						<div style={{ height: 4, borderRadius: 999, background: "var(--surface-3)", overflow: "hidden" }}>
+						<div style={{ height: 3, borderRadius: 999, background: "var(--surface-3)", overflow: "hidden" }}>
 							<div style={{ width: "100%", height: "100%", background: "var(--link)", opacity: 0.9 }} />
 						</div>
 						<div
@@ -1111,21 +1399,12 @@ function ProvidersMini({ providers }: { providers: ProviderAggregate[] }) {
 
 function ToolsMini({ tools, totalCalls }: { tools: ToolUsageStats[]; totalCalls: number }) {
 	return (
-		<div style={{ display: "flex", flexDirection: "column" }}>
+		<div className="omp-list">
 			{tools.map(t => {
 				const share = totalCalls > 0 ? t.calls / totalCalls : 0;
 				const errorRate = t.calls > 0 ? t.errors / t.calls : 0;
 				return (
-					<div
-						key={t.tool}
-						style={{
-							display: "flex",
-							alignItems: "center",
-							gap: 10,
-							padding: "9px 0",
-							borderBottom: "1px solid var(--border)",
-						}}
-					>
+					<div key={t.tool} className="omp-row">
 						<span
 							style={{
 								fontSize: 12,
@@ -1165,7 +1444,7 @@ function ToolsMini({ tools, totalCalls }: { tools: ToolUsageStats[]; totalCalls:
 						<div
 							style={{
 								width: 64,
-								height: 4,
+								height: 3,
 								borderRadius: 999,
 								background: "var(--surface-3)",
 								overflow: "hidden",
@@ -1202,21 +1481,12 @@ function ToolsMini({ tools, totalCalls }: { tools: ToolUsageStats[]; totalCalls:
 
 function ProjectsMini({ folders, totalRequests }: { folders: FolderStats[]; totalRequests: number }) {
 	return (
-		<div style={{ display: "flex", flexDirection: "column" }}>
+		<div className="omp-list">
 			{folders.map(f => {
 				const share = totalRequests > 0 ? f.totalRequests / totalRequests : 0;
 				const short = f.folder.split("/").pop() || f.folder;
 				return (
-					<div
-						key={f.folder}
-						style={{
-							display: "flex",
-							alignItems: "center",
-							gap: 10,
-							padding: "8px 0",
-							borderBottom: "1px solid var(--border)",
-						}}
-					>
+					<div key={f.folder} className="omp-row">
 						<span
 							style={{
 								fontFamily: "var(--font-mono)",
@@ -1231,7 +1501,7 @@ function ProjectsMini({ folders, totalRequests }: { folders: FolderStats[]; tota
 						<div
 							style={{
 								width: 72,
-								height: 4,
+								height: 3,
 								borderRadius: 999,
 								background: "var(--surface-3)",
 								overflow: "hidden",

--- a/packages/stats/src/client/routes/OverviewRoute.tsx
+++ b/packages/stats/src/client/routes/OverviewRoute.tsx
@@ -346,7 +346,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 				</div>
 
 				<AsyncBoundary loading={overviewRes.loading} error={overviewRes.error} data={overview}>
-					{overview && (
+					{v.tape && overview && (
 						<div className="omp-metrics-herd" role="region" aria-label="Key metrics">
 							<div className="omp-kpi">
 								<div className="omp-kpi-label">Requests</div>
@@ -543,73 +543,210 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 							</AsyncBoundary>
 						</div>
 					</div>
-					<div className="omp-scope-side">
-						{v.errors && !(errorsRes.data && errorsRes.data.length === 0) && (
-							<div
-								className="omp-section"
-								style={{
-									background: "var(--surface)",
-									border: "1px solid var(--border)",
-									borderRadius: "var(--radius-lg)",
-									padding: 12,
-								}}
-							>
-								<div className="omp-section-head">
-									<div>
-										<div className="omp-section-title">Health · Recent errors</div>
-										<p className="omp-section-desc">Latest failures — only prominent when unhealthy</p>
-									</div>
-									<a
-										href={`#/errors?range=${range}`}
-										className="stats-button stats-button-secondary"
-										style={{ fontSize: 11, padding: "5px 9px" }}
-									>
-										View all →
-									</a>
+				</div>
+			)}
+
+			{(v.errors || v.liveFeed) && (
+				<div className="omp-scope-side">
+					{v.errors && !(errorsRes.data && errorsRes.data.length === 0) && (
+						<div
+							className="omp-section"
+							style={{
+								background: "var(--surface)",
+								border: "1px solid var(--border)",
+								borderRadius: "var(--radius-lg)",
+								padding: 12,
+							}}
+						>
+							<div className="omp-section-head">
+								<div>
+									<div className="omp-section-title">Health · Recent errors</div>
+									<p className="omp-section-desc">Latest failures — only prominent when unhealthy</p>
 								</div>
-								<div className="omp-section-rule" />
-								<div className="omp-section-body">
-									<AsyncBoundary loading={errorsRes.loading} error={errorsRes.error} data={errorsRes.data}>
-										{errorsRes.data && (
-											<div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-												{errorsRes.data.slice(0, 5).map(err => (
-													<div
-														key={err.id ?? `${err.sessionFile}-${err.entryId}`}
-														role={err.id ? "button" : undefined}
-														tabIndex={err.id ? 0 : undefined}
-														onClick={() => err.id && onRequestClick(err.id)}
-														onKeyDown={
-															err.id
-																? e => {
-																		if (e.key === "Enter" || e.key === " ") {
-																			e.preventDefault();
-																			err.id && onRequestClick(err.id);
-																		}
+								<a
+									href={`#/errors?range=${range}`}
+									className="stats-button stats-button-secondary"
+									style={{ fontSize: 11, padding: "5px 9px" }}
+								>
+									View all →
+								</a>
+							</div>
+							<div className="omp-section-rule" />
+							<div className="omp-section-body">
+								<AsyncBoundary loading={errorsRes.loading} error={errorsRes.error} data={errorsRes.data}>
+									{errorsRes.data && (
+										<div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+											{errorsRes.data.slice(0, 5).map(err => (
+												<div
+													key={err.id ?? `${err.sessionFile}-${err.entryId}`}
+													role={err.id ? "button" : undefined}
+													tabIndex={err.id ? 0 : undefined}
+													onClick={() => err.id && onRequestClick(err.id)}
+													onKeyDown={
+														err.id
+															? e => {
+																	if (e.key === "Enter" || e.key === " ") {
+																		e.preventDefault();
+																		err.id && onRequestClick(err.id);
 																	}
-																: undefined
-														}
+																}
+															: undefined
+													}
+													style={{
+														display: "flex",
+														gap: 10,
+														padding: "8px 10px",
+														border: "1px solid var(--border)",
+														borderRadius: "var(--radius-md)",
+														background: "var(--surface-2)",
+														cursor: err.id ? "pointer" : undefined,
+													}}
+												>
+													<span
 														style={{
-															display: "flex",
-															gap: 10,
-															padding: "8px 10px",
-															border: "1px solid var(--border)",
-															borderRadius: "var(--radius-md)",
-															background: "var(--surface-2)",
-															cursor: err.id ? "pointer" : undefined,
+															width: 7,
+															height: 7,
+															borderRadius: 999,
+															background: "var(--danger)",
+															marginTop: 6,
+															flexShrink: 0,
 														}}
-													>
-														<span
+													/>
+													<div style={{ minWidth: 0, flex: 1 }}>
+														<div
 															style={{
-																width: 7,
-																height: 7,
-																borderRadius: 999,
-																background: "var(--danger)",
-																marginTop: 6,
-																flexShrink: 0,
+																fontSize: 12,
+																fontWeight: 600,
+																color: "var(--text)",
+																whiteSpace: "nowrap",
+																overflow: "hidden",
+																textOverflow: "ellipsis",
 															}}
-														/>
-														<div style={{ minWidth: 0, flex: 1 }}>
-															<div
+														>
+															{err.model}
+															<span
+																style={{
+																	fontWeight: 400,
+																	color: "var(--dim)",
+																	fontFamily: "var(--font-mono)",
+																	fontSize: 11,
+																	marginLeft: 6,
+																}}
+															>
+																{err.provider}
+															</span>
+														</div>
+														<div
+															style={{
+																fontSize: 11,
+																color: "var(--danger)",
+																fontFamily: "var(--font-mono)",
+																whiteSpace: "nowrap",
+																overflow: "hidden",
+																textOverflow: "ellipsis",
+																marginTop: 2,
+															}}
+															title={err.errorMessage ?? ""}
+														>
+															{err.errorMessage ?? "Unknown error"}
+														</div>
+														<div
+															style={{
+																fontSize: 11,
+																color: "var(--dim)",
+																fontFamily: "var(--font-mono)",
+																marginTop: 2,
+															}}
+														>
+															{format(new Date(err.timestamp), "MMM d, HH:mm")} ·{" "}
+															{formatDurationMs(err.duration)}
+														</div>
+													</div>
+												</div>
+											))}
+										</div>
+									)}
+								</AsyncBoundary>
+							</div>
+						</div>
+					)}
+					{v.liveFeed && !(recentRes.data && recentRes.data.length === 0) && (
+						<div
+							className="omp-section"
+							style={{
+								background: "var(--surface)",
+								border: "1px solid var(--border)",
+								borderRadius: "var(--radius-lg)",
+								padding: 12,
+							}}
+						>
+							<div className="omp-section-head">
+								<div>
+									<div className="omp-section-title">Live feed</div>
+									<p className="omp-section-desc">Newest requests</p>
+								</div>
+							</div>
+							<div className="omp-section-rule" />
+							<div className="omp-section-body">
+								<AsyncBoundary
+									loading={recentRes.loading}
+									error={recentRes.error}
+									data={recentRes.data}
+									fallback={
+										<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+											{Array.from({ length: 4 }).map((_, i) => (
+												<div key={i} style={{ display: "flex", gap: 10, alignItems: "center" }}>
+													<Skeleton variant="circle" width={8} height={8} />
+													<div style={{ flex: 1 }}>
+														<Skeleton variant="text" width="60%" height={14} />
+														<Skeleton variant="text" width="40%" height={10} />
+													</div>
+												</div>
+											))}
+										</div>
+									}
+								>
+									<div style={{ display: "flex", flexDirection: "column" }}>
+										{previewRequests.map(req => {
+											const isError = !!req.errorMessage;
+											const openDetails = () => req.id && onRequestClick(req.id);
+											return (
+												<div
+													key={req.id ?? `${req.sessionFile}-${req.entryId}`}
+													role={req.id ? "button" : undefined}
+													tabIndex={req.id ? 0 : undefined}
+													onClick={openDetails}
+													onKeyDown={
+														req.id
+															? e => {
+																	if (e.key === "Enter" || e.key === " ") {
+																		e.preventDefault();
+																		openDetails();
+																	}
+																}
+															: undefined
+													}
+													style={{
+														display: "flex",
+														gap: 10,
+														padding: "8px 2px",
+														borderBottom: "1px solid var(--border)",
+														cursor: req.id ? "pointer" : undefined,
+													}}
+												>
+													<span
+														style={{
+															width: 6,
+															height: 6,
+															borderRadius: 999,
+															background: isError ? "var(--danger)" : "var(--success)",
+															marginTop: 7,
+															flexShrink: 0,
+														}}
+													/>
+													<div style={{ minWidth: 0, flex: 1 }}>
+														<div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
+															<span
 																style={{
 																	fontSize: 12,
 																	fontWeight: 600,
@@ -619,194 +756,60 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 																	textOverflow: "ellipsis",
 																}}
 															>
-																{err.model}
-																<span
-																	style={{
-																		fontWeight: 400,
-																		color: "var(--dim)",
-																		fontFamily: "var(--font-mono)",
-																		fontSize: 11,
-																		marginLeft: 6,
-																	}}
-																>
-																	{err.provider}
-																</span>
-															</div>
-															<div
+																{req.model}
+															</span>
+															<span
 																style={{
+																	fontFamily: "var(--font-mono)",
 																	fontSize: 11,
-																	color: "var(--danger)",
+																	color: "var(--dim)",
+																	flexShrink: 0,
+																}}
+															>
+																{format(new Date(req.timestamp), "HH:mm:ss")}
+															</span>
+														</div>
+														<div
+															style={{
+																display: "flex",
+																justifyContent: "space-between",
+																gap: 8,
+																fontSize: 11,
+																color: "var(--muted)",
+															}}
+														>
+															<span
+																style={{
 																	fontFamily: "var(--font-mono)",
 																	whiteSpace: "nowrap",
 																	overflow: "hidden",
 																	textOverflow: "ellipsis",
-																	marginTop: 2,
 																}}
-																title={err.errorMessage ?? ""}
 															>
-																{err.errorMessage ?? "Unknown error"}
-															</div>
-															<div
+																{req.provider}
+															</span>
+															<span
 																style={{
-																	fontSize: 11,
-																	color: "var(--dim)",
 																	fontFamily: "var(--font-mono)",
-																	marginTop: 2,
+																	fontVariantNumeric: "tabular-nums",
+																	whiteSpace: "nowrap",
 																}}
 															>
-																{format(new Date(err.timestamp), "MMM d, HH:mm")} ·{" "}
-																{formatDurationMs(err.duration)}
-															</div>
+																{req.usage.totalTokens > 0
+																	? `${formatCompact(req.usage.totalTokens)} tok`
+																	: ""}{" "}
+																{req.usage.totalTokens > 0 ? `· ${formatMessageCost(req, 2)}` : ""}
+															</span>
 														</div>
 													</div>
-												))}
-											</div>
-										)}
-									</AsyncBoundary>
-								</div>
-							</div>
-						)}
-						{v.liveFeed && !(recentRes.data && recentRes.data.length === 0) && (
-							<div
-								className="omp-section"
-								style={{
-									background: "var(--surface)",
-									border: "1px solid var(--border)",
-									borderRadius: "var(--radius-lg)",
-									padding: 12,
-								}}
-							>
-								<div className="omp-section-head">
-									<div>
-										<div className="omp-section-title">Live feed</div>
-										<p className="omp-section-desc">Newest requests</p>
+												</div>
+											);
+										})}
 									</div>
-								</div>
-								<div className="omp-section-rule" />
-								<div className="omp-section-body">
-									<AsyncBoundary
-										loading={recentRes.loading}
-										error={recentRes.error}
-										data={recentRes.data}
-										fallback={
-											<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-												{Array.from({ length: 4 }).map((_, i) => (
-													<div key={i} style={{ display: "flex", gap: 10, alignItems: "center" }}>
-														<Skeleton variant="circle" width={8} height={8} />
-														<div style={{ flex: 1 }}>
-															<Skeleton variant="text" width="60%" height={14} />
-															<Skeleton variant="text" width="40%" height={10} />
-														</div>
-													</div>
-												))}
-											</div>
-										}
-									>
-										<div style={{ display: "flex", flexDirection: "column" }}>
-											{previewRequests.map(req => {
-												const isError = !!req.errorMessage;
-												const openDetails = () => req.id && onRequestClick(req.id);
-												return (
-													<div
-														key={req.id ?? `${req.sessionFile}-${req.entryId}`}
-														role={req.id ? "button" : undefined}
-														tabIndex={req.id ? 0 : undefined}
-														onClick={openDetails}
-														onKeyDown={
-															req.id
-																? e => {
-																		if (e.key === "Enter" || e.key === " ") {
-																			e.preventDefault();
-																			openDetails();
-																		}
-																	}
-																: undefined
-														}
-														style={{
-															display: "flex",
-															gap: 10,
-															padding: "8px 2px",
-															borderBottom: "1px solid var(--border)",
-															cursor: req.id ? "pointer" : undefined,
-														}}
-													>
-														<span
-															style={{
-																width: 6,
-																height: 6,
-																borderRadius: 999,
-																background: isError ? "var(--danger)" : "var(--success)",
-																marginTop: 7,
-																flexShrink: 0,
-															}}
-														/>
-														<div style={{ minWidth: 0, flex: 1 }}>
-															<div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
-																<span
-																	style={{
-																		fontSize: 12,
-																		fontWeight: 600,
-																		color: "var(--text)",
-																		whiteSpace: "nowrap",
-																		overflow: "hidden",
-																		textOverflow: "ellipsis",
-																	}}
-																>
-																	{req.model}
-																</span>
-																<span
-																	style={{
-																		fontFamily: "var(--font-mono)",
-																		fontSize: 11,
-																		color: "var(--dim)",
-																		flexShrink: 0,
-																	}}
-																>
-																	{format(new Date(req.timestamp), "HH:mm:ss")}
-																</span>
-															</div>
-															<div
-																style={{
-																	display: "flex",
-																	justifyContent: "space-between",
-																	gap: 8,
-																	fontSize: 11,
-																	color: "var(--muted)",
-																}}
-															>
-																<span
-																	style={{
-																		fontFamily: "var(--font-mono)",
-																		whiteSpace: "nowrap",
-																		overflow: "hidden",
-																		textOverflow: "ellipsis",
-																	}}
-																>
-																	{req.provider}
-																</span>
-																<span
-																	style={{
-																		fontFamily: "var(--font-mono)",
-																		fontVariantNumeric: "tabular-nums",
-																		whiteSpace: "nowrap",
-																	}}
-																>
-																	{req.usage.totalTokens > 0
-																		? `${formatCompact(req.usage.totalTokens)} tok`
-																		: ""}{" "}
-																	{req.usage.totalTokens > 0 ? `· ${formatMessageCost(req, 2)}` : ""}
-																</span>
-															</div>
-														</div>
-													</div>
-												);
-											})}
-										</div>
-									</AsyncBoundary>
-								</div>
+								</AsyncBoundary>
 							</div>
-						)}
-					</div>
+						</div>
+					)}
 				</div>
 			)}
 

--- a/packages/stats/src/client/routes/ProjectsRoute.tsx
+++ b/packages/stats/src/client/routes/ProjectsRoute.tsx
@@ -1,15 +1,31 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { getFolderStats } from "../api";
 import { formatDurationMs, formatEstimatedCost, formatInteger, formatPercent } from "../data/formatters";
 import { useResource } from "../data/useResource";
-import { buildFolderRows, type FolderRowView } from "../data/view-models";
-import type { TimeRange } from "../types";
-import { AsyncBoundary, DataTable, Panel, StatusPill } from "../ui";
+import { buildFolderRows } from "../data/view-models";
+import type { FolderStats, TimeRange } from "../types";
+import { AsyncBoundary } from "../ui";
 
 export interface ProjectsRouteProps {
 	active: boolean;
 	range: TimeRange;
 	refreshTrigger: number;
+}
+
+type SortKey = "requests" | "cost" | "folder";
+type SortDir = "asc" | "desc";
+const SORT_KEY = "omp-stats:projects-sort";
+function load(): { key: SortKey; dir: SortDir } {
+	try {
+		const raw = sessionStorage.getItem(SORT_KEY);
+		if (raw) return JSON.parse(raw) as never;
+	} catch {}
+	return { key: "requests", dir: "desc" };
+}
+function save(v: { key: SortKey; dir: SortDir }) {
+	try {
+		sessionStorage.setItem(SORT_KEY, JSON.stringify(v));
+	} catch {}
 }
 
 export function ProjectsRoute({ active, range, refreshTrigger }: ProjectsRouteProps) {
@@ -22,156 +38,145 @@ export function ProjectsRoute({ active, range, refreshTrigger }: ProjectsRoutePr
 		enabled: active,
 	});
 
-	const folderRows = useMemo(() => {
-		if (!foldersData) return [];
-		return buildFolderRows(foldersData);
-	}, [foldersData]);
-
-	const columns = useMemo(
-		() => [
-			{
-				key: "folder",
-				header: "Project/Folder",
-				render: (item: FolderRowView) => (
-					<div
-						className="stats-font-medium stats-text-primary truncate max-w-[440px]"
-						title={item.folder || "(root)"}
-					>
-						{item.folder || "(root)"}
-					</div>
-				),
-			},
-			{
-				key: "totalRequests",
-				header: "Requests",
-				numeric: true,
-				render: (item: FolderRowView) => (
-					<div className="stats-text-right">
-						<div className="font-mono">{formatInteger(item.totalRequests)}</div>
-						<div className="stats-progress-bar-track mt-1 ml-auto w-24 h-1">
-							<div
-								className="stats-progress-bar-fill"
-								data-variant="link"
-								style={{ width: `${item.requestsPercentage}%` }}
-							/>
-						</div>
-					</div>
-				),
-			},
-			{
-				key: "totalCost",
-				header: "API-equivalent estimate",
-				numeric: true,
-				render: (item: FolderRowView) => (
-					<div className="stats-text-right">
-						<div className="font-mono">{formatEstimatedCost(item.totalCost, item.unpricedRequests)}</div>
-						<div className="stats-progress-bar-track mt-1 ml-auto w-24 h-1">
-							<div
-								className="stats-progress-bar-fill"
-								data-variant="success"
-								style={{ width: `${item.costPercentage}%` }}
-							/>
-						</div>
-					</div>
-				),
-			},
-			{
-				key: "totalTokens",
-				header: "Tokens",
-				numeric: true,
-				render: (item: FolderRowView) => (
-					<div className="font-mono">{formatInteger(item.totalInputTokens + item.totalOutputTokens)}</div>
-				),
-			},
-			{
-				key: "cacheRate",
-				header: "Cache Rate",
-				numeric: true,
-				render: (item: FolderRowView) => <span className="font-mono">{formatPercent(item.cacheRate)}</span>,
-			},
-			{
-				key: "cacheSavings",
-				header: "Cache Savings",
-				numeric: true,
-				render: (item: FolderRowView) => (
-					<span className={`${item.cacheSavings < 0 ? "stats-text-danger" : "stats-text-success"} font-medium`}>
-						{formatPercent(item.cacheSavings)}
-					</span>
-				),
-			},
-			{
-				key: "errorRate",
-				header: "Error Rate",
-				numeric: true,
-				render: (item: FolderRowView) => (
-					<StatusPill variant={item.errorRate > 0.1 ? "danger" : item.errorRate > 0 ? "warning" : "success"}>
-						{formatPercent(item.errorRate)}
-					</StatusPill>
-				),
-			},
-			{
-				key: "avgDuration",
-				header: "Avg Duration",
-				numeric: true,
-				render: (item: FolderRowView) => formatDurationMs(item.avgDuration),
-			},
-		],
-		[],
-	);
-
-	const renderMobileCard = (item: FolderRowView) => (
-		<div className="stats-mobile-card">
-			<div className="stats-mobile-card-header mb-2">
-				<div className="stats-font-semibold stats-text-primary">{item.folder || "(root)"}</div>
-				<StatusPill variant={item.errorRate > 0.1 ? "danger" : item.errorRate > 0 ? "warning" : "success"}>
-					{formatPercent(item.errorRate)} Err
-				</StatusPill>
-			</div>
-			<div className="stats-mobile-card-grid">
-				<div>
-					<div className="stats-mobile-card-label">Requests</div>
-					<div className="stats-mobile-card-value font-mono">{formatInteger(item.totalRequests)}</div>
-				</div>
-				<div>
-					<div className="stats-mobile-card-label">API-equivalent estimate</div>
-					<div className="stats-mobile-card-value font-mono">
-						{formatEstimatedCost(item.totalCost, item.unpricedRequests)}
-					</div>
-				</div>
-				<div>
-					<div className="stats-mobile-card-label">Cache Rate</div>
-					<div className="stats-mobile-card-value">{formatPercent(item.cacheRate)}</div>
-				</div>
-				<div>
-					<div className="stats-mobile-card-label">Cache Savings</div>
-					<div className="stats-mobile-card-value">{formatPercent(item.cacheSavings)}</div>
-				</div>
-				<div>
-					<div className="stats-mobile-card-label">Duration</div>
-					<div className="stats-mobile-card-value">{formatDurationMs(item.avgDuration)}</div>
-				</div>
-			</div>
-		</div>
-	);
-
 	return (
 		<div className="stats-route-container">
-			<Panel title="Projects & Folders" subtitle="Aggregate proxy metrics grouped by folder path">
-				<AsyncBoundary
-					loading={loading}
-					error={error}
-					data={foldersData}
-					emptyText="No project folders recorded for this range."
+			<div className="omp-hero">
+				<div className="omp-hero-head">
+					<h2 className="omp-hero-title">
+						Projects <span>{range} · folder rows</span>
+					</h2>
+					<span className="omp-hero-range">{foldersData ? `${foldersData.length} projects` : "loading"}</span>
+				</div>
+				<p
+					style={{
+						fontFamily: "var(--font-sans)",
+						fontSize: 12,
+						color: "var(--muted)",
+						margin: 0,
+						maxWidth: 720,
+						lineHeight: 1.5,
+					}}
 				>
-					<DataTable
-						columns={columns}
-						data={folderRows}
-						keyExtractor={item => item.folder}
-						renderMobileCard={renderMobileCard}
-						emptyText="No project folders recorded for this range."
-					/>
-				</AsyncBoundary>
-			</Panel>
+					Folder rows like Overview’s Projects section — ranked by requests with cost context. Same open layout, no
+					card grid, just rows with share bars.
+				</p>
+			</div>
+
+			<AsyncBoundary loading={loading} error={error} data={foldersData}>
+				{foldersData && <ProjectsRanked folders={foldersData} />}
+			</AsyncBoundary>
+		</div>
+	);
+}
+
+function ProjectsRanked({ folders }: { folders: FolderStats[] }) {
+	const base = useMemo(() => buildFolderRows(folders), [folders]);
+	const [sort, setSort] = useState<{ key: SortKey; dir: SortDir }>(() => load());
+	useEffect(() => save(sort), [sort]);
+
+	const rows = useMemo(() => {
+		const mul = sort.dir === "asc" ? 1 : -1;
+		return [...base].sort((a, b) => {
+			let cmp = 0;
+			switch (sort.key) {
+				case "requests":
+					cmp = a.totalRequests - b.totalRequests;
+					break;
+				case "cost":
+					cmp = a.totalCost - b.totalCost;
+					break;
+				case "folder":
+					cmp = a.folder.localeCompare(b.folder);
+					break;
+			}
+			if (cmp !== 0) return cmp * mul;
+			return b.totalRequests - a.totalRequests;
+		});
+	}, [base, sort]);
+
+	const toggle = (key: SortKey) =>
+		setSort(prev =>
+			prev.key === key
+				? { key, dir: prev.dir === "asc" ? "desc" : "asc" }
+				: { key, dir: key === "folder" ? "asc" : "desc" },
+		);
+	const btn = (label: string, key: SortKey) => {
+		const active = sort.key === key;
+		return (
+			<button type="button" data-active={active ? "true" : "false"} onClick={() => toggle(key)}>
+				{label}{" "}
+				<span style={{ fontSize: 10, opacity: active ? 1 : 0.35 }}>
+					{active ? (sort.dir === "asc" ? "↑" : "↓") : "↕"}
+				</span>
+			</button>
+		);
+	};
+
+	return (
+		<div className="omp-section">
+			<div className="omp-section-head">
+				<div>
+					<div className="omp-section-title">Folders ranked</div>
+					<p className="omp-section-desc">Click header to sort. Share bar shows requests vs busiest folder.</p>
+				</div>
+				<span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--dim)" }}>
+					{rows.length} folders
+				</span>
+			</div>
+			<div className="omp-section-rule" />
+			<div className="omp-section-body">
+				<div
+					className="omp-ranked-head"
+					style={{
+						display: "grid",
+						gridTemplateColumns: "22px minmax(0, 1.6fr) 84px 96px 96px 84px 76px",
+						gap: 10,
+					}}
+				>
+					<span>#</span>
+					<span>{btn("Project", "folder")}</span>
+					<span style={{ textAlign: "center" }}>Share</span>
+					<span style={{ textAlign: "right" }}>{btn("Requests", "requests")}</span>
+					<span style={{ textAlign: "right" }}>{btn("Est. cost", "cost")}</span>
+					<span style={{ textAlign: "right" }}>Avg dur</span>
+					<span style={{ textAlign: "right" }}>Cache</span>
+				</div>
+				<div className="omp-ranked-list">
+					{rows.map((f, i) => (
+						<div
+							key={f.folder}
+							className="omp-ranked-row"
+							style={{ gridTemplateColumns: "22px minmax(0, 1.6fr) 84px 96px 96px 84px 76px" }}
+						>
+							<span className="omp-ranked-row-rank">{i + 1}</span>
+							<span className="omp-ranked-row-main">
+								<span
+									className="omp-ranked-row-title"
+									title={f.folder}
+									style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}
+								>
+									{f.folder}
+								</span>
+								<span className="omp-ranked-row-sub">
+									{formatPercent(f.errorRate, 1)} err ·{" "}
+									{f.totalRequests ? `${((f.cacheRate ?? 0) * 100).toFixed(1)}% cache` : ""}
+								</span>
+							</span>
+							<span className="omp-ranked-bar">
+								<span className="omp-ranked-bar-fill" style={{ width: `${f.requestsPercentage}%` }} />
+							</span>
+							<span className="omp-ranked-metric">
+								<strong>{formatInteger(f.totalRequests)}</strong>
+							</span>
+							<span className="omp-ranked-metric">
+								{formatEstimatedCost(f.totalCost, f.unpricedRequests, 2)}
+							</span>
+							<span className="omp-ranked-metric">{f.avgDuration ? formatDurationMs(f.avgDuration) : "—"}</span>
+							<span className="omp-ranked-metric">{formatPercent(f.cacheRate)}</span>
+						</div>
+					))}
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/packages/stats/src/client/routes/ProvidersRoute.tsx
+++ b/packages/stats/src/client/routes/ProvidersRoute.tsx
@@ -1,12 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { getProviderDashboardStats } from "../api";
-import { CHART_THEMES } from "../components/chart-shared";
 import { formatCompact, formatEstimatedCost, formatInteger, formatPercent } from "../data/formatters";
 import { useResource } from "../data/useResource";
 import { type ProviderSortKey, providerFailureTone, type SortDir, sortProviderRows } from "../data/view-models";
 import type { ProviderAggregate, TimeRange } from "../types";
 import { AsyncBoundary } from "../ui";
-import { useSystemTheme } from "../useSystemTheme";
 
 export interface ProvidersRouteProps {
 	active: boolean;
@@ -316,8 +314,6 @@ function ProviderRanked({ providers, range }: { providers: ProviderAggregate[]; 
 }
 
 function ProviderMiniTrend({ provider, range }: { provider: string; range: TimeRange }) {
-	const theme = useSystemTheme();
-	const chartTheme = CHART_THEMES[theme];
 	// We don't have per-provider series loaded here; show placeholder that this would be per-provider trend if needed.
 	// To keep data honest, we show a compact note instead of invented data.
 	return (

--- a/packages/stats/src/client/routes/ProvidersRoute.tsx
+++ b/packages/stats/src/client/routes/ProvidersRoute.tsx
@@ -1,40 +1,32 @@
-import { useMemo, useState } from "react";
-import { Bar } from "react-chartjs-2";
+import { useEffect, useMemo, useState } from "react";
 import { getProviderDashboardStats } from "../api";
-import {
-	barDatasetStyle,
-	buildSharedPlugins,
-	buildSharedScales,
-	buildTopNByModelSeries,
-	CHART_THEMES,
-	MODEL_COLORS,
-	styleDatasets,
-} from "../components/chart-shared";
-import {
-	formatCompact,
-	formatCost,
-	formatEstimatedCost,
-	formatInteger,
-	formatPercent,
-	formatRelativeTime,
-	formatTokensPerSecond,
-} from "../data/formatters";
+import { CHART_THEMES } from "../components/chart-shared";
+import { formatCompact, formatEstimatedCost, formatInteger, formatPercent } from "../data/formatters";
 import { useResource } from "../data/useResource";
-import type {
-	ProviderAggregate,
-	ProviderDashboardStats,
-	ProviderHourlyPoint,
-	ProviderWindowInsight,
-	TimeRange,
-	UsageWindowSeries,
-} from "../types";
-import { AsyncBoundary, DataTable, type DataTableColumn, EmptyState, Panel, SegmentedControl } from "../ui";
+import { type ProviderSortKey, providerFailureTone, type SortDir, sortProviderRows } from "../data/view-models";
+import type { ProviderAggregate, TimeRange } from "../types";
+import { AsyncBoundary } from "../ui";
 import { useSystemTheme } from "../useSystemTheme";
 
 export interface ProvidersRouteProps {
 	active: boolean;
 	range: TimeRange;
 	refreshTrigger: number;
+}
+
+const SORT_KEY = "omp-stats:providers-sort";
+type Stored = { key: ProviderSortKey; dir: SortDir };
+function load(): Stored {
+	try {
+		const raw = sessionStorage.getItem(SORT_KEY);
+		if (raw) return JSON.parse(raw) as Stored;
+	} catch {}
+	return { key: "requests", dir: "desc" };
+}
+function save(v: Stored) {
+	try {
+		sessionStorage.setItem(SORT_KEY, JSON.stringify(v));
+	} catch {}
 }
 
 export function ProvidersRoute({ active, range, refreshTrigger }: ProvidersRouteProps) {
@@ -48,471 +40,298 @@ export function ProvidersRoute({ active, range, refreshTrigger }: ProvidersRoute
 	});
 
 	return (
-		<div className="stats-route-container space-y-6">
-			<AsyncBoundary loading={loading} error={error} data={stats}>
+		<div className="stats-route-container">
+			<div className="omp-hero">
+				<div className="omp-hero-head">
+					<h2 className="omp-hero-title">
+						Providers <span>{range} · operational</span>
+					</h2>
+					<span className="omp-hero-range">
+						{stats
+							? `${stats.providers.length} providers · ${formatInteger(stats.providers.reduce((s, p) => s + p.totalRequests, 0))} req`
+							: "loading"}
+					</span>
+				</div>
 				{stats && (
-					<>
-						<ProviderTotalsPanel providers={stats.providers} />
-						<ProviderTrendPanel stats={stats} />
-						<PeakHoursPanel hourly={stats.hourly} providers={stats.providers} />
-						<WindowInsightsPanel insights={stats.windowInsights} />
-						<WindowUtilizationPanel usageSeries={stats.usageSeries} />
-					</>
+					<div className="omp-token-grid" style={{ marginTop: 4 }}>
+						<div className="omp-token-item">
+							<div className="omp-token-label">Top provider</div>
+							<div className="omp-token-value" style={{ fontSize: 14 }}>
+								{stats.providers[0]?.provider ?? "—"}
+							</div>
+							<div className="omp-token-bar">
+								<div
+									className="omp-token-bar-fill"
+									style={{
+										width: `${
+											((stats.providers[0]?.totalRequests ?? 0) /
+												Math.max(
+													1,
+													stats.providers.reduce((s, p) => s + p.totalRequests, 0),
+												)) *
+											100
+										}%`,
+										background: "var(--text)",
+									}}
+								/>
+							</div>
+						</div>
+						<div className="omp-token-item">
+							<div className="omp-token-label">Total tokens</div>
+							<div className="omp-token-value">
+								{formatCompact(stats.providers.reduce((s, p) => s + p.totalTokens, 0))}
+							</div>
+							<div style={{ fontFamily: "var(--font-sans)", fontSize: 11, color: "var(--muted)" }}>
+								across all providers
+							</div>
+						</div>
+						<div className="omp-token-item">
+							<div className="omp-token-label">Est. cost</div>
+							<div className="omp-token-value">
+								{formatEstimatedCost(
+									stats.providers.reduce((s, p) => s + p.totalCost, 0),
+									stats.providers.reduce((s, p) => s + p.unpricedRequests, 0),
+								)}
+							</div>
+							<div style={{ fontFamily: "var(--font-sans)", fontSize: 11, color: "var(--muted)" }}>
+								api-equivalent
+							</div>
+						</div>
+						<div className="omp-token-item">
+							<div className="omp-token-label">Elevated failures</div>
+							<div
+								className="omp-token-value"
+								style={{
+									color: stats.providers.some(p => p.failedRequests / Math.max(1, p.totalRequests) >= 0.08)
+										? "var(--danger)"
+										: "var(--muted)",
+								}}
+							>
+								{stats.providers.filter(p => p.failedRequests / Math.max(1, p.totalRequests) >= 0.03).length}
+							</div>
+							<div style={{ fontFamily: "var(--font-sans)", fontSize: 11, color: "var(--dim)" }}>
+								providers ≥3% fail
+							</div>
+						</div>
+					</div>
 				)}
+			</div>
+
+			<AsyncBoundary loading={loading} error={error} data={stats}>
+				{stats && <ProviderRanked providers={stats.providers} range={range} />}
 			</AsyncBoundary>
 		</div>
 	);
 }
 
-// ---------------------------------------------------------------------------
-// Provider totals
-// ---------------------------------------------------------------------------
+function ProviderRanked({ providers, range }: { providers: ProviderAggregate[]; range: TimeRange }) {
+	const [sort, setSort] = useState<Stored>(() => load());
+	const [expanded, setExpanded] = useState<string | null>(null);
+	useEffect(() => save(sort), [sort]);
 
-function ProviderTotalsPanel({ providers }: { providers: ProviderAggregate[] }) {
-	const grandTotal = useMemo(() => providers.reduce((sum, p) => sum + p.totalTokens, 0), [providers]);
-	const unpricedRequests = useMemo(
-		() => providers.reduce((sum, provider) => sum + provider.unpricedRequests, 0),
-		[providers],
-	);
-
-	const columns: DataTableColumn<ProviderAggregate>[] = [
-		{ key: "provider", header: "Provider", render: p => <span className="font-medium">{p.provider}</span> },
-		{ key: "requests", header: "Requests", numeric: true, render: p => formatInteger(p.totalRequests) },
-		{
-			key: "errors",
-			header: "Error Rate",
-			numeric: true,
-			render: p => formatPercent(p.totalRequests > 0 ? p.failedRequests / p.totalRequests : 0),
-		},
-		{ key: "models", header: "Models", numeric: true, render: p => formatInteger(p.models) },
-		{
-			key: "tokens",
-			header: "Tokens",
-			numeric: true,
-			render: p => (
-				<span
-					title={`Input ${formatCompact(p.totalInputTokens)} · Output ${formatCompact(p.totalOutputTokens)} · Cache read ${formatCompact(p.totalCacheReadTokens)} · Cache write ${formatCompact(p.totalCacheWriteTokens)}`}
-				>
-					{formatCompact(p.totalTokens)}
+	const rows = useMemo(() => sortProviderRows(providers, sort.key, sort.dir), [providers, sort]);
+	const totalRequests = useMemo(() => providers.reduce((s, p) => s + p.totalRequests, 0), [providers]);
+	const toggle = (key: ProviderSortKey) =>
+		setSort(prev => (prev.key === key ? { key, dir: prev.dir === "asc" ? "desc" : "asc" } : { key, dir: "desc" }));
+	const btn = (label: string, key: ProviderSortKey) => {
+		const active = sort.key === key;
+		return (
+			<button type="button" data-active={active ? "true" : "false"} onClick={() => toggle(key)}>
+				{label}
+				<span style={{ fontSize: 10, opacity: active ? 1 : 0.35 }}>
+					{active ? (sort.dir === "asc" ? "↑" : "↓") : "↕"}
 				</span>
-			),
-		},
-		{
-			key: "share",
-			header: "Share",
-			numeric: true,
-			render: p => formatPercent(grandTotal > 0 ? p.totalTokens / grandTotal : 0),
-		},
-		{
-			key: "cost",
-			header: "API-equivalent estimate",
-			numeric: true,
-			render: provider => formatEstimatedCost(provider.totalCost, provider.unpricedRequests),
-		},
-		{ key: "tps", header: "Tok/s", numeric: true, render: p => formatTokensPerSecond(p.avgTokensPerSecond) },
-	];
+			</button>
+		);
+	};
 
 	return (
-		<Panel
-			title="Provider Totals"
-			subtitle={
-				unpricedRequests > 0
-					? `Token, request, and API-equivalent estimates; excludes ${unpricedRequests.toLocaleString()} unpriced subscription request${unpricedRequests === 1 ? "" : "s"}`
-					: "Token, request, and API-equivalent estimates over the active range"
-			}
-		>
-			<DataTable
-				columns={columns}
-				data={providers}
-				keyExtractor={p => p.provider}
-				emptyText="No requests recorded in this range"
-			/>
-		</Panel>
+		<div className="omp-section">
+			<div className="omp-section-head">
+				<div>
+					<div className="omp-section-title">Provider share</div>
+					<p className="omp-section-desc">
+						Operational list — share, cost, failures, cache, models. Elevated failure rows tint red/amber; normal
+						providers stay quiet.
+					</p>
+				</div>
+				<span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--dim)" }}>
+					{rows.length} providers
+				</span>
+			</div>
+			<div className="omp-section-rule" />
+			<div className="omp-section-body">
+				<div
+					className="omp-ranked-head"
+					style={{
+						display: "grid",
+						gridTemplateColumns: "22px minmax(0, 1.4fr) 84px 90px 90px 90px 70px 28px",
+						gap: 10,
+					}}
+				>
+					<span style={{ textAlign: "right" }}>#</span>
+					<span>{btn("Provider", "provider")}</span>
+					<span style={{ textAlign: "center" }}>Share</span>
+					<span style={{ textAlign: "right" }}>{btn("Requests", "requests")}</span>
+					<span style={{ textAlign: "right" }}>{btn("Est. cost", "cost")}</span>
+					<span style={{ textAlign: "right" }}>{btn("Failures", "failure")}</span>
+					<span style={{ textAlign: "right" }}>{btn("Cache", "cache")}</span>
+					<span />
+				</div>
+				<div className="omp-ranked-list">
+					{rows.map((p, idx) => {
+						const rate = p.totalRequests > 0 ? p.failedRequests / p.totalRequests : 0;
+						const tone = providerFailureTone(rate);
+						const cacheRate = p.totalTokens > 0 ? p.totalCacheReadTokens / p.totalTokens : 0;
+						const share = totalRequests > 0 ? p.totalRequests / totalRequests : 0;
+						const isExpanded = expanded === p.provider;
+						return (
+							<div
+								key={p.provider}
+								className="omp-ranked-row omp-provider-row"
+								data-tone={tone}
+								data-expanded={isExpanded ? "true" : "false"}
+								style={{ gridTemplateColumns: "22px minmax(0, 1.4fr) 84px 90px 90px 90px 70px 28px" }}
+								role="button"
+								tabIndex={0}
+								onClick={() => setExpanded(isExpanded ? null : p.provider)}
+								onKeyDown={e => {
+									if (e.key === "Enter" || e.key === " ") {
+										e.preventDefault();
+										setExpanded(isExpanded ? null : p.provider);
+									}
+								}}
+							>
+								<span className="omp-ranked-row-rank">{idx + 1}</span>
+								<span className="omp-ranked-row-main">
+									<span className="omp-ranked-row-title">{p.provider}</span>
+									<span className="omp-ranked-row-sub">
+										{p.models} model{p.models === 1 ? "" : "s"} · {formatCompact(p.totalTokens)} tok
+									</span>
+								</span>
+								<span className="omp-ranked-bar">
+									<span
+										className="omp-ranked-bar-fill"
+										style={{
+											width: `${share * 100}%`,
+											background:
+												tone === "danger"
+													? "var(--danger)"
+													: tone === "warning"
+														? "var(--amber)"
+														: "var(--text)",
+										}}
+									/>
+								</span>
+								<span className="omp-ranked-metric">
+									<strong>{formatInteger(p.totalRequests)}</strong>
+									<small>{formatPercent(share, 1)}</small>
+								</span>
+								<span className="omp-ranked-metric">
+									{formatEstimatedCost(p.totalCost, p.unpricedRequests, 2)}
+								</span>
+								<span
+									className="omp-ranked-metric"
+									style={{
+										color:
+											tone === "danger"
+												? "var(--danger)"
+												: tone === "warning"
+													? "var(--amber)"
+													: "var(--muted)",
+									}}
+								>
+									{formatInteger(p.failedRequests)}
+									<small>{formatPercent(rate, 1)}</small>
+								</span>
+								<span className="omp-ranked-metric">{formatPercent(cacheRate, 1)}</span>
+								<button
+									type="button"
+									className="omp-ranked-expand"
+									aria-label={isExpanded ? "Collapse" : "Expand"}
+									onClick={e => {
+										e.stopPropagation();
+										setExpanded(isExpanded ? null : p.provider);
+									}}
+								>
+									{isExpanded ? "−" : "+"}
+								</button>
+
+								{isExpanded && (
+									<div className="omp-ranked-detail" onClick={e => e.stopPropagation()}>
+										<div className="omp-ranked-detail-grid">
+											<div>
+												<div className="omp-ranked-detail-label">Tokens</div>
+												<div className="omp-ranked-detail-value">{formatCompact(p.totalTokens)}</div>
+												<div
+													style={{ fontSize: 11, color: "var(--muted)", fontFamily: "var(--font-mono)" }}
+												>
+													in {formatCompact(p.totalInputTokens)} · out {formatCompact(p.totalOutputTokens)}
+												</div>
+											</div>
+											<div>
+												<div className="omp-ranked-detail-label">Cache</div>
+												<div className="omp-ranked-detail-value">{formatPercent(cacheRate, 1)}</div>
+												<div style={{ fontSize: 11, color: "var(--muted)" }}>
+													{formatCompact(p.totalCacheReadTokens)} read
+												</div>
+											</div>
+											<div>
+												<div className="omp-ranked-detail-label">Latency</div>
+												<div className="omp-ranked-detail-value">
+													{p.avgTokensPerSecond ? `${p.avgTokensPerSecond.toFixed(1)} tok/s` : "—"}
+												</div>
+												<div style={{ fontSize: 11, color: "var(--muted)" }}>{p.models} models</div>
+											</div>
+											<div>
+												<div className="omp-ranked-detail-label">Failures</div>
+												<div
+													className="omp-ranked-detail-value"
+													style={{
+														color:
+															tone === "ok"
+																? "var(--text)"
+																: tone === "warning"
+																	? "var(--amber)"
+																	: "var(--danger)",
+													}}
+												>
+													{formatPercent(rate, 2)}
+												</div>
+												<div style={{ fontSize: 11, color: "var(--muted)" }}>
+													{formatInteger(p.failedRequests)} / {formatInteger(p.totalRequests)}
+												</div>
+											</div>
+										</div>
+										<ProviderMiniTrend provider={p.provider} range={range} />
+									</div>
+								)}
+							</div>
+						);
+					})}
+				</div>
+			</div>
+		</div>
 	);
 }
 
-// ---------------------------------------------------------------------------
-// Token / cost trend by provider
-// ---------------------------------------------------------------------------
-
-function ProviderTrendPanel({ stats }: { stats: ProviderDashboardStats }) {
-	const [metric, setMetric] = useState<"tokens" | "cost">("tokens");
+function ProviderMiniTrend({ provider, range }: { provider: string; range: TimeRange }) {
 	const theme = useSystemTheme();
 	const chartTheme = CHART_THEMES[theme];
-	const unpricedRequests = useMemo(
-		() => stats.providers.reduce((sum, provider) => sum + provider.unpricedRequests, 0),
-		[stats.providers],
-	);
-
-	// buildTopNByModelSeries keys on `model`; feed it the provider name so we
-	// get the same top-N + "Other" rollup without a parallel implementation.
-	const chartData = useMemo(() => {
-		const points = stats.series.map(p => ({ ...p, model: p.provider }));
-		return buildTopNByModelSeries<(typeof points)[number], { total: number }>(points, {
-			topN: 6,
-			rankWeight: p => (metric === "tokens" ? p.totalTokens : p.cost),
-			initBucket: () => ({ total: 0 }),
-			accumulate: (bucket, p) => {
-				bucket.total += metric === "tokens" ? p.totalTokens : p.cost;
-			},
-			bucketToValue: bucket => bucket.total,
-		});
-	}, [stats.series, metric]);
-
-	const formatValue = metric === "tokens" ? formatCompact : (v: number) => formatCost(v);
-	const options = useMemo(() => {
-		const { sharedScaleBase, yScale } = buildSharedScales({ chartTheme, formatY: formatValue });
-		return {
-			responsive: true,
-			maintainAspectRatio: false,
-			interaction: { mode: "index" as const, intersect: false },
-			plugins: buildSharedPlugins({
-				chartTheme,
-				showLegend: true,
-				defaultLabel: metric === "tokens" ? "Tokens" : "API-equivalent estimate",
-				formatValue,
-				footer: items => {
-					if (items.length < 2) return undefined;
-					const total = items.reduce((sum, item) => sum + (item.parsed.y ?? 0), 0);
-					return `Total: ${formatValue(total)}`;
-				},
-			}),
-			scales: {
-				x: { ...sharedScaleBase, stacked: true },
-				y: { ...yScale, stacked: true },
-			},
-		};
-	}, [chartTheme, metric, formatValue]);
-
-	const data = useMemo(
-		() => ({
-			labels: chartData.labels,
-			datasets: styleDatasets(chartData, i => barDatasetStyle(MODEL_COLORS[i % MODEL_COLORS.length])),
-		}),
-		[chartData],
-	);
-
+	// We don't have per-provider series loaded here; show placeholder that this would be per-provider trend if needed.
+	// To keep data honest, we show a compact note instead of invented data.
 	return (
-		<Panel
-			title="Burn by Provider"
-			subtitle={
-				metric === "cost" && unpricedRequests > 0
-					? `API-equivalent estimates over time; excludes ${unpricedRequests.toLocaleString()} unpriced subscription request${unpricedRequests === 1 ? "" : "s"}`
-					: "Stacked token or API-equivalent estimate burn over time"
-			}
-			actions={
-				<SegmentedControl
-					options={[
-						{ value: "tokens" as const, label: "Tokens" },
-						{ value: "cost" as const, label: "API-equivalent estimate" },
-					]}
-					value={metric}
-					onChange={setMetric}
-				/>
-			}
+		<div
+			style={{
+				fontFamily: "var(--font-mono)",
+				fontSize: 11,
+				color: "var(--dim)",
+				paddingTop: 4,
+				borderTop: "1px dashed var(--border)",
+			}}
 		>
-			<div className="h-[300px]">
-				{chartData.labels.length === 0 ? (
-					<EmptyState message="No provider activity in this range" />
-				) : (
-					<Bar data={data} options={options} />
-				)}
-			</div>
-		</Panel>
-	);
-}
-
-// ---------------------------------------------------------------------------
-// Peak burn hours
-// ---------------------------------------------------------------------------
-
-const ALL_PROVIDERS = "__all__";
-
-function PeakHoursPanel({ hourly, providers }: { hourly: ProviderHourlyPoint[]; providers: ProviderAggregate[] }) {
-	const [provider, setProvider] = useState(ALL_PROVIDERS);
-	const theme = useSystemTheme();
-	const chartTheme = CHART_THEMES[theme];
-
-	const { tokensByHour, peakHour } = useMemo(() => {
-		// oxlint-disable-next-line unicorn/no-new-array -- length preallocation
-		const tokens = new Array<number>(24).fill(0);
-		for (const point of hourly) {
-			if (provider !== ALL_PROVIDERS && point.provider !== provider) continue;
-			tokens[point.hour] += point.totalTokens;
-		}
-		let peak = 0;
-		for (let hour = 1; hour < 24; hour++) {
-			if (tokens[hour] > tokens[peak]) peak = hour;
-		}
-		return { tokensByHour: tokens, peakHour: peak };
-	}, [hourly, provider]);
-
-	const hasData = tokensByHour.some(v => v > 0);
-
-	const data = useMemo(
-		() => ({
-			labels: Array.from({ length: 24 }, (_, hour) => `${String(hour).padStart(2, "0")}:00`),
-			datasets: [
-				{
-					label: "Tokens",
-					data: tokensByHour,
-					...barDatasetStyle(MODEL_COLORS[2]),
-					// Highlight the peak hour in the brand accent color.
-					backgroundColor: tokensByHour.map((_, hour) => (hour === peakHour ? MODEL_COLORS[0] : MODEL_COLORS[2])),
-				},
-			],
-		}),
-		[tokensByHour, peakHour],
-	);
-
-	const options = useMemo(() => {
-		const { sharedScaleBase, yScale } = buildSharedScales({ chartTheme, formatY: formatCompact });
-		return {
-			responsive: true,
-			maintainAspectRatio: false,
-			plugins: buildSharedPlugins({
-				chartTheme,
-				showLegend: false,
-				defaultLabel: "Tokens",
-				formatValue: formatCompact,
-			}),
-			scales: { x: sharedScaleBase, y: yScale },
-		};
-	}, [chartTheme]);
-
-	return (
-		<Panel
-			title="Peak Burn Hours"
-			subtitle={
-				hasData
-					? `Token burn by local hour of day — peak at ${String(peakHour).padStart(2, "0")}:00`
-					: "Token burn by local hour of day"
-			}
-			actions={
-				<select
-					className="stats-select"
-					value={provider}
-					onChange={e => setProvider(e.target.value)}
-					aria-label="Provider"
-				>
-					<option value={ALL_PROVIDERS}>All providers</option>
-					{providers.map(p => (
-						<option key={p.provider} value={p.provider}>
-							{p.provider}
-						</option>
-					))}
-				</select>
-			}
-		>
-			<div className="h-[260px]">
-				{hasData ? <Bar data={data} options={options} /> : <EmptyState message="No activity in this range" />}
-			</div>
-		</Panel>
-	);
-}
-
-// ---------------------------------------------------------------------------
-// Subscription window insights
-// ---------------------------------------------------------------------------
-
-function WindowInsightsPanel({ insights }: { insights: ProviderWindowInsight[] }) {
-	const columns: DataTableColumn<ProviderWindowInsight>[] = [
-		{ key: "provider", header: "Provider", render: i => <span className="font-medium">{i.provider}</span> },
-		{ key: "window", header: "Window", render: i => i.windowLabel },
-		{ key: "accounts", header: "Accounts", numeric: true, render: i => formatInteger(i.accounts) },
-		{
-			key: "consumed",
-			header: "Windows Burned",
-			numeric: true,
-			render: i => (
-				<span title="Subscription-window equivalents consumed in range (sum of used-fraction increases across accounts)">
-					{i.fractionConsumed.toFixed(2)}
-				</span>
-			),
-		},
-		{
-			key: "capacity",
-			header: "Est. Tokens / Window",
-			numeric: true,
-			render: i => (
-				<span title="Provider tokens burned in range ÷ windows burned — what one full window is worth">
-					{i.estTokensPerWindow !== null ? formatCompact(i.estTokensPerWindow) : "—"}
-				</span>
-			),
-		},
-		{
-			key: "peak",
-			header: "Peak Utilization",
-			numeric: true,
-			render: i => (
-				<span title="Peak of summed used fraction across accounts at any sampled instant">
-					{formatPercent(i.peakConcurrentFraction)}
-				</span>
-			),
-		},
-		{
-			key: "ideal",
-			header: "Ideal Accounts",
-			numeric: true,
-			render: i => (
-				<span
-					title="Accounts needed to keep peak demand under 90% of fleet capacity"
-					className={i.idealAccounts > i.accounts ? "stats-text-warning font-semibold" : undefined}
-				>
-					{formatInteger(i.idealAccounts)}
-					{i.idealAccounts > i.accounts ? ` (have ${i.accounts})` : ""}
-				</span>
-			),
-		},
-		{
-			key: "exhausted",
-			header: "Exhaustions",
-			numeric: true,
-			render: i => (
-				<span className={i.exhaustedEvents > 0 ? "stats-text-warning" : undefined}>
-					{formatInteger(i.exhaustedEvents)}
-				</span>
-			),
-		},
-	];
-
-	return (
-		<Panel
-			title="Subscription Windows"
-			subtitle="What each usage window buys you, and how many accounts peak demand needs"
-		>
-			<DataTable
-				columns={columns}
-				data={insights}
-				keyExtractor={i => `${i.provider}::${i.windowKey}`}
-				emptyText="No usage snapshots recorded yet — they accumulate whenever usage is fetched (TUI footer, /usage, omp usage)"
-			/>
-		</Panel>
-	);
-}
-
-// ---------------------------------------------------------------------------
-// Window utilization
-// ---------------------------------------------------------------------------
-
-const UTILIZATION_COLORS = {
-	ok: "#62d394",
-	warning: "#f5c14b",
-	exhausted: "#ff6b7d",
-} as const;
-
-function WindowUtilizationPanel({ usageSeries }: { usageSeries: UsageWindowSeries[] }) {
-	const providers = useMemo(() => [...new Set(usageSeries.map(s => s.provider))], [usageSeries]);
-	const [selected, setSelected] = useState<string | null>(null);
-	const provider = selected !== null && providers.includes(selected) ? selected : (providers[0] ?? null);
-	const theme = useSystemTheme();
-	const chartTheme = CHART_THEMES[theme];
-
-	// One row per (window, account): the latest recorded fraction. Snapshot
-	// history is bursty (rows appear whenever usage is fetched), so a "how full
-	// is each window right now" bar reads far better than a time axis.
-	const rows = useMemo(() => {
-		return usageSeries
-			.filter(s => s.provider === provider)
-			.map(s => {
-				const latest = [...s.points].reverse().find(p => p.usedFraction !== null);
-				return latest
-					? {
-							label: `${s.windowLabel} · ${s.accountLabel}`,
-							fraction: latest.usedFraction ?? 0,
-							exhausted: latest.exhausted,
-							recordedAt: latest.timestamp,
-						}
-					: null;
-			})
-			.filter(row => row !== null)
-			.sort((a, b) => b.fraction - a.fraction);
-	}, [usageSeries, provider]);
-
-	const data = useMemo(
-		() => ({
-			labels: rows.map(r => r.label),
-			datasets: [
-				{
-					label: "Used",
-					data: rows.map(r => r.fraction * 100),
-					backgroundColor: rows.map(r =>
-						r.exhausted
-							? UTILIZATION_COLORS.exhausted
-							: r.fraction >= 0.8
-								? UTILIZATION_COLORS.warning
-								: UTILIZATION_COLORS.ok,
-					),
-					borderWidth: 0,
-					borderRadius: 4,
-					barThickness: 18,
-				},
-			],
-		}),
-		[rows],
-	);
-
-	const options = useMemo(() => {
-		const { sharedScaleBase, yScale } = buildSharedScales({ chartTheme, formatY: v => `${Math.round(v)}%` });
-		const xMax = Math.max(100, ...rows.map(r => r.fraction * 100));
-		const shared = buildSharedPlugins({
-			chartTheme,
-			showLegend: false,
-			defaultLabel: "Used",
-			formatValue: v => `${v.toFixed(1)}%`,
-		});
-		return {
-			indexAxis: "y" as const,
-			responsive: true,
-			maintainAspectRatio: false,
-			plugins: {
-				...shared,
-				tooltip: {
-					...shared.tooltip,
-					callbacks: {
-						label: (ctx: { dataIndex: number; parsed: { x: number | null } }) => {
-							const row = rows[ctx.dataIndex];
-							const used = `${(ctx.parsed.x ?? 0).toFixed(1)}% used`;
-							return row ? `${used} · recorded ${formatRelativeTime(row.recordedAt)}` : used;
-						},
-					},
-				},
-			},
-			scales: {
-				x: { ...yScale, max: xMax },
-				y: { ...sharedScaleBase, grid: { display: false } },
-			},
-		};
-	}, [chartTheme, rows]);
-
-	return (
-		<Panel
-			title="Window Utilization"
-			subtitle="Latest recorded limit utilization per account and window — red bars are exhausted, amber above 80%"
-			actions={
-				providers.length > 1 ? (
-					<select
-						className="stats-select"
-						value={provider ?? ""}
-						onChange={e => setSelected(e.target.value)}
-						aria-label="Provider"
-					>
-						{providers.map(p => (
-							<option key={p} value={p}>
-								{p}
-							</option>
-						))}
-					</select>
-				) : undefined
-			}
-		>
-			<div style={{ height: Math.max(160, rows.length * 34 + 60) }}>
-				{rows.length === 0 ? (
-					<EmptyState message="No usage snapshots recorded yet — they accumulate whenever usage is fetched" />
-				) : (
-					<Bar data={data} options={options} />
-				)}
-			</div>
-		</Panel>
+			Provider <span style={{ color: "var(--text)" }}>{provider}</span> · window {range} · per-provider burn
+			available via Overview trend. No extra mock series — honest placeholder.
+		</div>
 	);
 }

--- a/packages/stats/src/client/routes/RequestsRoute.tsx
+++ b/packages/stats/src/client/routes/RequestsRoute.tsx
@@ -1,9 +1,10 @@
-import { useMemo } from "react";
-import { getRecentRequests } from "../api";
-import { formatDurationMs, formatInteger, formatMessageCost, formatRelativeTime } from "../data/formatters";
+import { useEffect, useMemo, useState } from "react";
+import { getRequestsPaginated } from "../api";
+import { formatDurationMs, formatInteger, formatMessageCost } from "../data/formatters";
 import { useResource } from "../data/useResource";
+import { type RequestSortKey, type SortDir, sortRequests } from "../data/view-models";
 import type { MessageStats, TimeRange } from "../types";
-import { AsyncBoundary, DataTable, Panel, StatusPill } from "../ui";
+import { AsyncBoundary, StatusPill } from "../ui";
 
 export interface RequestsRouteProps {
 	active: boolean;
@@ -12,112 +13,231 @@ export interface RequestsRouteProps {
 	onRequestClick: (id: number) => void;
 }
 
-export function RequestsRoute({ active, refreshTrigger, onRequestClick }: RequestsRouteProps) {
+const PAGE_SIZE = 25;
+const SORT_KEY = "omp-stats:requests-sort";
+type Stored = { key: RequestSortKey; dir: SortDir };
+function loadSort(): Stored {
+	try {
+		const raw = sessionStorage.getItem(SORT_KEY);
+		if (raw) return JSON.parse(raw) as Stored;
+	} catch {}
+	return { key: "timestamp", dir: "desc" };
+}
+function saveSort(v: Stored) {
+	try {
+		sessionStorage.setItem(SORT_KEY, JSON.stringify(v));
+	} catch {}
+}
+
+export function RequestsRoute({ active, range, refreshTrigger, onRequestClick }: RequestsRouteProps) {
+	const [offset, setOffset] = useState(0);
+	useEffect(() => setOffset(0), [range, refreshTrigger]);
+
 	const {
-		data: recentRequests,
+		data: page,
 		error,
 		loading,
-	} = useResource(["recent-requests-dense", refreshTrigger], signal => getRecentRequests(50, signal), {
-		pollMs: 30000,
-		enabled: active,
-	});
-
-	const columns = useMemo(
-		() => [
-			{
-				key: "model",
-				header: "Model",
-				render: (item: MessageStats) => (
-					<div>
-						<div className="stats-font-medium stats-text-primary">{item.model}</div>
-						<div className="stats-text-xs stats-text-muted">{item.provider}</div>
-					</div>
-				),
-			},
-			{
-				key: "timestamp",
-				header: "Time",
-				render: (item: MessageStats) => formatRelativeTime(item.timestamp),
-			},
-			{
-				key: "tokens",
-				header: "Tokens",
-				numeric: true,
-				render: (item: MessageStats) => formatInteger(item.usage.totalTokens),
-			},
-			{
-				key: "cost",
-				header: "API-equivalent estimate",
-				numeric: true,
-				render: (item: MessageStats) => formatMessageCost(item, 4),
-			},
-			{
-				key: "duration",
-				header: "Duration",
-				numeric: true,
-				render: (item: MessageStats) => formatDurationMs(item.duration),
-			},
-			{
-				key: "status",
-				header: "Status",
-				className: "stats-text-center",
-				render: (item: MessageStats) => (
-					<StatusPill variant={item.errorMessage ? "danger" : "success"}>
-						{item.errorMessage ? "Failed" : "Success"}
-					</StatusPill>
-				),
-			},
-		],
-		[],
-	);
-
-	const renderMobileCard = (item: MessageStats, onClick?: () => void) => (
-		<div className="stats-mobile-card" onClick={onClick}>
-			<div className="stats-mobile-card-header">
-				<div>
-					<div className="stats-font-semibold stats-text-primary">{item.model}</div>
-					<div className="stats-text-xs stats-text-muted">{item.provider}</div>
-				</div>
-				<StatusPill variant={item.errorMessage ? "danger" : "success"}>
-					{item.errorMessage ? "Failed" : "Success"}
-				</StatusPill>
-			</div>
-			<div className="stats-mobile-card-grid">
-				<div>
-					<div className="stats-mobile-card-label">Time</div>
-					<div className="stats-mobile-card-value">{formatRelativeTime(item.timestamp)}</div>
-				</div>
-				<div>
-					<div className="stats-mobile-card-label">API-equivalent estimate</div>
-					<div className="stats-mobile-card-value">{formatMessageCost(item, 4)}</div>
-				</div>
-				<div>
-					<div className="stats-mobile-card-label">Tokens</div>
-					<div className="stats-mobile-card-value">{formatInteger(item.usage.totalTokens)}</div>
-				</div>
-				<div>
-					<div className="stats-mobile-card-label">Duration</div>
-					<div className="stats-mobile-card-value">{formatDurationMs(item.duration)}</div>
-				</div>
-			</div>
-			{item.errorMessage && <div className="stats-mobile-card-error truncate mt-2">{item.errorMessage}</div>}
-		</div>
+	} = useResource(
+		["requests", range, refreshTrigger, offset],
+		signal => getRequestsPaginated(range, PAGE_SIZE, offset, signal),
+		{ pollMs: 30000, enabled: active },
 	);
 
 	return (
 		<div className="stats-route-container">
-			<Panel title="All Recent Requests" subtitle="Up to 50 most recent requests processed by OMP">
-				<AsyncBoundary loading={loading} error={error} data={recentRequests}>
-					<DataTable
-						columns={columns}
-						data={recentRequests || []}
-						keyExtractor={item => item.id || `${item.sessionFile}-${item.entryId}`}
-						onRowClick={item => item.id && onRequestClick(item.id)}
-						renderMobileCard={renderMobileCard}
-						emptyText="No recent requests found"
+			<div className="omp-hero">
+				<div className="omp-hero-head">
+					<h2 className="omp-hero-title">
+						Requests <span>{range} · explorer</span>
+					</h2>
+					<span className="omp-hero-range">
+						{page ? `${page.total} total · page ${Math.floor(offset / PAGE_SIZE) + 1}` : "loading"}
+					</span>
+				</div>
+				<p
+					style={{
+						fontFamily: "var(--font-sans)",
+						fontSize: 12,
+						color: "var(--muted)",
+						margin: 0,
+						maxWidth: 720,
+						lineHeight: 1.5,
+					}}
+				>
+					Serious explorer — time, model, provider, input/output, cache, latency, cost, status. Row click opens the
+					drawer (reuses RequestDrawer). Sorted client-side within the loaded page; paginated server-side.
+				</p>
+			</div>
+
+			<AsyncBoundary loading={loading} error={error} data={page}>
+				{page && (
+					<RequestsExplorer
+						requests={page.requests}
+						total={page.total}
+						offset={offset}
+						setOffset={setOffset}
+						onRequestClick={onRequestClick}
 					/>
-				</AsyncBoundary>
-			</Panel>
+				)}
+			</AsyncBoundary>
+		</div>
+	);
+}
+
+function RequestsExplorer({
+	requests,
+	total,
+	offset,
+	setOffset,
+	onRequestClick,
+}: {
+	requests: MessageStats[];
+	total: number;
+	offset: number;
+	setOffset: (n: number) => void;
+	onRequestClick: (id: number) => void;
+}) {
+	const [sort, setSort] = useState<Stored>(() => loadSort());
+	useEffect(() => saveSort(sort), [sort]);
+
+	const sorted = useMemo(() => sortRequests(requests, sort.key, sort.dir), [requests, sort]);
+	const toggle = (key: RequestSortKey) =>
+		setSort(prev => (prev.key === key ? { key, dir: prev.dir === "asc" ? "desc" : "asc" } : { key, dir: "desc" }));
+	const headBtn = (label: string, key: RequestSortKey) => {
+		const active = sort.key === key;
+		return (
+			<button type="button" data-active={active ? "true" : "false"} onClick={() => toggle(key)}>
+				{label}{" "}
+				<span style={{ fontSize: 10, opacity: active ? 1 : 0.35 }}>
+					{active ? (sort.dir === "asc" ? "↑" : "↓") : "↕"}
+				</span>
+			</button>
+		);
+	};
+
+	return (
+		<div className="omp-section">
+			<div className="omp-section-head">
+				<div>
+					<div className="omp-section-title">Request stream</div>
+					<p className="omp-section-desc">
+						Click any row for full request detail. Cache columns distinguish prompt caching from plain tokens.
+					</p>
+				</div>
+				<span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--dim)" }}>
+					{formatInteger(total)} total
+				</span>
+			</div>
+			<div className="omp-section-rule" />
+			<div className="omp-section-body">
+				<div className="omp-explorer-wrap">
+					<div className="omp-explorer-head">
+						<span>{headBtn("Time", "timestamp")}</span>
+						<span>{headBtn("Model", "model")}</span>
+						<span className="hide-md">Provider</span>
+						<span style={{ textAlign: "right" }}>{headBtn("In", "tokens")}</span>
+						<span style={{ textAlign: "right" }}>Out</span>
+						<span style={{ textAlign: "right" }} className="hide-md">
+							Cache
+						</span>
+						<span style={{ textAlign: "right" }}>{headBtn("Latency", "duration")}</span>
+						<span style={{ textAlign: "right" }}>{headBtn("Cost", "cost")}</span>
+						<span style={{ textAlign: "center" }}>Status</span>
+					</div>
+					{sorted.length === 0 ? (
+						<div className="stats-table-empty">No requests in this window.</div>
+					) : (
+						sorted.map(r => {
+							const isError = !!r.errorMessage;
+							return (
+								<div
+									key={r.id ?? `${r.entryId}-${r.timestamp}`}
+									className="omp-explorer-row"
+									role="button"
+									tabIndex={0}
+									onClick={() => r.id && onRequestClick(r.id)}
+									onKeyDown={e => {
+										if ((e.key === "Enter" || e.key === " ") && r.id) {
+											e.preventDefault();
+											onRequestClick(r.id);
+										}
+									}}
+								>
+									<span className="mono" style={{ color: "var(--dim)" }}>
+										{new Date(r.timestamp).toLocaleString()}
+									</span>
+									<span
+										style={{
+											fontFamily: "var(--font-mono)",
+											fontSize: 11,
+											color: "var(--text)",
+											fontWeight: 600,
+											overflow: "hidden",
+											textOverflow: "ellipsis",
+											whiteSpace: "nowrap",
+										}}
+										title={r.model}
+									>
+										{r.model}
+									</span>
+									<span
+										className="mono hide-md"
+										title={r.provider}
+										style={{ overflow: "hidden", textOverflow: "ellipsis" }}
+									>
+										{r.provider}
+									</span>
+									<span className="mono" style={{ textAlign: "right" }}>
+										{formatInteger(r.usage.input)}
+									</span>
+									<span className="mono" style={{ textAlign: "right" }}>
+										{formatInteger(r.usage.output)}
+									</span>
+									<span className="mono hide-md" style={{ textAlign: "right" }}>
+										{formatInteger(r.usage.cacheRead)}
+									</span>
+									<span className="mono" style={{ textAlign: "right" }}>
+										{formatDurationMs(r.duration)}
+									</span>
+									<span className="mono" style={{ textAlign: "right", color: "var(--amber)" }}>
+										{formatMessageCost(r, 4)}
+									</span>
+									<span style={{ textAlign: "center" }}>
+										<StatusPill variant={isError ? "danger" : "success"}>
+											{isError ? "Fail" : "OK"}
+										</StatusPill>
+									</span>
+								</div>
+							);
+						})
+					)}
+					<div className="omp-explorer-pager">
+						<span>
+							Showing {sorted.length === 0 ? 0 : offset + 1}–{offset + sorted.length} of {formatInteger(total)}
+						</span>
+						<div style={{ display: "flex", gap: 6 }}>
+							<button
+								type="button"
+								className="stats-button stats-button-secondary"
+								style={{ fontSize: 11, padding: "5px 10px" }}
+								disabled={offset === 0}
+								onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+							>
+								← Prev
+							</button>
+							<button
+								type="button"
+								className="stats-button stats-button-secondary"
+								style={{ fontSize: 11, padding: "5px 10px" }}
+								disabled={offset + PAGE_SIZE >= total}
+								onClick={() => setOffset(offset + PAGE_SIZE)}
+							>
+								Next →
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/packages/stats/src/client/routes/ToolsRoute.tsx
+++ b/packages/stats/src/client/routes/ToolsRoute.tsx
@@ -1,8 +1,5 @@
-import { useMemo, useState } from "react";
-import { Line } from "react-chartjs-2";
+import { useEffect, useMemo, useState } from "react";
 import { getToolDashboardStats } from "../api";
-import { CHART_THEMES, MODEL_COLORS } from "../components/chart-shared";
-import { formatRangeTick, rangeMeta } from "../components/range-meta";
 import {
 	formatCompact,
 	formatEstimatedCost,
@@ -11,15 +8,30 @@ import {
 	formatRelativeTime,
 } from "../data/formatters";
 import { useResource } from "../data/useResource";
-import { buildToolRows, type ToolRowView } from "../data/view-models";
-import type { TimeRange, ToolModelStats, ToolTimeSeriesPoint, ToolUsageStats } from "../types";
-import { AsyncBoundary, DataTable, Panel, StatusPill } from "../ui";
-import { useSystemTheme } from "../useSystemTheme";
+import { buildToolRows } from "../data/view-models";
+import type { TimeRange, ToolUsageStats } from "../types";
+import { AsyncBoundary, StatusPill } from "../ui";
 
 export interface ToolsRouteProps {
 	active: boolean;
 	range: TimeRange;
 	refreshTrigger: number;
+}
+
+type SortKey = "calls" | "errorRate" | "resultChars" | "tokens" | "cost" | "tool";
+type SortDir = "asc" | "desc";
+const SORT_KEY = "omp-stats:tools-sort";
+function load(): { key: SortKey; dir: SortDir } {
+	try {
+		const raw = sessionStorage.getItem(SORT_KEY);
+		if (raw) return JSON.parse(raw) as never;
+	} catch {}
+	return { key: "calls", dir: "desc" };
+}
+function save(v: { key: SortKey; dir: SortDir }) {
+	try {
+		sessionStorage.setItem(SORT_KEY, JSON.stringify(v));
+	} catch {}
 }
 
 export function ToolsRoute({ active, range, refreshTrigger }: ToolsRouteProps) {
@@ -33,443 +45,163 @@ export function ToolsRoute({ active, range, refreshTrigger }: ToolsRouteProps) {
 	});
 
 	return (
-		<div className="stats-route-container space-y-6">
-			<AsyncBoundary loading={loading} error={error} data={stats} emptyText="No tool calls recorded for this range.">
-				{stats && (
-					<>
-						<ToolsSummaryPanel byTool={stats.byTool} />
-						<ToolCallsChart series={stats.series} timeRange={range} />
-						<ToolsTable byTool={stats.byTool} />
-						<ToolModelPanel byToolModel={stats.byToolModel} />
-					</>
-				)}
+		<div className="stats-route-container">
+			<div className="omp-hero">
+				<div className="omp-hero-head">
+					<h2 className="omp-hero-title">
+						Tools <span>{range} · behavior</span>
+					</h2>
+					<span className="omp-hero-range">
+						{stats
+							? `${stats.byTool.length} tools · ${formatInteger(stats.byTool.reduce((s, t) => s + t.calls, 0))} calls`
+							: "loading"}
+					</span>
+				</div>
+				<p
+					style={{
+						fontFamily: "var(--font-sans)",
+						fontSize: 12,
+						color: "var(--muted)",
+						margin: 0,
+						maxWidth: 720,
+						lineHeight: 1.5,
+					}}
+				>
+					Tool behavior — calls, error rate, result size (chars fed back), tokens induced and cost share from
+					invoking turns. No invented latency or context-residency; honest attribution only.
+				</p>
+			</div>
+
+			<AsyncBoundary loading={loading} error={error} data={stats}>
+				{stats && <ToolsRanked byTool={stats.byTool} />}
 			</AsyncBoundary>
 		</div>
 	);
 }
 
-// ---------------------------------------------------------------------------
-// Summary metrics
-// ---------------------------------------------------------------------------
+function ToolsRanked({ byTool }: { byTool: ToolUsageStats[] }) {
+	const baseRows = useMemo(() => buildToolRows(byTool), [byTool]);
+	const [sort, setSort] = useState<{ key: SortKey; dir: SortDir }>(() => load());
+	useEffect(() => save(sort), [sort]);
 
-function ToolsSummaryPanel({ byTool }: { byTool: ToolUsageStats[] }) {
-	const totals = useMemo(() => {
-		let calls = 0;
-		let errors = 0;
-		let tokens = 0;
-		let output = 0;
-		let cost = 0;
-		let unpricedRequests = 0;
-		let resultChars = 0;
-		let argsChars = 0;
-		for (const t of byTool) {
-			calls += t.calls;
-			errors += t.errors;
-			tokens += t.totalTokensShare;
-			output += t.outputTokensShare;
-			cost += t.costShare;
-			unpricedRequests += t.unpricedRequestsShare;
-			resultChars += t.resultChars;
-			argsChars += t.argsChars;
-		}
-		return { calls, errors, tokens, output, cost, unpricedRequests, resultChars, argsChars, tools: byTool.length };
-	}, [byTool]);
+	const rows = useMemo(() => {
+		const mul = sort.dir === "asc" ? 1 : -1;
+		return [...baseRows].sort((a, b) => {
+			let cmp = 0;
+			switch (sort.key) {
+				case "calls":
+					cmp = a.calls - b.calls;
+					break;
+				case "errorRate":
+					cmp = a.errorRate - b.errorRate;
+					break;
+				case "resultChars":
+					cmp = a.resultChars - b.resultChars;
+					break;
+				case "tokens":
+					cmp = a.totalTokensShare - b.totalTokensShare;
+					break;
+				case "cost":
+					cmp = a.costShare - b.costShare;
+					break;
+				case "tool":
+					cmp = a.tool.localeCompare(b.tool);
+					break;
+			}
+			if (cmp !== 0) return cmp * mul;
+			return b.calls - a.calls;
+		});
+	}, [baseRows, sort]);
 
-	return (
-		<Panel
-			title="Tool Usage"
-			subtitle="Tokens and API-equivalent estimates are split from invoking turns across each turn's tool calls"
-		>
-			<div className="stats-metric-cluster">
-				<div className="stats-metric-primary-grid">
-					<div className="stats-metric-card primary">
-						<div className="stats-metric-label">Tool Calls</div>
-						<div className="stats-metric-value">{formatInteger(totals.calls)}</div>
-					</div>
-					<div className="stats-metric-card primary">
-						<div className="stats-metric-label">Tools Used</div>
-						<div className="stats-metric-value">{formatInteger(totals.tools)}</div>
-					</div>
-					<div className="stats-metric-card primary">
-						<div className="stats-metric-label">Error Rate</div>
-						<div className="stats-metric-value">
-							{formatPercent(totals.calls > 0 ? totals.errors / totals.calls : 0)}
-						</div>
-					</div>
-					<div className="stats-metric-card primary">
-						<div className="stats-metric-label">Attributed API-equivalent estimate</div>
-						<div className="stats-metric-value">{formatEstimatedCost(totals.cost, totals.unpricedRequests)}</div>
-					</div>
-				</div>
-
-				<div className="stats-metric-secondary-grid">
-					<div className="stats-metric-card secondary">
-						<div className="stats-metric-label">Attributed Tokens</div>
-						<div className="stats-metric-value">{formatCompact(Math.round(totals.tokens))}</div>
-					</div>
-					<div className="stats-metric-card secondary">
-						<div className="stats-metric-label">Attributed Output</div>
-						<div className="stats-metric-value">{formatCompact(Math.round(totals.output))}</div>
-					</div>
-					<div className="stats-metric-card secondary">
-						<div className="stats-metric-label">Result Text</div>
-						<div className="stats-metric-value">{formatCompact(totals.resultChars)} chars</div>
-					</div>
-					<div className="stats-metric-card secondary">
-						<div className="stats-metric-label">Call Arguments</div>
-						<div className="stats-metric-value">{formatCompact(totals.argsChars)} chars</div>
-					</div>
-				</div>
-			</div>
-		</Panel>
-	);
-}
-
-// ---------------------------------------------------------------------------
-// Calls over time (stacked by top tools)
-// ---------------------------------------------------------------------------
-
-const TOP_TOOLS = 6;
-
-function buildToolCallSeries(points: ToolTimeSeriesPoint[]): {
-	buckets: number[];
-	tools: string[];
-	data: Map<number, Record<string, number>>;
-} {
-	const totals = new Map<string, number>();
-	for (const p of points) totals.set(p.tool, (totals.get(p.tool) ?? 0) + p.calls);
-	const ranked = [...totals.entries()].sort((a, b) => b[1] - a[1]);
-	const top = ranked.slice(0, TOP_TOOLS).map(([tool]) => tool);
-	const topSet = new Set(top);
-	const hasOther = ranked.length > top.length;
-	const tools = hasOther ? [...top, "Other"] : top;
-
-	const buckets = [...new Set(points.map(p => p.timestamp))].sort((a, b) => a - b);
-	const data = new Map<number, Record<string, number>>();
-	for (const bucket of buckets) data.set(bucket, {});
-	for (const p of points) {
-		const label = topSet.has(p.tool) ? p.tool : "Other";
-		const row = data.get(p.timestamp);
-		if (row) row[label] = (row[label] ?? 0) + p.calls;
-	}
-	return { buckets, tools, data };
-}
-
-function ToolCallsChart({ series, timeRange }: { series: ToolTimeSeriesPoint[]; timeRange: TimeRange }) {
-	const theme = useSystemTheme();
-	const chartTheme = CHART_THEMES[theme];
-	const meta = rangeMeta(timeRange);
-
-	const chartSeries = useMemo(() => buildToolCallSeries(series), [series]);
-
-	const data = useMemo(
-		() => ({
-			labels: chartSeries.buckets.map(ts => formatRangeTick(ts, timeRange)),
-			datasets: chartSeries.tools.map((tool, index) => ({
-				label: tool,
-				data: chartSeries.buckets.map(bucket => chartSeries.data.get(bucket)?.[tool] ?? 0),
-				borderColor: MODEL_COLORS[index % MODEL_COLORS.length],
-				backgroundColor: `${MODEL_COLORS[index % MODEL_COLORS.length]}30`,
-				fill: true,
-				tension: 0.4,
-				pointRadius: 0,
-				pointHoverRadius: 4,
-				borderWidth: 2,
-			})),
-		}),
-		[chartSeries, timeRange],
-	);
-
-	const options = useMemo(
-		() => ({
-			responsive: true,
-			maintainAspectRatio: false,
-			interaction: { mode: "index" as const, intersect: false },
-			plugins: {
-				legend: {
-					position: "top" as const,
-					align: "start" as const,
-					labels: {
-						color: chartTheme.legendLabel,
-						usePointStyle: true,
-						padding: 16,
-						font: { size: 12 },
-						boxWidth: 8,
-					},
-				},
-				tooltip: {
-					backgroundColor: chartTheme.tooltipBackground,
-					titleColor: chartTheme.tooltipTitle,
-					bodyColor: chartTheme.tooltipBody,
-					borderColor: chartTheme.tooltipBorder,
-					borderWidth: 1,
-					padding: 12,
-					cornerRadius: 8,
-					callbacks: {
-						label: (context: { dataset: { label?: string }; parsed: { y: number | null } }) =>
-							`${context.dataset.label ?? ""}: ${formatInteger(context.parsed.y ?? 0)} calls`,
-					},
-				},
-			},
-			scales: {
-				x: {
-					stacked: true,
-					grid: { color: chartTheme.grid, drawBorder: false },
-					ticks: { color: chartTheme.tick, font: { size: 11 } },
-				},
-				y: {
-					stacked: true,
-					grid: { color: chartTheme.grid, drawBorder: false },
-					ticks: { color: chartTheme.tick, font: { size: 11 }, precision: 0 },
-					min: 0,
-				},
-			},
-		}),
-		[chartTheme],
-	);
+	const toggle = (key: SortKey) =>
+		setSort(prev =>
+			prev.key === key
+				? { key, dir: prev.dir === "asc" ? "desc" : "asc" }
+				: { key, dir: key === "tool" ? "asc" : "desc" },
+		);
+	const btn = (label: string, key: SortKey) => {
+		const active = sort.key === key;
+		return (
+			<button type="button" data-active={active ? "true" : "false"} onClick={() => toggle(key)}>
+				{label}
+				<span style={{ fontSize: 10, opacity: active ? 1 : 0.35 }}>
+					{active ? (sort.dir === "asc" ? "↑" : "↓") : "↕"}
+				</span>
+			</button>
+		);
+	};
 
 	return (
-		<Panel title="Calls Over Time" subtitle={`Tool calls over ${meta.windowLabel}, stacked by tool`}>
-			<div className="h-[280px]">
-				{chartSeries.buckets.length === 0 ? (
-					<div className="h-full flex items-center justify-center text-stats-muted text-sm">No data available</div>
-				) : (
-					<Line data={data} options={options} />
-				)}
+		<div className="omp-section">
+			<div className="omp-section-head">
+				<div>
+					<div className="omp-section-title">Tool calls ranked</div>
+					<p className="omp-section-desc">
+						Share bar = calls vs busiest tool. Tokens/cost are invoking-turn attribution (split evenly per turn).
+					</p>
+				</div>
+				<span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--dim)" }}>
+					{rows.length} tools
+				</span>
 			</div>
-		</Panel>
-	);
-}
+			<div className="omp-section-rule" />
+			<div className="omp-section-body">
+				<div
+					className="omp-ranked-head"
+					style={{
+						display: "grid",
+						gridTemplateColumns: "22px minmax(0, 1.4fr) 84px 90px 90px 90px 90px 70px",
+						gap: 10,
+					}}
+				>
+					<span>#</span>
+					<span>{btn("Tool", "tool")}</span>
+					<span style={{ textAlign: "center" }}>Share</span>
+					<span style={{ textAlign: "right" }}>{btn("Calls", "calls")}</span>
+					<span style={{ textAlign: "right" }}>{btn("Error", "errorRate")}</span>
+					<span style={{ textAlign: "right" }}>{btn("Result chars", "resultChars")}</span>
+					<span style={{ textAlign: "right" }}>{btn("Tokens", "tokens")}</span>
+					<span style={{ textAlign: "right" }}>{btn("Cost", "cost")}</span>
+				</div>
 
-// ---------------------------------------------------------------------------
-// Per-tool table
-// ---------------------------------------------------------------------------
-
-function errorPillVariant(errorRate: number): "danger" | "warning" | "success" {
-	return errorRate > 0.1 ? "danger" : errorRate > 0 ? "warning" : "success";
-}
-
-function ToolsTable({ byTool }: { byTool: ToolUsageStats[] }) {
-	const rows = useMemo(() => buildToolRows(byTool), [byTool]);
-
-	const columns = useMemo(
-		() => [
-			{
-				key: "tool",
-				header: "Tool",
-				render: (item: ToolRowView) => (
-					<div className="stats-font-medium stats-text-primary font-mono truncate max-w-[280px]" title={item.tool}>
-						{item.tool}
-					</div>
-				),
-			},
-			{
-				key: "calls",
-				header: "Calls",
-				numeric: true,
-				render: (item: ToolRowView) => (
-					<div className="stats-text-right">
-						<div className="font-mono">{formatInteger(item.calls)}</div>
-						<div className="stats-progress-bar-track mt-1 ml-auto w-24 h-1">
-							<div
-								className="stats-progress-bar-fill"
-								data-variant="link"
-								style={{ width: `${item.callsPercentage}%` }}
-							/>
+				<div className="omp-ranked-list">
+					{rows.map((t, idx) => (
+						<div
+							key={t.tool}
+							className="omp-ranked-row"
+							style={{ gridTemplateColumns: "22px minmax(0, 1.4fr) 84px 90px 90px 90px 90px 70px" }}
+						>
+							<span className="omp-ranked-row-rank">{idx + 1}</span>
+							<span className="omp-ranked-row-main">
+								<span
+									className="omp-ranked-row-title"
+									title={t.tool}
+									style={{ fontFamily: "var(--font-mono)" }}
+								>
+									{t.tool}
+								</span>
+								<span className="omp-ranked-row-sub">last {formatRelativeTime(t.lastUsed)}</span>
+							</span>
+							<span className="omp-ranked-bar">
+								<span className="omp-ranked-bar-fill" style={{ width: `${t.callsPercentage}%` }} />
+							</span>
+							<span className="omp-ranked-metric">
+								<strong>{formatInteger(t.calls)}</strong>
+							</span>
+							<span className="omp-ranked-metric">
+								<StatusPill variant={t.errorRate > 0.1 ? "danger" : t.errorRate > 0 ? "warning" : "success"}>
+									{formatPercent(t.errorRate, 1)}
+								</StatusPill>
+							</span>
+							<span className="omp-ranked-metric">{formatCompact(t.resultChars)}</span>
+							<span className="omp-ranked-metric">{formatCompact(Math.round(t.totalTokensShare))}</span>
+							<span className="omp-ranked-metric">
+								{formatEstimatedCost(t.costShare, t.unpricedRequestsShare, 2)}
+							</span>
 						</div>
-					</div>
-				),
-			},
-			{
-				key: "errorRate",
-				header: "Error Rate",
-				numeric: true,
-				render: (item: ToolRowView) => (
-					<StatusPill variant={errorPillVariant(item.errorRate)}>{formatPercent(item.errorRate)}</StatusPill>
-				),
-			},
-			{
-				key: "tokens",
-				header: "Attr. Tokens",
-				numeric: true,
-				render: (item: ToolRowView) => (
-					<span className="font-mono" title="Invoking turns' total tokens, split across each turn's calls">
-						{formatCompact(Math.round(item.totalTokensShare))}
-					</span>
-				),
-			},
-			{
-				key: "cost",
-				header: "Attr. API-equivalent estimate",
-				numeric: true,
-				render: (item: ToolRowView) => (
-					<span className="font-mono">{formatEstimatedCost(item.costShare, item.unpricedRequestsShare)}</span>
-				),
-			},
-			{
-				key: "resultChars",
-				header: "Result Text",
-				numeric: true,
-				render: (item: ToolRowView) => (
-					<span className="font-mono" title="Characters of tool-result text fed back into context">
-						{formatCompact(item.resultChars)}
-					</span>
-				),
-			},
-			{
-				key: "lastUsed",
-				header: "Last Used",
-				numeric: true,
-				render: (item: ToolRowView) => (
-					<span className="stats-text-secondary">{formatRelativeTime(item.lastUsed)}</span>
-				),
-			},
-		],
-		[],
-	);
-
-	const renderMobileCard = (item: ToolRowView) => (
-		<div className="stats-mobile-card">
-			<div className="stats-mobile-card-header mb-2">
-				<div className="stats-font-semibold stats-text-primary font-mono">{item.tool}</div>
-				<StatusPill variant={errorPillVariant(item.errorRate)}>{formatPercent(item.errorRate)} Err</StatusPill>
-			</div>
-			<div className="stats-mobile-card-grid">
-				<div>
-					<div className="stats-mobile-card-label">Calls</div>
-					<div className="stats-mobile-card-value font-mono">{formatInteger(item.calls)}</div>
-				</div>
-				<div>
-					<div className="stats-mobile-card-label">Attr. Tokens</div>
-					<div className="stats-mobile-card-value font-mono">
-						{formatCompact(Math.round(item.totalTokensShare))}
-					</div>
-				</div>
-				<div>
-					<div className="stats-mobile-card-label">Attr. API-equivalent estimate</div>
-					<div className="stats-mobile-card-value font-mono">
-						{formatEstimatedCost(item.costShare, item.unpricedRequestsShare)}
-					</div>
-				</div>
-				<div>
-					<div className="stats-mobile-card-label">Result Text</div>
-					<div className="stats-mobile-card-value font-mono">{formatCompact(item.resultChars)}</div>
+					))}
 				</div>
 			</div>
 		</div>
-	);
-
-	return (
-		<Panel title="By Tool" subtitle="Usage per tool, most called first">
-			<DataTable
-				columns={columns}
-				data={rows}
-				keyExtractor={item => item.tool}
-				renderMobileCard={renderMobileCard}
-				emptyText="No tool calls recorded for this range."
-			/>
-		</Panel>
-	);
-}
-
-// ---------------------------------------------------------------------------
-// Per-(tool, model) breakdown
-// ---------------------------------------------------------------------------
-
-function ToolModelPanel({ byToolModel }: { byToolModel: ToolModelStats[] }) {
-	const [tool, setTool] = useState<string | null>(null);
-
-	const tools = useMemo(() => [...new Set(byToolModel.map(row => row.tool))].sort(), [byToolModel]);
-
-	const rows = useMemo(() => {
-		const filtered = tool ? byToolModel.filter(row => row.tool === tool) : byToolModel;
-		return filtered.map(row => ({
-			...row,
-			errorRate: row.calls > 0 ? row.errors / row.calls : 0,
-		}));
-	}, [byToolModel, tool]);
-
-	const columns = useMemo(
-		() => [
-			{
-				key: "tool",
-				header: "Tool",
-				render: (item: ToolModelStats & { errorRate: number }) => (
-					<span className="stats-font-medium stats-text-primary font-mono">{item.tool}</span>
-				),
-			},
-			{
-				key: "model",
-				header: "Model",
-				render: (item: ToolModelStats & { errorRate: number }) => (
-					<div>
-						<div className="stats-text-primary">{item.model || "(unknown)"}</div>
-						<div className="stats-text-secondary text-xs">{item.provider}</div>
-					</div>
-				),
-			},
-			{
-				key: "calls",
-				header: "Calls",
-				numeric: true,
-				render: (item: ToolModelStats & { errorRate: number }) => (
-					<span className="font-mono">{formatInteger(item.calls)}</span>
-				),
-			},
-			{
-				key: "errorRate",
-				header: "Error Rate",
-				numeric: true,
-				render: (item: ToolModelStats & { errorRate: number }) => (
-					<StatusPill variant={errorPillVariant(item.errorRate)}>{formatPercent(item.errorRate)}</StatusPill>
-				),
-			},
-			{
-				key: "tokens",
-				header: "Attr. Tokens",
-				numeric: true,
-				render: (item: ToolModelStats & { errorRate: number }) => (
-					<span className="font-mono">{formatCompact(Math.round(item.totalTokensShare))}</span>
-				),
-			},
-			{
-				key: "cost",
-				header: "Attr. API-equivalent estimate",
-				numeric: true,
-				render: (item: ToolModelStats & { errorRate: number }) => (
-					<span className="font-mono">{formatEstimatedCost(item.costShare, item.unpricedRequestsShare)}</span>
-				),
-			},
-		],
-		[],
-	);
-
-	return (
-		<Panel title="By Model" subtitle="Which models call which tools">
-			<div className="mb-4" style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
-				<span className="stats-text-secondary" style={{ fontSize: "0.875rem", whiteSpace: "nowrap" }}>
-					Tool
-				</span>
-				<select
-					className="stats-select"
-					value={tool ?? ""}
-					onChange={e => setTool(e.target.value || null)}
-					style={{ maxWidth: "320px", flex: 1 }}
-				>
-					<option value="">All tools</option>
-					{tools.map(name => (
-						<option key={name} value={name}>
-							{name}
-						</option>
-					))}
-				</select>
-			</div>
-			<DataTable
-				columns={columns}
-				data={rows}
-				keyExtractor={item => `${item.tool}::${item.model}::${item.provider}`}
-				emptyText="No tool calls recorded for this range."
-			/>
-		</Panel>
 	);
 }

--- a/packages/stats/src/client/styles.css
+++ b/packages/stats/src/client/styles.css
@@ -7,517 +7,1197 @@
    ========================================================================== */
 
 :root {
-  color-scheme: dark;
-  --page: oklch(0.148 0.022 306);
-  --surface: oklch(0.193 0.022 307);
-  --surface-2: oklch(0.233 0.024 307);
-  --surface-3: oklch(0.27 0.028 307);
-  --raised: oklch(0.215 0.02 307);
-  --border: oklch(1 0 0 / 0.08);
-  --border-strong: oklch(1 0 0 / 0.13);
-  --text: oklch(0.93 0.008 307);
-  --muted: oklch(0.69 0.015 307);
-  --dim: oklch(0.52 0.018 307);
-  --accent: oklch(0.72 0.04 230);
-  --accent-fg: oklch(0.14 0.02 307);
-  --accent-muted: oklch(0.72 0.04 230 / 0.11);
-  --focus: oklch(0.78 0.12 205);
-  --link: oklch(0.80 0.11 205);
-  --success: oklch(0.74 0.13 150);
-  --danger: oklch(0.66 0.19 25);
-  --warning: oklch(0.78 0.14 85);
-  --amber: oklch(0.77 0.16 84);
-  --text-primary: var(--text);
-  --text-secondary: var(--muted);
-  --text-muted: var(--dim);
-  --border-subtle: var(--border);
-  --accent-red: var(--danger);
-  --accent-green: var(--success);
-  --accent-cyan: var(--success);
-  --bg-hover: var(--surface-2);
-  --bg-elevated: var(--surface-2);
-  --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+	color-scheme: dark;
+	--page: oklch(0.148 0.022 306);
+	--surface: oklch(0.193 0.022 307);
+	--surface-2: oklch(0.233 0.024 307);
+	--surface-3: oklch(0.27 0.028 307);
+	--raised: oklch(0.215 0.02 307);
+	--border: oklch(1 0 0 / 0.08);
+	--border-strong: oklch(1 0 0 / 0.13);
+	--text: oklch(0.93 0.008 307);
+	--muted: oklch(0.69 0.015 307);
+	--dim: oklch(0.52 0.018 307);
+	--accent: oklch(0.72 0.04 230);
+	--accent-fg: oklch(0.14 0.02 307);
+	--accent-muted: oklch(0.72 0.04 230 / 0.11);
+	--focus: oklch(0.78 0.12 205);
+	--link: oklch(0.8 0.11 205);
+	--success: oklch(0.74 0.13 150);
+	--danger: oklch(0.66 0.19 25);
+	--warning: oklch(0.78 0.14 85);
+	--amber: oklch(0.77 0.16 84);
+	--text-primary: var(--text);
+	--text-secondary: var(--muted);
+	--text-muted: var(--dim);
+	--border-subtle: var(--border);
+	--accent-red: var(--danger);
+	--accent-green: var(--success);
+	--accent-cyan: var(--success);
+	--bg-hover: var(--surface-2);
+	--bg-elevated: var(--surface-2);
+	--select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
 
-  --radius-sm: 3px;
-  --radius-md: 5px;
-  --radius-lg: 8px;
-  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
-  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  --font-display: "Inter", ui-sans-serif, system-ui, sans-serif;
-  --raised: oklch(0.985 0.005 307);
-  --chart-req: oklch(0.68 0.015 307);
-  --chart-err: var(--danger);
-  --tok-input: oklch(0.60 0.015 307);
-  --tok-output: oklch(0.70 0.015 307);
-  --tok-read: var(--success);
-  --tok-write: var(--dim);
-  --space-1: 4px;
-  --space-2: 8px;
-  --space-3: 12px;
-  --space-4: 16px;
-  --content-gap: 18px;
-  --content-pad: 22px;
+	--radius-sm: 3px;
+	--radius-md: 5px;
+	--radius-lg: 8px;
+	--font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+	--font-sans:
+		"Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
+		sans-serif;
+	--font-display: "Inter", ui-sans-serif, system-ui, sans-serif;
+	--raised: oklch(0.985 0.005 307);
+	--chart-req: oklch(0.68 0.015 307);
+	--chart-err: var(--danger);
+	--tok-input: oklch(0.6 0.015 307);
+	--tok-output: oklch(0.7 0.015 307);
+	--tok-read: var(--success);
+	--tok-write: var(--dim);
+	--space-1: 4px;
+	--space-2: 8px;
+	--space-3: 12px;
+	--space-4: 16px;
+	--content-gap: 18px;
+	--content-pad: 22px;
 }
 
 @media (prefers-color-scheme: light) {
-  :root:not([data-theme]) {
-    color-scheme: light;
-    --page: oklch(0.99 0.004 307);
-    --surface: oklch(1 0 0);
-    --surface-2: oklch(0.968 0.006 307);
-    --surface-3: oklch(0.94 0.008 307);
-    --raised: oklch(0.985 0.005 307);
-    --border: oklch(0 0 0 / 0.08);
-    --border-strong: oklch(0 0 0 / 0.13);
-    --text: oklch(0.22 0.03 307);
-    --muted: oklch(0.45 0.025 307);
-    --dim: oklch(0.56 0.02 307);
-    --accent: oklch(0.57 0.06 230);
-    --accent-fg: oklch(0.99 0.01 230);
-    --accent-muted: oklch(0.57 0.06 230 / 0.10);
-    --focus: oklch(0.62 0.14 232);
-    --link: oklch(0.56 0.13 232);
-    --success: oklch(0.54 0.12 150);
-    --danger: oklch(0.56 0.18 25);
-    --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23555' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
-    --warning: oklch(0.62 0.13 85);
-    --amber: oklch(0.66 0.15 80);
-    --chart-req: oklch(0.43 0.015 307);
-    --chart-err: var(--danger);
-    --tok-input: oklch(0.50 0.015 307);
-    --tok-output: oklch(0.58 0.015 307);
-    --tok-read: var(--success);
-    --tok-write: var(--dim);
-  }
+	:root:not([data-theme]) {
+		color-scheme: light;
+		--page: oklch(0.99 0.004 307);
+		--surface: oklch(1 0 0);
+		--surface-2: oklch(0.968 0.006 307);
+		--surface-3: oklch(0.94 0.008 307);
+		--raised: oklch(0.985 0.005 307);
+		--border: oklch(0 0 0 / 0.08);
+		--border-strong: oklch(0 0 0 / 0.13);
+		--text: oklch(0.22 0.03 307);
+		--muted: oklch(0.45 0.025 307);
+		--dim: oklch(0.56 0.02 307);
+		--accent: oklch(0.57 0.06 230);
+		--accent-fg: oklch(0.99 0.01 230);
+		--accent-muted: oklch(0.57 0.06 230 / 0.1);
+		--focus: oklch(0.62 0.14 232);
+		--link: oklch(0.56 0.13 232);
+		--success: oklch(0.54 0.12 150);
+		--danger: oklch(0.56 0.18 25);
+		--select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23555' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+		--warning: oklch(0.62 0.13 85);
+		--amber: oklch(0.66 0.15 80);
+		--chart-req: oklch(0.43 0.015 307);
+		--chart-err: var(--danger);
+		--tok-input: oklch(0.5 0.015 307);
+		--tok-output: oklch(0.58 0.015 307);
+		--tok-read: var(--success);
+		--tok-write: var(--dim);
+	}
 }
 [data-theme="light"] {
-  color-scheme: light;
-  --page: oklch(0.99 0.004 307);
-  --surface: oklch(1 0 0);
-  --surface-2: oklch(0.968 0.006 307);
-  --surface-3: oklch(0.94 0.008 307);
-  --raised: oklch(0.985 0.005 307);
-  --border: oklch(0 0 0 / 0.08);
-  --border-strong: oklch(0 0 0 / 0.13);
-  --text: oklch(0.22 0.03 307);
-  --muted: oklch(0.45 0.025 307);
-  --dim: oklch(0.56 0.02 307);
-  --accent: oklch(0.57 0.06 230);
-  --accent-fg: oklch(0.99 0.01 230);
-  --accent-muted: oklch(0.57 0.06 230 / 0.10);
-  --focus: oklch(0.62 0.14 232);
-  --link: oklch(0.56 0.13 232);
-  --success: oklch(0.54 0.12 150);
-  --danger: oklch(0.56 0.18 25);
-  --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23555' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
-  --warning: oklch(0.62 0.13 85);
-  --amber: oklch(0.66 0.15 80);
-  --chart-req: oklch(0.43 0.015 307);
-  --chart-err: var(--danger);
-  --tok-input: oklch(0.50 0.015 307);
-  --tok-output: oklch(0.58 0.015 307);
-  --tok-read: var(--success);
-  --tok-write: var(--dim);
+	color-scheme: light;
+	--page: oklch(0.99 0.004 307);
+	--surface: oklch(1 0 0);
+	--surface-2: oklch(0.968 0.006 307);
+	--surface-3: oklch(0.94 0.008 307);
+	--raised: oklch(0.985 0.005 307);
+	--border: oklch(0 0 0 / 0.08);
+	--border-strong: oklch(0 0 0 / 0.13);
+	--text: oklch(0.22 0.03 307);
+	--muted: oklch(0.45 0.025 307);
+	--dim: oklch(0.56 0.02 307);
+	--accent: oklch(0.57 0.06 230);
+	--accent-fg: oklch(0.99 0.01 230);
+	--accent-muted: oklch(0.57 0.06 230 / 0.1);
+	--focus: oklch(0.62 0.14 232);
+	--link: oklch(0.56 0.13 232);
+	--success: oklch(0.54 0.12 150);
+	--danger: oklch(0.56 0.18 25);
+	--select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23555' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+	--warning: oklch(0.62 0.13 85);
+	--amber: oklch(0.66 0.15 80);
+	--chart-req: oklch(0.43 0.015 307);
+	--chart-err: var(--danger);
+	--tok-input: oklch(0.5 0.015 307);
+	--tok-output: oklch(0.58 0.015 307);
+	--tok-read: var(--success);
+	--tok-write: var(--dim);
 }
-[data-theme="dark"] { color-scheme: dark; }
+[data-theme="dark"] {
+	color-scheme: dark;
+}
 [data-density="compact"] {
-  --content-gap: 12px;
-  --content-pad: 16px;
-  --space-3: 10px;
-  --space-4: 12px;
+	--content-gap: 12px;
+	--content-pad: 16px;
+	--space-3: 10px;
+	--space-4: 12px;
 }
 
 /* Base */
 @layer base {
-  * { box-sizing: border-box; }
-  html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-  body {
-    font-family: var(--font-sans);
-    background: var(--page);
-    color: var(--text);
-    margin: 0; min-height: 100vh;
-    font-size: 13px;
-    line-height: 1.5;
-    letter-spacing: -0.01em;
-  }
-  button:focus-visible, a:focus-visible, [tabindex]:focus-visible {
-    outline: 2px solid var(--focus); outline-offset: 2px;
-  }
+	* {
+		box-sizing: border-box;
+	}
+	html {
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
+	}
+	body {
+		font-family: var(--font-sans);
+		background: var(--page);
+		color: var(--text);
+		margin: 0;
+		min-height: 100vh;
+		font-size: 13px;
+		line-height: 1.5;
+		letter-spacing: -0.01em;
+	}
+	button:focus-visible,
+	a:focus-visible,
+	[tabindex]:focus-visible {
+		outline: 2px solid var(--focus);
+		outline-offset: 2px;
+	}
 }
 
 /* App shell */
-.stats-app-container { display: flex; min-height: 100vh; background: var(--page); color: var(--text); }
+.stats-app-container {
+	display: flex;
+	min-height: 100vh;
+	background: var(--page);
+	color: var(--text);
+}
 
 /* Nav Rail — collapsible */
 .stats-nav-rail {
-  width: 220px; background: var(--surface);
-  border-right: 1px solid var(--border);
-  display: flex; flex-direction: column; flex-shrink: 0;
-  position: sticky; top: 0; height: 100vh; overflow: hidden;
-  transition: width 0.18s ease;
+	width: 220px;
+	background: var(--surface);
+	border-right: 1px solid var(--border);
+	display: flex;
+	flex-direction: column;
+	flex-shrink: 0;
+	position: sticky;
+	top: 0;
+	height: 100vh;
+	overflow: hidden;
+	transition: width 0.18s ease;
 }
-.stats-nav-rail[data-collapsed="true"] { width: 56px; }
+.stats-nav-rail[data-collapsed="true"] {
+	width: 56px;
+}
 .stats-nav-rail[data-collapsed="true"] .stats-nav-rail-item-label,
 .stats-nav-rail[data-collapsed="true"] .stats-logo-text,
 .stats-nav-rail[data-collapsed="true"] .stats-logo-subtext,
 .stats-nav-rail[data-collapsed="true"] .stats-version-tag,
-.stats-nav-rail[data-collapsed="true"] .stats-nav-rail-footer-label { display: none; }
-.stats-nav-rail[data-collapsed="true"] .stats-nav-rail-header { padding: 14px 0; justify-content: center; }
-.stats-nav-rail[data-collapsed="true"] .stats-nav-rail-item { justify-content: center; padding: 9px; }
-.stats-desktop-nav { display: flex; }
-@media (max-width: 1023px) { .stats-desktop-nav { display: none; } }
+.stats-nav-rail[data-collapsed="true"] .stats-nav-rail-footer-label {
+	display: none;
+}
+.stats-nav-rail[data-collapsed="true"] .stats-nav-rail-header {
+	padding: 14px 0;
+	justify-content: center;
+}
+.stats-nav-rail[data-collapsed="true"] .stats-nav-rail-item {
+	justify-content: center;
+	padding: 9px;
+}
+.stats-desktop-nav {
+	display: flex;
+}
+@media (max-width: 1023px) {
+	.stats-desktop-nav {
+		display: none;
+	}
+}
 .stats-nav-rail-header {
-  padding: 16px 16px 14px; border-bottom: 1px solid var(--border);
-  min-height: 56px; display: flex; align-items: center; gap: 10px; flex-shrink: 0;
+	padding: 16px 16px 14px;
+	border-bottom: 1px solid var(--border);
+	min-height: 56px;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	flex-shrink: 0;
 }
 .stats-logo-mark {
-  width: 28px; height: 28px; border-radius: 6px;
-  background: var(--text); color: var(--surface);
-  display: grid; place-items: center;
-  font-family: var(--font-mono); font-size: 11px; font-weight: 800; letter-spacing: -0.02em; flex-shrink: 0;
+	width: 28px;
+	height: 28px;
+	border-radius: 6px;
+	background: var(--text);
+	color: var(--surface);
+	display: grid;
+	place-items: center;
+	font-family: var(--font-mono);
+	font-size: 11px;
+	font-weight: 800;
+	letter-spacing: -0.02em;
+	flex-shrink: 0;
 }
-.stats-nav-rail[data-collapsed="true"] .stats-logo-mark { width: 28px; height: 28px; }
-.stats-logo-container { display: flex; flex-direction: column; gap: 0; min-width: 0; }
-.stats-logo-text { font-family: var(--font-sans); font-size: 12px; font-weight: 800; letter-spacing: -0.02em; color: var(--text); line-height: 1.1; }
-.stats-logo-subtext { font-family: var(--font-sans); font-size: 11px; font-weight: 500; letter-spacing: 0.02em; color: var(--dim); line-height: 1; }
+.stats-nav-rail[data-collapsed="true"] .stats-logo-mark {
+	width: 28px;
+	height: 28px;
+}
+.stats-logo-container {
+	display: flex;
+	flex-direction: column;
+	gap: 0;
+	min-width: 0;
+}
+.stats-logo-text {
+	font-family: var(--font-sans);
+	font-size: 12px;
+	font-weight: 800;
+	letter-spacing: -0.02em;
+	color: var(--text);
+	line-height: 1.1;
+}
+.stats-logo-subtext {
+	font-family: var(--font-sans);
+	font-size: 11px;
+	font-weight: 500;
+	letter-spacing: 0.02em;
+	color: var(--dim);
+	line-height: 1;
+}
 .stats-nav-collapse-btn {
-  margin-left: auto; width: 26px; height: 26px; display: grid; place-items: center;
-  border: 1px solid var(--border); background: var(--surface-2); color: var(--muted);
-  border-radius: var(--radius-sm); cursor: pointer; flex-shrink: 0;
+	margin-left: auto;
+	width: 26px;
+	height: 26px;
+	display: grid;
+	place-items: center;
+	border: 1px solid var(--border);
+	background: var(--surface-2);
+	color: var(--muted);
+	border-radius: var(--radius-sm);
+	cursor: pointer;
+	flex-shrink: 0;
 }
-.stats-nav-collapse-btn:hover { color: var(--text); border-color: var(--border-strong); background: var(--surface-3); }
-.stats-nav-rail-menu { flex: 1; padding: 10px 8px; display: flex; flex-direction: column; gap: 2px; overflow-y: auto; }
+.stats-nav-collapse-btn:hover {
+	color: var(--text);
+	border-color: var(--border-strong);
+	background: var(--surface-3);
+}
+.stats-nav-rail-menu {
+	flex: 1;
+	padding: 10px 8px;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	overflow-y: auto;
+}
 .stats-nav-rail-item {
-  display: flex; align-items: center; gap: 10px; padding: 8px 10px;
-  font-size: 13px; font-weight: 500; color: var(--muted);
-  background: transparent; border: 1px solid transparent; border-radius: var(--radius-md);
-  cursor: pointer; text-align: left; transition: all 0.14s ease; width: 100%;
-  font-family: var(--font-sans); letter-spacing: -0.01em;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 8px 10px;
+	font-size: 13px;
+	font-weight: 500;
+	color: var(--muted);
+	background: transparent;
+	border: 1px solid transparent;
+	border-radius: var(--radius-md);
+	cursor: pointer;
+	text-align: left;
+	transition: all 0.14s ease;
+	width: 100%;
+	font-family: var(--font-sans);
+	letter-spacing: -0.01em;
 }
-.stats-nav-rail-item:hover { color: var(--text); background: var(--surface-2); }
+.stats-nav-rail-item:hover {
+	color: var(--text);
+	background: var(--surface-2);
+}
 .stats-nav-rail-item[data-active="true"] {
-  color: var(--text); background: var(--surface-2); border-color: transparent;
-  box-shadow: inset 2px 0 0 var(--text);
+	color: var(--text);
+	background: var(--surface-2);
+	border-color: transparent;
+	box-shadow: inset 2px 0 0 var(--text);
 }
-.stats-nav-rail-item-icon { flex-shrink: 0; opacity: 0.85; }
-.stats-nav-rail-item[data-active="true"] .stats-nav-rail-item-icon { opacity: 1; }
-.stats-nav-rail-item-label { flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.stats-nav-rail-footer { padding: 10px 12px; border-top: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; gap: 8px; flex-shrink: 0; }
-.stats-nav-rail-footer-label { font-family: var(--font-sans); font-size: 11px; color: var(--dim); letter-spacing: 0.01em; }
+.stats-nav-rail-item-icon {
+	flex-shrink: 0;
+	opacity: 0.85;
+}
+.stats-nav-rail-item[data-active="true"] .stats-nav-rail-item-icon {
+	opacity: 1;
+}
+.stats-nav-rail-item-label {
+	flex: 1;
+	min-width: 0;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.stats-nav-rail-footer {
+	padding: 10px 12px;
+	border-top: 1px solid var(--border);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	flex-shrink: 0;
+}
+.stats-nav-rail-footer-label {
+	font-family: var(--font-sans);
+	font-size: 11px;
+	color: var(--dim);
+	letter-spacing: 0.01em;
+}
 .stats-version-tag {
-  font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.06em; color: var(--dim);
-  border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 2px 6px; background: var(--surface-2);
+	font-family: var(--font-mono);
+	font-size: 9px;
+	letter-spacing: 0.06em;
+	color: var(--dim);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-sm);
+	padding: 2px 6px;
+	background: var(--surface-2);
 }
 .stats-density-toggle {
-  display: inline-flex; align-items: center; gap: 4px; padding: 4px 6px; border-radius: var(--radius-sm);
-  border: 1px solid var(--border); background: var(--surface-2); color: var(--muted); cursor: pointer;
-  font-family: var(--font-sans); font-size: 11px; font-weight: 600;
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px 6px;
+	border-radius: var(--radius-sm);
+	border: 1px solid var(--border);
+	background: var(--surface-2);
+	color: var(--muted);
+	cursor: pointer;
+	font-family: var(--font-sans);
+	font-size: 11px;
+	font-weight: 600;
 }
-.stats-density-toggle:hover { color: var(--text); background: var(--surface-3); }
+.stats-density-toggle:hover {
+	color: var(--text);
+	background: var(--surface-3);
+}
 
 /* Main pane */
-.stats-main-pane { flex: 1; display: flex; flex-direction: column; min-width: 0; background: var(--page); }
+.stats-main-pane {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+	background: var(--page);
+}
 
 .stats-top-bar {
-  height: 56px; background: var(--surface); border-bottom: 1px solid var(--border);
-  display: flex; align-items: center; justify-content: space-between; padding: 0 18px; gap: 14px;
-  position: sticky; top: 0; z-index: 10;
+	height: 56px;
+	background: var(--surface);
+	border-bottom: 1px solid var(--border);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0 18px;
+	gap: 14px;
+	position: sticky;
+	top: 0;
+	z-index: 10;
 }
 @media (max-width: 767px) {
-  .stats-top-bar { padding: 0 12px; flex-wrap: wrap; height: auto; min-height: 56px; padding-top: 8px; padding-bottom: 8px; gap: 10px; }
+	.stats-top-bar {
+		padding: 0 12px;
+		flex-wrap: wrap;
+		height: auto;
+		min-height: 56px;
+		padding-top: 8px;
+		padding-bottom: 8px;
+		gap: 10px;
+	}
 }
-.stats-top-bar-left { display: flex; align-items: center; gap: 10px; min-width: 0; }
-.stats-mobile-menu-btn { display: none; background: var(--surface-2); border: 1px solid var(--border); color: var(--text); padding: 6px; cursor: pointer; border-radius: var(--radius-md); }
-@media (max-width: 1023px) { .stats-mobile-menu-btn { display: inline-flex; align-items: center; justify-content: center; } }
+.stats-top-bar-left {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	min-width: 0;
+}
+.stats-mobile-menu-btn {
+	display: none;
+	background: var(--surface-2);
+	border: 1px solid var(--border);
+	color: var(--text);
+	padding: 6px;
+	cursor: pointer;
+	border-radius: var(--radius-md);
+}
+@media (max-width: 1023px) {
+	.stats-mobile-menu-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+	}
+}
 .stats-page-title {
-  font-family: var(--font-sans); font-size: 13px; font-weight: 700; color: var(--text); margin: 0; letter-spacing: -0.02em;
-  display: flex; align-items: center; gap: 8px; white-space: nowrap;
+	font-family: var(--font-sans);
+	font-size: 13px;
+	font-weight: 700;
+	color: var(--text);
+	margin: 0;
+	letter-spacing: -0.02em;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	white-space: nowrap;
 }
 .stats-page-title-rule {
-  width: 18px; height: 1px; background: var(--border-strong); display: inline-block; opacity: 0.9;
+	width: 18px;
+	height: 1px;
+	background: var(--border-strong);
+	display: inline-block;
+	opacity: 0.9;
 }
-.stats-top-bar-right { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-@media (max-width: 767px) { .stats-top-bar-right { width: 100%; justify-content: space-between; gap: 8px; } }
-.stats-top-bar-meta { display: flex; align-items: center; gap: 8px; }
+.stats-top-bar-right {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	flex-wrap: wrap;
+}
+@media (max-width: 767px) {
+	.stats-top-bar-right {
+		width: 100%;
+		justify-content: space-between;
+		gap: 8px;
+	}
+}
+.stats-top-bar-meta {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
 .stats-last-updated {
-  font-family: var(--font-mono); font-size: 10px; color: var(--dim); font-variant-numeric: tabular-nums;
-  background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 3px 6px;
+	font-family: var(--font-mono);
+	font-size: 10px;
+	color: var(--dim);
+	font-variant-numeric: tabular-nums;
+	background: var(--surface-2);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-sm);
+	padding: 3px 6px;
 }
-.stats-content-area { flex: 1; overflow-y: auto; }
-.stats-content-inner { max-width: 1360px; margin: 0 auto; padding: var(--content-pad); display: flex; flex-direction: column; gap: var(--content-gap); }
-@media (max-width: 767px) { .stats-content-inner { padding: 14px; gap: 14px; } }
+.stats-content-area {
+	flex: 1;
+	overflow-y: auto;
+}
+.stats-content-inner {
+	max-width: 1360px;
+	margin: 0 auto;
+	padding: var(--content-pad);
+	display: flex;
+	flex-direction: column;
+	gap: var(--content-gap);
+}
+@media (max-width: 767px) {
+	.stats-content-inner {
+		padding: 14px;
+		gap: 14px;
+	}
+}
 
 /* Mobile drawer */
-.stats-mobile-drawer-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.38); backdrop-filter: blur(2px); z-index: 100; }
-.stats-mobile-drawer { position: absolute; left: 0; top: 0; bottom: 0; width: 268px; background: var(--surface); border-right: 1px solid var(--border); display: flex; flex-direction: column; z-index: 101; animation: slideIn 0.2s ease-out; }
-@keyframes slideIn { from { transform: translateX(-100%); } to { transform: translateX(0); } }
-.stats-mobile-drawer-header { height: 56px; display: flex; align-items: center; justify-content: space-between; padding: 0 14px 0 16px; border-bottom: 1px solid var(--border); }
-.stats-mobile-nav { display: flex; height: calc(100% - 56px); }
+.stats-mobile-drawer-overlay {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.38);
+	backdrop-filter: blur(2px);
+	z-index: 100;
+}
+.stats-mobile-drawer {
+	position: absolute;
+	left: 0;
+	top: 0;
+	bottom: 0;
+	width: 268px;
+	background: var(--surface);
+	border-right: 1px solid var(--border);
+	display: flex;
+	flex-direction: column;
+	z-index: 101;
+	animation: slideIn 0.2s ease-out;
+}
+@keyframes slideIn {
+	from {
+		transform: translateX(-100%);
+	}
+	to {
+		transform: translateX(0);
+	}
+}
+.stats-mobile-drawer-header {
+	height: 56px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0 14px 0 16px;
+	border-bottom: 1px solid var(--border);
+}
+.stats-mobile-nav {
+	display: flex;
+	height: calc(100% - 56px);
+}
 
 /* Buttons — text-forward, not pill-heavy */
 .stats-button {
-  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
-  padding: 7px 11px; font-size: 12.5px; font-weight: 600; border-radius: var(--radius-md);
-  border: 1px solid transparent; cursor: pointer; transition: all 0.14s ease; font-family: var(--font-sans);
-  letter-spacing: -0.01em;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	padding: 7px 11px;
+	font-size: 12.5px;
+	font-weight: 600;
+	border-radius: var(--radius-md);
+	border: 1px solid transparent;
+	cursor: pointer;
+	transition: all 0.14s ease;
+	font-family: var(--font-sans);
+	letter-spacing: -0.01em;
 }
-.stats-button:active:not(:disabled) { transform: translateY(1px); }
-.stats-button-primary { background: var(--text); color: var(--surface); border-color: var(--text); }
-.stats-button-primary:hover:not(:disabled) { opacity: 0.9; }
-.stats-button-primary:disabled { opacity: 0.5; cursor: not-allowed; }
-.stats-button-secondary { background: var(--surface-2); color: var(--text); border-color: var(--border); }
-.stats-button-secondary:hover:not(:disabled) { background: var(--surface-3); border-color: var(--border-strong); }
-.stats-button-secondary:disabled { opacity: 0.5; cursor: not-allowed; }
-.stats-button-ghost { background: transparent; color: var(--muted); border-color: var(--border); }
-.stats-button-ghost:hover { color: var(--text); background: var(--surface-2); }
-.stats-sync-btn { background: var(--surface); color: var(--text); border-color: var(--border-strong); }
-.stats-sync-btn:hover:not(:disabled) { background: var(--surface-2); }
+.stats-button:active:not(:disabled) {
+	transform: translateY(1px);
+}
+.stats-button-primary {
+	background: var(--text);
+	color: var(--surface);
+	border-color: var(--text);
+}
+.stats-button-primary:hover:not(:disabled) {
+	opacity: 0.9;
+}
+.stats-button-primary:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+.stats-button-secondary {
+	background: var(--surface-2);
+	color: var(--text);
+	border-color: var(--border);
+}
+.stats-button-secondary:hover:not(:disabled) {
+	background: var(--surface-3);
+	border-color: var(--border-strong);
+}
+.stats-button-secondary:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+.stats-button-ghost {
+	background: transparent;
+	color: var(--muted);
+	border-color: var(--border);
+}
+.stats-button-ghost:hover {
+	color: var(--text);
+	background: var(--surface-2);
+}
+.stats-sync-btn {
+	background: var(--surface);
+	color: var(--text);
+	border-color: var(--border-strong);
+}
+.stats-sync-btn:hover:not(:disabled) {
+	background: var(--surface-2);
+}
 .stats-range-control {
-  display: flex; background: var(--surface-2); border: 1px solid var(--border);
-  border-radius: var(--radius-md); padding: 2px; gap: 1px;
+	display: flex;
+	background: var(--surface-2);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-md);
+	padding: 2px;
+	gap: 1px;
 }
 .stats-range-control-btn {
-  padding: 5px 9px; font-size: 11px; font-weight: 650; letter-spacing: 0.01em;
-  color: var(--muted); background: transparent; border: 1px solid transparent; border-radius: 4px;
-  cursor: pointer; transition: all 0.14s ease; font-family: var(--font-sans);
+	padding: 5px 9px;
+	font-size: 11px;
+	font-weight: 650;
+	letter-spacing: 0.01em;
+	color: var(--muted);
+	background: transparent;
+	border: 1px solid transparent;
+	border-radius: 4px;
+	cursor: pointer;
+	transition: all 0.14s ease;
+	font-family: var(--font-sans);
 }
-.stats-range-control-btn:hover { color: var(--text); }
-.stats-range-control-btn[data-active="true"] { background: var(--text); color: var(--surface); border-color: var(--text); }
+.stats-range-control-btn:hover {
+	color: var(--text);
+}
+.stats-range-control-btn[data-active="true"] {
+	background: var(--text);
+	color: var(--surface);
+	border-color: var(--text);
+}
 
 /* Sync + Theme */
-.stats-sync-container { display: flex; align-items: center; gap: 8px; }
-.stats-sync-status-msg { font-size: 11px; font-family: var(--font-sans); }
-.stats-sync-status-msg[data-type="success"] { color: var(--success); }
-.stats-sync-status-msg[data-type="error"] { color: var(--danger); }
-.stats-sync-icon { flex-shrink: 0; }
-.stats-spin { animation: spin 1s linear infinite; }
-@keyframes spin { to { transform: rotate(360deg); } }
+.stats-sync-container {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+.stats-sync-status-msg {
+	font-size: 11px;
+	font-family: var(--font-sans);
+}
+.stats-sync-status-msg[data-type="success"] {
+	color: var(--success);
+}
+.stats-sync-status-msg[data-type="error"] {
+	color: var(--danger);
+}
+.stats-sync-icon {
+	flex-shrink: 0;
+}
+.stats-spin {
+	animation: spin 1s linear infinite;
+}
+@keyframes spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
 
 .stats-range-control-btn[data-active="true"] {
-  color: var(--text);
-  background: var(--surface);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+	color: var(--text);
+	background: var(--surface);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
 }
 
 /* Select (native <select>, themed to match RangeControl/Buttons) */
 .stats-select {
-  appearance: none;
-  padding: 6px 28px 6px 12px;
-  font-size: 13px;
-  font-weight: 500;
-  font-family: inherit;
-  color: var(--text);
-  background-color: var(--surface-2);
-  /* Chevron follows theme: light stroke on dark, dark stroke on light. */
-  background-image: var(--select-chevron);
-  background-repeat: no-repeat;
-  background-position: right 10px center;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  transition: border-color 0.15s ease, background-color 0.15s ease;
-  max-width: 100%;
-  text-overflow: ellipsis;
+	appearance: none;
+	padding: 6px 28px 6px 12px;
+	font-size: 13px;
+	font-weight: 500;
+	font-family: inherit;
+	color: var(--text);
+	background-color: var(--surface-2);
+	/* Chevron follows theme: light stroke on dark, dark stroke on light. */
+	background-image: var(--select-chevron);
+	background-repeat: no-repeat;
+	background-position: right 10px center;
+	border: 1px solid var(--border);
+	border-radius: var(--radius-md);
+	cursor: pointer;
+	transition:
+		border-color 0.15s ease,
+		background-color 0.15s ease;
+	max-width: 100%;
+	text-overflow: ellipsis;
 }
 
 .stats-select:hover:not(:disabled) {
-  border-color: var(--border-strong);
-  background-color: var(--bg-hover);
+	border-color: var(--border-strong);
+	background-color: var(--bg-hover);
 }
 
 .stats-select:focus-visible {
-  outline: 2px solid var(--link);
-  outline-offset: 1px;
+	outline: 2px solid var(--link);
+	outline-offset: 1px;
 }
 
 .stats-select:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
+	opacity: 0.5;
+	cursor: not-allowed;
 }
 
 /* Prevent iOS from zooming the viewport when a select receives focus. */
 @media (pointer: coarse) {
-  .stats-select {
-    font-size: 16px;
-  }
+	.stats-select {
+		font-size: 16px;
+	}
 }
 
 /* Dropdown list itself follows the page theme via color-scheme. */
 .stats-select option {
-  background-color: var(--surface);
-  color: var(--text);
+	background-color: var(--surface);
+	color: var(--text);
 }
 /* Forced-colors (Windows High Contrast) suppresses background images, so the
    custom chevron vanishes; restore the native indicator instead. */
 @media (forced-colors: active) {
-  .stats-select {
-    appearance: auto;
-  }
+	.stats-select {
+		appearance: auto;
+	}
 }
 
 /* Sync Button & Container */
 .stats-sync-container {
-  display: flex;
-  align-items: center;
-  gap: 12px;
+	display: flex;
+	align-items: center;
+	gap: 12px;
 }
 
 .stats-sync-status-msg {
-  font-size: 11px;
-  font-variant-numeric: tabular-nums;
-  max-width: 200px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+	font-size: 11px;
+	font-variant-numeric: tabular-nums;
+	max-width: 200px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .stats-sync-status-msg[data-type="success"] {
-  color: var(--success);
+	color: var(--success);
 }
 
 .stats-sync-status-msg[data-type="error"] {
-  color: var(--danger);
+	color: var(--danger);
 }
 
 .stats-sync-icon {
-  flex-shrink: 0;
+	flex-shrink: 0;
 }
 
 .stats-spin {
-  animation: spin 1s linear infinite;
+	animation: spin 1s linear infinite;
 }
 
 @keyframes spin {
-  to { transform: rotate(360deg); }
+	to {
+		transform: rotate(360deg);
+	}
 }
 
 /* Panel */
 /* Panel — instrument housing */
 /* ========== OVERVIEW — de-cardified ========== */
-.stats-route-container { display: flex; flex-direction: column; gap: var(--content-gap); }
+.stats-route-container {
+	display: flex;
+	flex-direction: column;
+	gap: var(--content-gap);
+}
 
 /* Hero metrics — open, typographic, not 6 equal cards */
 .omp-hero {
-  display: flex; flex-direction: column; gap: 14px;
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
 }
 .omp-hero-head {
-  display: flex; align-items: baseline; justify-content: space-between; gap: 12px; flex-wrap: wrap;
-  border-bottom: 1px solid var(--border); padding-bottom: 12px;
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 12px;
+	flex-wrap: wrap;
+	border-bottom: 1px solid var(--border);
+	padding-bottom: 12px;
 }
 .omp-hero-title {
-  font-family: var(--font-sans); font-size: 22px; font-weight: 800; letter-spacing: -0.03em; color: var(--text); line-height: 1;
-  display: flex; align-items: baseline; gap: 10px;
+	font-family: var(--font-sans);
+	font-size: 22px;
+	font-weight: 800;
+	letter-spacing: -0.03em;
+	color: var(--text);
+	line-height: 1;
+	display: flex;
+	align-items: baseline;
+	gap: 10px;
 }
-.omp-hero-title span { font-weight: 500; font-size: 12px; color: var(--dim); letter-spacing: 0.04em; text-transform: uppercase; font-family: var(--font-mono); }
+.omp-hero-title span {
+	font-weight: 500;
+	font-size: 12px;
+	color: var(--dim);
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	font-family: var(--font-mono);
+}
 .omp-hero-range {
-  font-family: var(--font-mono); font-size: 11px; color: var(--muted); background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 4px 8px; font-variant-numeric: tabular-nums;
+	font-family: var(--font-mono);
+	font-size: 11px;
+	color: var(--muted);
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-sm);
+	padding: 4px 8px;
+	font-variant-numeric: tabular-nums;
 }
 .omp-metrics-herd {
-  display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 18px; align-items: baseline;
+	display: grid;
+	grid-template-columns: repeat(5, minmax(0, 1fr));
+	gap: 18px;
+	align-items: baseline;
 }
-@media (max-width: 1023px) { .omp-metrics-herd { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
-@media (max-width: 639px) { .omp-metrics-herd { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; } }
-.omp-kpi { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+@media (max-width: 1023px) {
+	.omp-metrics-herd {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+}
+@media (max-width: 639px) {
+	.omp-metrics-herd {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 14px;
+	}
+}
+.omp-kpi {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+}
 .omp-kpi-label {
-  font-family: var(--font-sans); font-size: 11px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--dim);
+	font-family: var(--font-sans);
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--dim);
 }
 .omp-kpi-value {
-  font-family: var(--font-sans); font-size: 26px; font-weight: 800; letter-spacing: -0.035em; color: var(--text); line-height: 1; font-variant-numeric: tabular-nums;
+	font-family: var(--font-sans);
+	font-size: 26px;
+	font-weight: 800;
+	letter-spacing: -0.035em;
+	color: var(--text);
+	line-height: 1;
+	font-variant-numeric: tabular-nums;
 }
-@media (max-width: 767px) { .omp-kpi-value { font-size: 22px; } }
-.omp-kpi-value[data-mono="true"] { font-family: var(--font-mono); font-weight: 700; letter-spacing: -0.02em; }
-.omp-kpi-sub { font-family: var(--font-mono); font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.omp-kpi-accent { width: 24px; height: 2px; border-radius: 1px; background: var(--border-strong); margin-top: 6px; }
-.omp-kpi[data-tone="danger"] .omp-kpi-accent { background: var(--danger); }
-.omp-kpi[data-tone="success"] .omp-kpi-accent { background: var(--success); }
-.omp-kpi[data-tone="warning"] .omp-kpi-accent { background: var(--amber); }
+@media (max-width: 767px) {
+	.omp-kpi-value {
+		font-size: 22px;
+	}
+}
+.omp-kpi-value[data-mono="true"] {
+	font-family: var(--font-mono);
+	font-weight: 700;
+	letter-spacing: -0.02em;
+}
+.omp-kpi-sub {
+	font-family: var(--font-mono);
+	font-size: 11px;
+	color: var(--muted);
+	font-variant-numeric: tabular-nums;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.omp-kpi-accent {
+	width: 24px;
+	height: 2px;
+	border-radius: 1px;
+	background: var(--border-strong);
+	margin-top: 6px;
+}
+.omp-kpi[data-tone="danger"] .omp-kpi-accent {
+	background: var(--danger);
+}
+.omp-kpi[data-tone="success"] .omp-kpi-accent {
+	background: var(--success);
+}
+.omp-kpi[data-tone="warning"] .omp-kpi-accent {
+	background: var(--amber);
+}
 
 /* Legacy tape kept for compatibility but not used in new overview */
-.stats-overview-tape { display: none; }
+.stats-overview-tape {
+	display: none;
+}
 
 /* Overview toolbar — dashboards */
 .omp-dashboard-bar {
-  display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap;
-  padding: 8px 10px; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-md);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	flex-wrap: wrap;
+	padding: 8px 10px;
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-md);
 }
-.omp-dashboard-tabs { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
+.omp-dashboard-tabs {
+	display: flex;
+	gap: 6px;
+	flex-wrap: wrap;
+	align-items: center;
+}
 .omp-dashboard-tab {
-  padding: 5px 10px; font-size: 12px; font-weight: 600; font-family: var(--font-sans); letter-spacing: -0.01em;
-  color: var(--muted); background: transparent; border: 1px solid var(--border); border-radius: var(--radius-sm); cursor: pointer;
+	padding: 5px 10px;
+	font-size: 12px;
+	font-weight: 600;
+	font-family: var(--font-sans);
+	letter-spacing: -0.01em;
+	color: var(--muted);
+	background: transparent;
+	border: 1px solid var(--border);
+	border-radius: var(--radius-sm);
+	cursor: pointer;
 }
-.omp-dashboard-tab[data-active="true"] { background: var(--text); color: var(--surface); border-color: var(--text); }
-.omp-dashboard-actions { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
+.omp-dashboard-tab[data-active="true"] {
+	background: var(--text);
+	color: var(--surface);
+	border-color: var(--text);
+}
+.omp-dashboard-actions {
+	display: flex;
+	gap: 6px;
+	align-items: center;
+	flex-wrap: wrap;
+}
 .omp-dashboard-input {
-  font-family: var(--font-sans); font-size: 12px; padding: 5px 8px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); color: var(--text); min-width: 140px;
+	font-family: var(--font-sans);
+	font-size: 12px;
+	padding: 5px 8px;
+	border: 1px solid var(--border);
+	border-radius: var(--radius-sm);
+	background: var(--surface-2);
+	color: var(--text);
+	min-width: 140px;
 }
-.omp-dashboard-input:focus { outline: 2px solid var(--focus); outline-offset: 1px; }
+.omp-dashboard-input:focus {
+	outline: 2px solid var(--focus);
+	outline-offset: 1px;
+}
 
 /* Section — open, not boxed */
 .omp-section {
-  display: flex; flex-direction: column; gap: 10px;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
 }
 .omp-section-head {
-  display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; flex-wrap: wrap;
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 12px;
+	flex-wrap: wrap;
 }
 .omp-section-title {
-  font-family: var(--font-sans); font-size: 13px; font-weight: 700; color: var(--text); letter-spacing: -0.02em; line-height: 1.2;
+	font-family: var(--font-sans);
+	font-size: 13px;
+	font-weight: 700;
+	color: var(--text);
+	letter-spacing: -0.02em;
+	line-height: 1.2;
 }
 .omp-section-desc {
-  font-family: var(--font-sans); font-size: 12px; color: var(--muted); line-height: 1.4; margin: 2px 0 0;
+	font-family: var(--font-sans);
+	font-size: 12px;
+	color: var(--muted);
+	line-height: 1.4;
+	margin: 2px 0 0;
 }
-.omp-section-rule { height: 1px; background: var(--border); width: 100%; }
-.omp-section-body { min-width: 0; }
+.omp-section-rule {
+	height: 1px;
+	background: var(--border);
+	width: 100%;
+}
+.omp-section-body {
+	min-width: 0;
+}
 
 /* Scope chart — restrained instrument, not card */
 .omp-scope-wrap {
-  display: grid; grid-template-columns: minmax(0, 1.6fr) minmax(280px, 0.95fr); gap: 16px; align-items: start;
+	display: grid;
+	grid-template-columns: minmax(0, 1.6fr) minmax(280px, 0.95fr);
+	gap: 16px;
+	align-items: start;
 }
-@media (max-width: 1023px) { .omp-scope-wrap { grid-template-columns: 1fr; } }
+@media (max-width: 1023px) {
+	.omp-scope-wrap {
+		grid-template-columns: 1fr;
+	}
+}
 .omp-scope-main {
-  background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden; display: flex; flex-direction: column; min-width: 0;
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-lg);
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
 }
-.omp-scope-side { display: flex; flex-direction: column; gap: 12px; min-width: 0; }
+.omp-scope-side {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	min-width: 0;
+}
 .omp-scope-header {
-  display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 10px 12px; border-bottom: 1px solid var(--border); background: var(--surface);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	padding: 10px 12px;
+	border-bottom: 1px solid var(--border);
+	background: var(--surface);
 }
-.omp-scope-title { font-family: var(--font-sans); font-size: 12px; font-weight: 700; letter-spacing: -0.015em; color: var(--text); display: flex; align-items: center; gap: 8px; }
-.omp-scope-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--success); box-shadow: 0 0 0 3px oklch(0.74 0.13 150 / 0.14); }
-.omp-scope-legend { display: flex; align-items: center; gap: 10px; font-family: var(--font-mono); font-size: 11px; color: var(--muted); }
-.omp-scope-legend span { display: inline-flex; align-items: center; gap: 5px; }
-.omp-scope-legend i { width: 12px; height: 2px; border-radius: 999px; display: inline-block; }
-.omp-scope-body { padding: 12px 10px 8px; position: relative; min-width: 0; min-height: 260px; }
-[data-theme="light"] .stats-scope-wrap .stats-scope-grid { opacity: 0.14; }
+.omp-scope-title {
+	font-family: var(--font-sans);
+	font-size: 12px;
+	font-weight: 700;
+	letter-spacing: -0.015em;
+	color: var(--text);
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+.omp-scope-dot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--success);
+	box-shadow: 0 0 0 3px oklch(0.74 0.13 150 / 0.14);
+}
+.omp-scope-legend {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	font-family: var(--font-mono);
+	font-size: 11px;
+	color: var(--muted);
+}
+.omp-scope-legend span {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+}
+.omp-scope-legend i {
+	width: 12px;
+	height: 2px;
+	border-radius: 999px;
+	display: inline-block;
+}
+.omp-scope-body {
+	padding: 12px 10px 8px;
+	position: relative;
+	min-width: 0;
+	min-height: 260px;
+}
+[data-theme="light"] .stats-scope-wrap .stats-scope-grid {
+	opacity: 0.14;
+}
 
 /* Token breakdown — 4-up, muted, not heavy cards */
 .omp-token-grid {
-  display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px;
+	display: grid;
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+	gap: 12px;
 }
-@media (max-width: 767px) { .omp-token-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 767px) {
+	.omp-token-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
 .omp-token-item {
-  padding: 10px 0; border-top: 1px solid var(--border); display: flex; flex-direction: column; gap: 6px;
+	padding: 10px 0;
+	border-top: 1px solid var(--border);
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
 }
-.omp-token-label { font-family: var(--font-sans); font-size: 11px; font-weight: 650; letter-spacing: 0.05em; text-transform: uppercase; color: var(--dim); }
-.omp-token-value { font-family: var(--font-mono); font-size: 16px; font-weight: 700; letter-spacing: -0.02em; color: var(--text); font-variant-numeric: tabular-nums; }
-.omp-token-bar { height: 3px; border-radius: 999px; background: var(--surface-3); overflow: hidden; }
-.omp-token-bar-fill { height: 100%; border-radius: 999px; }
+.omp-token-label {
+	font-family: var(--font-sans);
+	font-size: 11px;
+	font-weight: 650;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+	color: var(--dim);
+}
+.omp-token-value {
+	font-family: var(--font-mono);
+	font-size: 16px;
+	font-weight: 700;
+	letter-spacing: -0.02em;
+	color: var(--text);
+	font-variant-numeric: tabular-nums;
+}
+.omp-token-bar {
+	height: 3px;
+	border-radius: 999px;
+	background: var(--surface-3);
+	overflow: hidden;
+}
+.omp-token-bar-fill {
+	height: 100%;
+	border-radius: 999px;
+}
 
 /* Row lists — model/provider/tool — open list, not cards */
-.omp-list { display: flex; flex-direction: column; }
-.omp-row {
-  display: flex; align-items: center; gap: 10px; padding: 9px 0; border-bottom: 1px solid var(--border); min-width: 0;
+.omp-list {
+	display: flex;
+	flex-direction: column;
 }
-.omp-row:last-child { border-bottom: none; }
-.omp-row-rank { font-family: var(--font-mono); font-size: 10px; font-weight: 700; color: var(--dim); width: 18px; text-align: right; flex-shrink: 0; }
-.omp-row-main { flex: 1; min-width: 0; }
-.omp-row-title { font-family: var(--font-sans); font-size: 12.5px; font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.omp-row-sub { font-family: var(--font-mono); font-size: 11px; color: var(--dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.omp-row-bar { width: 84px; height: 3px; border-radius: 999px; background: var(--surface-3); overflow: hidden; flex-shrink: 0; }
-.omp-row-bar-fill { height: 100%; border-radius: 999px; background: var(--text); opacity: 0.9; }
-.omp-row-metric { font-family: var(--font-mono); font-size: 11px; font-variant-numeric: tabular-nums; color: var(--muted); min-width: 56px; text-align: right; flex-shrink: 0; }
-.omp-provider-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
-@media (max-width: 639px) { .omp-provider-grid { grid-template-columns: 1fr; } }
-.omp-provider-item { padding: 10px 0; border-top: 1px solid var(--border); display: flex; flex-direction: column; gap: 6px; }
-.omp-provider-name { font-family: var(--font-sans); font-size: 12px; font-weight: 700; color: var(--text); letter-spacing: -0.01em; }
+.omp-row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 9px 0;
+	border-bottom: 1px solid var(--border);
+	min-width: 0;
+}
+.omp-row:last-child {
+	border-bottom: none;
+}
+.omp-row-rank {
+	font-family: var(--font-mono);
+	font-size: 10px;
+	font-weight: 700;
+	color: var(--dim);
+	width: 18px;
+	text-align: right;
+	flex-shrink: 0;
+}
+.omp-row-main {
+	flex: 1;
+	min-width: 0;
+}
+.omp-row-title {
+	font-family: var(--font-sans);
+	font-size: 12.5px;
+	font-weight: 600;
+	color: var(--text);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.omp-row-sub {
+	font-family: var(--font-mono);
+	font-size: 11px;
+	color: var(--dim);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.omp-row-bar {
+	width: 84px;
+	height: 3px;
+	border-radius: 999px;
+	background: var(--surface-3);
+	overflow: hidden;
+	flex-shrink: 0;
+}
+.omp-row-bar-fill {
+	height: 100%;
+	border-radius: 999px;
+	background: var(--text);
+	opacity: 0.9;
+}
+.omp-row-metric {
+	font-family: var(--font-mono);
+	font-size: 11px;
+	font-variant-numeric: tabular-nums;
+	color: var(--muted);
+	min-width: 56px;
+	text-align: right;
+	flex-shrink: 0;
+}
+.omp-provider-grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 12px;
+}
+@media (max-width: 639px) {
+	.omp-provider-grid {
+		grid-template-columns: 1fr;
+	}
+}
+.omp-provider-item {
+	padding: 10px 0;
+	border-top: 1px solid var(--border);
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+.omp-provider-name {
+	font-family: var(--font-sans);
+	font-size: 12px;
+	font-weight: 700;
+	color: var(--text);
+	letter-spacing: -0.01em;
+}
 
 /* ======================================================================
    Inner routes — ranked lists, explorer tables, error groups
@@ -525,615 +1205,1538 @@
    ====================================================================== */
 
 .omp-ranked-head {
-  display: flex; align-items: center; gap: 8px; padding: 6px 0 8px; border-bottom: 1px solid var(--border);
-  font-family: var(--font-sans); font-size: 11px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--dim);
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 0 8px;
+	border-bottom: 1px solid var(--border);
+	font-family: var(--font-sans);
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--dim);
 }
 .omp-ranked-head button {
-  background: transparent; border: 1px solid transparent; border-radius: var(--radius-sm);
-  padding: 3px 6px; font: inherit; color: inherit; cursor: pointer; display: inline-flex; align-items: center; gap: 4px;
+	background: transparent;
+	border: 1px solid transparent;
+	border-radius: var(--radius-sm);
+	padding: 3px 6px;
+	font: inherit;
+	color: inherit;
+	cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
 }
-.omp-ranked-head button:hover { color: var(--text); background: var(--surface-2); border-color: var(--border); }
-.omp-ranked-head button[data-active="true"] { color: var(--text); background: var(--surface-3); border-color: var(--border-strong); }
+.omp-ranked-head button:hover {
+	color: var(--text);
+	background: var(--surface-2);
+	border-color: var(--border);
+}
+.omp-ranked-head button[data-active="true"] {
+	color: var(--text);
+	background: var(--surface-3);
+	border-color: var(--border-strong);
+}
 
-.omp-ranked-list { display: flex; flex-direction: column; }
-.omp-ranked-row {
-  display: grid; grid-template-columns: 22px minmax(0, 1.6fr) 84px repeat(4, 82px) minmax(0, 0.8fr) 28px;
-  align-items: center; gap: 10px; padding: 10px 0; border-bottom: 1px solid var(--border); min-width: 0;
+.omp-ranked-list {
+	display: flex;
+	flex-direction: column;
 }
-.omp-ranked-row:last-child { border-bottom: none; }
-.omp-ranked-row:hover { background: color-mix(in oklch, var(--surface-2) 60%, transparent); }
-.omp-ranked-row[data-expanded="true"] { background: var(--surface-2); margin: 0 -8px; padding: 10px 8px; border: 1px solid var(--border); border-radius: var(--radius-md); }
-.omp-ranked-row:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; }
-.omp-ranked-row-rank { font-family: var(--font-mono); font-size: 10px; font-weight: 700; color: var(--dim); text-align: right; }
-.omp-ranked-row-main { min-width: 0; display: flex; flex-direction: column; gap: 2px; }
-.omp-ranked-row-title { font-family: var(--font-mono); font-size: 12.5px; font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.omp-ranked-row-sub { font-family: var(--font-sans); font-size: 11px; color: var(--dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.omp-ranked-bar { height: 3px; border-radius: 999px; background: var(--surface-3); overflow: hidden; }
-.omp-ranked-bar-fill { height: 100%; border-radius: 999px; background: var(--text); opacity: 0.85; }
-.omp-ranked-metric { font-family: var(--font-mono); font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; text-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: 1.4; }
-.omp-ranked-metric strong { color: var(--text); font-weight: 700; }
-.omp-ranked-metric small { display: block; font-size: 10px; color: var(--dim); font-family: var(--font-sans); }
-.omp-ranked-expand { width: 22px; height: 22px; display: grid; place-items: center; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); color: var(--muted); cursor: pointer; }
-.omp-ranked-expand:hover { color: var(--text); border-color: var(--border-strong); }
+.omp-ranked-row {
+	display: grid;
+	grid-template-columns: 22px minmax(0, 1.6fr) 84px repeat(4, 82px) minmax(0, 0.8fr) 28px;
+	align-items: center;
+	gap: 10px;
+	padding: 10px 0;
+	border-bottom: 1px solid var(--border);
+	min-width: 0;
+}
+.omp-ranked-row:last-child {
+	border-bottom: none;
+}
+.omp-ranked-row:hover {
+	background: color-mix(in oklch, var(--surface-2) 60%, transparent);
+}
+.omp-ranked-row[data-expanded="true"] {
+	background: var(--surface-2);
+	margin: 0 -8px;
+	padding: 10px 8px;
+	border: 1px solid var(--border);
+	border-radius: var(--radius-md);
+}
+.omp-ranked-row:focus-visible {
+	outline: 2px solid var(--focus);
+	outline-offset: 2px;
+}
+.omp-ranked-row-rank {
+	font-family: var(--font-mono);
+	font-size: 10px;
+	font-weight: 700;
+	color: var(--dim);
+	text-align: right;
+}
+.omp-ranked-row-main {
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+.omp-ranked-row-title {
+	font-family: var(--font-mono);
+	font-size: 12.5px;
+	font-weight: 600;
+	color: var(--text);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.omp-ranked-row-sub {
+	font-family: var(--font-sans);
+	font-size: 11px;
+	color: var(--dim);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.omp-ranked-bar {
+	height: 3px;
+	border-radius: 999px;
+	background: var(--surface-3);
+	overflow: hidden;
+}
+.omp-ranked-bar-fill {
+	height: 100%;
+	border-radius: 999px;
+	background: var(--text);
+	opacity: 0.85;
+}
+.omp-ranked-metric {
+	font-family: var(--font-mono);
+	font-size: 11px;
+	color: var(--muted);
+	font-variant-numeric: tabular-nums;
+	text-align: right;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	line-height: 1.4;
+}
+.omp-ranked-metric strong {
+	color: var(--text);
+	font-weight: 700;
+}
+.omp-ranked-metric small {
+	display: block;
+	font-size: 10px;
+	color: var(--dim);
+	font-family: var(--font-sans);
+}
+.omp-ranked-expand {
+	width: 22px;
+	height: 22px;
+	display: grid;
+	place-items: center;
+	border: 1px solid var(--border);
+	border-radius: var(--radius-sm);
+	background: var(--surface-2);
+	color: var(--muted);
+	cursor: pointer;
+}
+.omp-ranked-expand:hover {
+	color: var(--text);
+	border-color: var(--border-strong);
+}
 
 @media (max-width: 1023px) {
-  .omp-ranked-row { grid-template-columns: 22px minmax(0, 1.2fr) 72px repeat(3, 74px) 28px; }
-  .omp-ranked-row .omp-ranked-hide-md { display: none; }
+	.omp-ranked-row {
+		grid-template-columns: 22px minmax(0, 1.2fr) 72px repeat(3, 74px) 28px;
+	}
+	.omp-ranked-row .omp-ranked-hide-md {
+		display: none;
+	}
 }
 @media (max-width: 767px) {
-  .omp-ranked-row { grid-template-columns: 18px minmax(0, 1fr) 28px; }
-  .omp-ranked-row .omp-ranked-hide-sm { display: none; }
-  .omp-ranked-bar { display: none; }
+	.omp-ranked-row {
+		grid-template-columns: 18px minmax(0, 1fr) 28px;
+	}
+	.omp-ranked-row .omp-ranked-hide-sm {
+		display: none;
+	}
+	.omp-ranked-bar {
+		display: none;
+	}
 }
 
 .omp-ranked-detail {
-  grid-column: 1 / -1; margin-top: 8px; padding: 12px; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-md);
-  display: flex; flex-direction: column; gap: 12px;
+	grid-column: 1 / -1;
+	margin-top: 8px;
+	padding: 12px;
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-md);
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
 }
-.omp-ranked-detail-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; }
-@media (max-width: 767px) { .omp-ranked-detail-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
-.omp-ranked-detail-label { font-family: var(--font-sans); font-size: 11px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--dim); }
-.omp-ranked-detail-value { font-family: var(--font-mono); font-size: 12px; font-weight: 600; color: var(--text); font-variant-numeric: tabular-nums; }
-
-/* Provider tones */
-.omp-provider-row[data-tone="danger"] { background: color-mix(in oklch, var(--danger) 7%, var(--surface)); }
-.omp-provider-row[data-tone="warning"] { background: color-mix(in oklch, var(--warning) 6%, var(--surface)); }
-.omp-provider-row[data-tone="danger"] .omp-ranked-row-title,
-.omp-provider-row[data-tone="warning"] .omp-ranked-row-title { color: var(--text); }
-
-/* Errors — grouped explorer */
-.omp-error-controls { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
-.omp-error-group {
-  display: grid; grid-template-columns: 1fr auto; gap: 8px; padding: 10px 12px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface);
-}
-.omp-error-group + .omp-error-group { margin-top: 8px; }
-.omp-error-group[data-expanded="true"] { border-color: var(--border-strong); background: var(--surface-2); }
-.omp-error-sig { font-family: var(--font-sans); font-size: 13px; font-weight: 600; color: var(--text); line-height: 1.3; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.omp-error-meta { font-family: var(--font-mono); font-size: 11px; color: var(--muted); display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
-.omp-error-meta strong { color: var(--text); }
-.omp-error-occ { margin-top: 10px; border-top: 1px solid var(--border); padding-top: 10px; display: flex; flex-direction: column; gap: 6px; max-height: 280px; overflow-y: auto; }
-.omp-error-occ-row { display: grid; grid-template-columns: 120px 1.2fr 80px auto; gap: 8px; font-family: var(--font-mono); font-size: 11px; color: var(--muted); padding: 4px 0; border-bottom: 1px solid var(--border); }
-.omp-error-occ-row span:first-child { color: var(--dim); }
-@media (max-width: 767px) { .omp-error-occ-row { grid-template-columns: 1fr auto; } .omp-error-occ-row .hide-sm { display: none; } }
-
-/* Requests explorer */
-.omp-explorer-wrap { border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--surface); overflow: hidden; }
-.omp-explorer-head { display: grid; grid-template-columns: 132px minmax(0, 1.2fr) 110px 84px 84px 72px 84px 68px 56px; gap: 0; padding: 8px 10px; border-bottom: 1px solid var(--border); font-family: var(--font-sans); font-size: 11px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--dim); }
-.omp-explorer-head button { font: inherit; color: inherit; background: transparent; border: none; cursor: pointer; text-align: left; padding: 0; }
-.omp-explorer-head button:hover { color: var(--text); }
-.omp-explorer-head button[data-active="true"] { color: var(--text); }
-.omp-explorer-row { display: grid; grid-template-columns: 132px minmax(0, 1.2fr) 110px 84px 84px 72px 84px 68px 56px; gap: 0; padding: 7px 10px; border-bottom: 1px solid var(--border); align-items: center; cursor: pointer; font-size: 12px; }
-.omp-explorer-row:last-child { border-bottom: none; }
-.omp-explorer-row:hover { background: var(--surface-2); }
-.omp-explorer-row span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.omp-explorer-row .mono { font-family: var(--font-mono); font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; }
-.omp-explorer-row .mono strong { color: var(--text); }
-.omp-explorer-pager { display: flex; gap: 8px; align-items: center; justify-content: space-between; padding: 10px 12px; border-top: 1px solid var(--border); background: var(--surface-2); font-family: var(--font-sans); font-size: 12px; color: var(--muted); flex-wrap: wrap; }
-@media (max-width: 1023px) {
-  .omp-explorer-head, .omp-explorer-row { grid-template-columns: 110px minmax(0, 1fr) 96px 68px 56px; }
-  .omp-explorer-head .hide-md, .omp-explorer-row .hide-md { display: none; }
+.omp-ranked-detail-grid {
+	display: grid;
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+	gap: 12px;
 }
 @media (max-width: 767px) {
-  .omp-explorer-head { display: none; }
-  .omp-explorer-row { grid-template-columns: 1fr; gap: 6px; padding: 10px 12px; }
-  .omp-explorer-row .hide-sm { display: none; }
-  .omp-explorer-metrics { display: flex; gap: 10px; flex-wrap: wrap; }
+	.omp-ranked-detail-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+.omp-ranked-detail-label {
+	font-family: var(--font-sans);
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--dim);
+}
+.omp-ranked-detail-value {
+	font-family: var(--font-mono);
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--text);
+	font-variant-numeric: tabular-nums;
+}
+
+/* Provider tones */
+.omp-provider-row[data-tone="danger"] {
+	background: color-mix(in oklch, var(--danger) 7%, var(--surface));
+}
+.omp-provider-row[data-tone="warning"] {
+	background: color-mix(in oklch, var(--warning) 6%, var(--surface));
+}
+.omp-provider-row[data-tone="danger"] .omp-ranked-row-title,
+.omp-provider-row[data-tone="warning"] .omp-ranked-row-title {
+	color: var(--text);
+}
+
+/* Errors — grouped explorer */
+.omp-error-controls {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	flex-wrap: wrap;
+}
+.omp-error-group {
+	display: grid;
+	grid-template-columns: 1fr auto;
+	gap: 8px;
+	padding: 10px 12px;
+	border: 1px solid var(--border);
+	border-radius: var(--radius-md);
+	background: var(--surface);
+}
+.omp-error-group + .omp-error-group {
+	margin-top: 8px;
+}
+.omp-error-group[data-expanded="true"] {
+	border-color: var(--border-strong);
+	background: var(--surface-2);
+}
+.omp-error-sig {
+	font-family: var(--font-sans);
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--text);
+	line-height: 1.3;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.omp-error-meta {
+	font-family: var(--font-mono);
+	font-size: 11px;
+	color: var(--muted);
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+	align-items: center;
+}
+.omp-error-meta strong {
+	color: var(--text);
+}
+.omp-error-occ {
+	margin-top: 10px;
+	border-top: 1px solid var(--border);
+	padding-top: 10px;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	max-height: 280px;
+	overflow-y: auto;
+}
+.omp-error-occ-row {
+	display: grid;
+	grid-template-columns: 120px 1.2fr 80px auto;
+	gap: 8px;
+	font-family: var(--font-mono);
+	font-size: 11px;
+	color: var(--muted);
+	padding: 4px 0;
+	border-bottom: 1px solid var(--border);
+}
+.omp-error-occ-row span:first-child {
+	color: var(--dim);
+}
+@media (max-width: 767px) {
+	.omp-error-occ-row {
+		grid-template-columns: 1fr auto;
+	}
+	.omp-error-occ-row .hide-sm {
+		display: none;
+	}
+}
+
+/* Requests explorer */
+.omp-explorer-wrap {
+	border: 1px solid var(--border);
+	border-radius: var(--radius-lg);
+	background: var(--surface);
+	overflow: hidden;
+}
+.omp-explorer-head {
+	display: grid;
+	grid-template-columns: 132px minmax(0, 1.2fr) 110px 84px 84px 72px 84px 68px 56px;
+	gap: 0;
+	padding: 8px 10px;
+	border-bottom: 1px solid var(--border);
+	font-family: var(--font-sans);
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--dim);
+}
+.omp-explorer-head button {
+	font: inherit;
+	color: inherit;
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	text-align: left;
+	padding: 0;
+}
+.omp-explorer-head button:hover {
+	color: var(--text);
+}
+.omp-explorer-head button[data-active="true"] {
+	color: var(--text);
+}
+.omp-explorer-row {
+	display: grid;
+	grid-template-columns: 132px minmax(0, 1.2fr) 110px 84px 84px 72px 84px 68px 56px;
+	gap: 0;
+	padding: 7px 10px;
+	border-bottom: 1px solid var(--border);
+	align-items: center;
+	cursor: pointer;
+	font-size: 12px;
+}
+.omp-explorer-row:last-child {
+	border-bottom: none;
+}
+.omp-explorer-row:hover {
+	background: var(--surface-2);
+}
+.omp-explorer-row span {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.omp-explorer-row .mono {
+	font-family: var(--font-mono);
+	font-size: 11px;
+	color: var(--muted);
+	font-variant-numeric: tabular-nums;
+}
+.omp-explorer-row .mono strong {
+	color: var(--text);
+}
+.omp-explorer-pager {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	justify-content: space-between;
+	padding: 10px 12px;
+	border-top: 1px solid var(--border);
+	background: var(--surface-2);
+	font-family: var(--font-sans);
+	font-size: 12px;
+	color: var(--muted);
+	flex-wrap: wrap;
+}
+@media (max-width: 1023px) {
+	.omp-explorer-head,
+	.omp-explorer-row {
+		grid-template-columns: 110px minmax(0, 1fr) 96px 68px 56px;
+	}
+	.omp-explorer-head .hide-md,
+	.omp-explorer-row .hide-md {
+		display: none;
+	}
+}
+@media (max-width: 767px) {
+	.omp-explorer-head {
+		display: none;
+	}
+	.omp-explorer-row {
+		grid-template-columns: 1fr;
+		gap: 6px;
+		padding: 10px 12px;
+	}
+	.omp-explorer-row .hide-sm {
+		display: none;
+	}
+	.omp-explorer-metrics {
+		display: flex;
+		gap: 10px;
+		flex-wrap: wrap;
+	}
 }
 
 /* Gain methodology */
-.omp-method { font-family: var(--font-sans); font-size: 11px; color: var(--muted); background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 8px 10px; line-height: 1.5; }
-.omp-method strong { color: var(--text); }
+.omp-method {
+	font-family: var(--font-sans);
+	font-size: 11px;
+	color: var(--muted);
+	background: var(--surface-2);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-md);
+	padding: 8px 10px;
+	line-height: 1.5;
+}
+.omp-method strong {
+	color: var(--text);
+}
 
 /* Behavior inline */
-.omp-behavior-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; }
-@media (max-width: 767px) { .omp-behavior-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
-.omp-behavior-kpi { padding: 10px 0; border-top: 1px solid var(--border); }
-.omp-behavior-kpi-label { font-family: var(--font-sans); font-size: 11px; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase; color: var(--dim); }
-.omp-behavior-kpi-value { font-family: var(--font-mono); font-size: 15px; font-weight: 700; color: var(--text); font-variant-numeric: tabular-nums; }
-.omp-behavior-kpi-sub { font-family: var(--font-mono); font-size: 11px; color: var(--muted); }
+.omp-behavior-grid {
+	display: grid;
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+	gap: 10px;
+}
+@media (max-width: 767px) {
+	.omp-behavior-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+.omp-behavior-kpi {
+	padding: 10px 0;
+	border-top: 1px solid var(--border);
+}
+.omp-behavior-kpi-label {
+	font-family: var(--font-sans);
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+	color: var(--dim);
+}
+.omp-behavior-kpi-value {
+	font-family: var(--font-mono);
+	font-size: 15px;
+	font-weight: 700;
+	color: var(--text);
+	font-variant-numeric: tabular-nums;
+}
+.omp-behavior-kpi-sub {
+	font-family: var(--font-mono);
+	font-size: 11px;
+	color: var(--muted);
+}
 
 /* Density compact overrides for inner rows */
-[data-density="compact"] .omp-ranked-row { padding: 7px 0; }
-[data-density="compact"] .omp-explorer-row { padding: 5px 10px; }
-[data-density="compact"] .omp-error-group { padding: 8px 10px; }
+[data-density="compact"] .omp-ranked-row {
+	padding: 7px 0;
+}
+[data-density="compact"] .omp-explorer-row {
+	padding: 5px 10px;
+}
+[data-density="compact"] .omp-error-group {
+	padding: 8px 10px;
+}
 
 /* Focus and reduced motion */
-.omp-ranked-expand:focus-visible, .omp-error-group:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; }
-@media (prefers-reduced-motion: reduce) { .omp-ranked-row, .omp-error-group, .omp-explorer-row { transition: none !important; } }
-
+.omp-ranked-expand:focus-visible,
+.omp-error-group:focus-visible {
+	outline: 2px solid var(--focus);
+	outline-offset: 2px;
+}
+@media (prefers-reduced-motion: reduce) {
+	.omp-ranked-row,
+	.omp-error-group,
+	.omp-explorer-row {
+		transition: none !important;
+	}
+}
 
 /* Panels — retained for non-overview routes, lightened */
 .stats-panel {
-  background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg);
-  overflow: hidden; display: flex; flex-direction: column;
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-lg);
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
 }
 .stats-panel-header {
-  display: flex; align-items: flex-start; justify-content: space-between; gap: 12px;
-  padding: 11px 12px; border-bottom: 1px solid var(--border); background: var(--surface);
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 11px 12px;
+	border-bottom: 1px solid var(--border);
+	background: var(--surface);
 }
-@media (max-width: 480px) { .stats-panel-header { flex-direction: column; } }
-.stats-panel-header-titles { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+@media (max-width: 480px) {
+	.stats-panel-header {
+		flex-direction: column;
+	}
+}
+.stats-panel-header-titles {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+}
 .stats-panel-eyebrow {
-  font-size: 11px; font-weight: 600; letter-spacing: 0.06em; color: var(--dim); font-family: var(--font-sans);
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.06em;
+	color: var(--dim);
+	font-family: var(--font-sans);
 }
-.stats-panel-title { font-family: var(--font-sans); font-size: 12.5px; font-weight: 700; color: var(--text); letter-spacing: -0.015em; line-height: 1.2; }
-.stats-panel-subtitle { font-family: var(--font-sans); font-size: 12px; color: var(--muted); line-height: 1.4; margin: 0; }
-.stats-panel-actions { display: flex; align-items: center; gap: 6px; flex-shrink: 0; flex-wrap: wrap; }
-.stats-panel-body { padding: 14px; }
-@media (max-width: 767px) { .stats-panel-body { padding: 12px; } }
+.stats-panel-title {
+	font-family: var(--font-sans);
+	font-size: 12.5px;
+	font-weight: 700;
+	color: var(--text);
+	letter-spacing: -0.015em;
+	line-height: 1.2;
+}
+.stats-panel-subtitle {
+	font-family: var(--font-sans);
+	font-size: 12px;
+	color: var(--muted);
+	line-height: 1.4;
+	margin: 0;
+}
+.stats-panel-actions {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex-shrink: 0;
+	flex-wrap: wrap;
+}
+.stats-panel-body {
+	padding: 14px;
+}
+@media (max-width: 767px) {
+	.stats-panel-body {
+		padding: 12px;
+	}
+}
 
 /* Metric cluster legacy — keep but de-emphasized */
-.stats-metric-cluster { display: flex; flex-direction: column; gap: 10px; }
-.stats-metric-primary-grid { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 10px; }
-@media (max-width: 1023px) { .stats-metric-primary-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
-@media (max-width: 480px) { .stats-metric-primary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
-.stats-metric-secondary-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; }
-@media (max-width: 767px) { .stats-metric-secondary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
-.stats-metric-card { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 11px; overflow: hidden; }
-.stats-metric-label { font-family: var(--font-sans); font-size: 11px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--dim); margin-bottom: 4px; }
-.stats-metric-value { font-family: var(--font-mono); font-size: 15px; font-weight: 700; color: var(--text); letter-spacing: -0.02em; font-variant-numeric: tabular-nums; }
+.stats-metric-cluster {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+.stats-metric-primary-grid {
+	display: grid;
+	grid-template-columns: repeat(5, minmax(0, 1fr));
+	gap: 10px;
+}
+@media (max-width: 1023px) {
+	.stats-metric-primary-grid {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+}
+@media (max-width: 480px) {
+	.stats-metric-primary-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+.stats-metric-secondary-grid {
+	display: grid;
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+	gap: 10px;
+}
+@media (max-width: 767px) {
+	.stats-metric-secondary-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+.stats-metric-card {
+	background: var(--surface-2);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-md);
+	padding: 11px;
+	overflow: hidden;
+}
+.stats-metric-label {
+	font-family: var(--font-sans);
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--dim);
+	margin-bottom: 4px;
+}
+.stats-metric-value {
+	font-family: var(--font-mono);
+	font-size: 15px;
+	font-weight: 700;
+	color: var(--text);
+	letter-spacing: -0.02em;
+	font-variant-numeric: tabular-nums;
+}
 
 /* Data table — densified */
-.stats-table-wrapper { width: 100%; }
-.stats-table-container { overflow-x: auto; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface); }
-.stats-table { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.stats-table-wrapper {
+	width: 100%;
+}
+.stats-table-container {
+	overflow-x: auto;
+	border: 1px solid var(--border);
+	border-radius: var(--radius-md);
+	background: var(--surface);
+}
+.stats-table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 12.5px;
+}
 .stats-table-th {
-  text-align: left; padding: 8px 10px; font-size: 11px; font-weight: 650; letter-spacing: 0.03em;
-  color: var(--dim); background: var(--surface-2); border-bottom: 1px solid var(--border); white-space: nowrap; font-family: var(--font-sans);
+	text-align: left;
+	padding: 8px 10px;
+	font-size: 11px;
+	font-weight: 650;
+	letter-spacing: 0.03em;
+	color: var(--dim);
+	background: var(--surface-2);
+	border-bottom: 1px solid var(--border);
+	white-space: nowrap;
+	font-family: var(--font-sans);
 }
-.stats-table-th[data-numeric="true"] { text-align: right; }
-.stats-table-td { padding: 8px 10px; border-bottom: 1px solid var(--border); color: var(--muted); vertical-align: middle; font-family: var(--font-sans); }
-.stats-table-td[data-mono="true"] { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
-.stats-table-tr { background: transparent; }
-.stats-table-tr-clickable { cursor: pointer; }
-.stats-table-tr-clickable:hover { background: var(--surface-2); }
-.stats-text-left { text-align: left; }
-.stats-text-right { text-align: right; }
-.stats-table-empty { padding: 28px 16px; text-align: center; color: var(--muted); font-size: 12.5px; }
-.stats-progress-bar-track { height: 3px; border-radius: 999px; background: var(--surface-3); overflow: hidden; }
-.stats-progress-bar-fill { height: 100%; border-radius: 999px; background: var(--text); opacity: 0.85; }
-.stats-table-mobile-only { display: none; }
-.stats-table-desktop-only { width: 100%; }
+.stats-table-th[data-numeric="true"] {
+	text-align: right;
+}
+.stats-table-td {
+	padding: 8px 10px;
+	border-bottom: 1px solid var(--border);
+	color: var(--muted);
+	vertical-align: middle;
+	font-family: var(--font-sans);
+}
+.stats-table-td[data-mono="true"] {
+	font-family: var(--font-mono);
+	font-variant-numeric: tabular-nums;
+}
+.stats-table-tr {
+	background: transparent;
+}
+.stats-table-tr-clickable {
+	cursor: pointer;
+}
+.stats-table-tr-clickable:hover {
+	background: var(--surface-2);
+}
+.stats-text-left {
+	text-align: left;
+}
+.stats-text-right {
+	text-align: right;
+}
+.stats-table-empty {
+	padding: 28px 16px;
+	text-align: center;
+	color: var(--muted);
+	font-size: 12.5px;
+}
+.stats-progress-bar-track {
+	height: 3px;
+	border-radius: 999px;
+	background: var(--surface-3);
+	overflow: hidden;
+}
+.stats-progress-bar-fill {
+	height: 100%;
+	border-radius: 999px;
+	background: var(--text);
+	opacity: 0.85;
+}
+.stats-table-mobile-only {
+	display: none;
+}
+.stats-table-desktop-only {
+	width: 100%;
+}
 @media (max-width: 767px) {
-  .stats-table-mobile-only { display: block; }
-  .stats-table-desktop-only { display: none; }
+	.stats-table-mobile-only {
+		display: block;
+	}
+	.stats-table-desktop-only {
+		display: none;
+	}
 }
-.stats-table-mobile-list { display: flex; flex-direction: column; gap: 10px; }
-.stats-table-mobile-card-wrapper { border: 1px solid var(--border); border-radius: var(--radius-md); overflow: hidden; background: var(--surface); }
-.stats-mobile-card { padding: 12px; display: flex; flex-direction: column; gap: 10px; }
-.stats-mobile-card-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 8px; }
-.stats-mobile-card-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
-.stats-mobile-card-label { font-family: var(--font-sans); font-size: 11px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--dim); }
-.stats-mobile-card-value { font-family: var(--font-mono); font-size: 12px; color: var(--text); font-variant-numeric: tabular-nums; }
-.stats-mobile-card-error { font-size: 11px; color: var(--danger); background: color-mix(in oklch, var(--danger) 8%, var(--surface-2)); border: 1px solid color-mix(in oklch, var(--danger) 14%, transparent); border-radius: var(--radius-sm); padding: 6px 8px; }
+.stats-table-mobile-list {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+.stats-table-mobile-card-wrapper {
+	border: 1px solid var(--border);
+	border-radius: var(--radius-md);
+	overflow: hidden;
+	background: var(--surface);
+}
+.stats-mobile-card {
+	padding: 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+.stats-mobile-card-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-start;
+	gap: 8px;
+}
+.stats-mobile-card-grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 8px;
+}
+.stats-mobile-card-label {
+	font-family: var(--font-sans);
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--dim);
+}
+.stats-mobile-card-value {
+	font-family: var(--font-mono);
+	font-size: 12px;
+	color: var(--text);
+	font-variant-numeric: tabular-nums;
+}
+.stats-mobile-card-error {
+	font-size: 11px;
+	color: var(--danger);
+	background: color-mix(in oklch, var(--danger) 8%, var(--surface-2));
+	border: 1px solid color-mix(in oklch, var(--danger) 14%, transparent);
+	border-radius: var(--radius-sm);
+	padding: 6px 8px;
+}
 
 /* Status pill — flat tag */
 .stats-status-pill {
-  display: inline-flex; align-items: center; gap: 4px; padding: 2px 7px; border-radius: var(--radius-sm);
-  font-size: 11px; font-weight: 700; letter-spacing: 0.01em; font-family: var(--font-mono); border: 1px solid var(--border);
-  line-height: 1.4;
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 2px 7px;
+	border-radius: var(--radius-sm);
+	font-size: 11px;
+	font-weight: 700;
+	letter-spacing: 0.01em;
+	font-family: var(--font-mono);
+	border: 1px solid var(--border);
+	line-height: 1.4;
 }
-.stats-status-pill[data-variant="success"] { color: var(--success); background: color-mix(in oklch, var(--success) 10%, var(--surface-2)); border-color: color-mix(in oklch, var(--success) 18%, transparent); }
-.stats-status-pill[data-variant="danger"] { color: var(--danger); background: color-mix(in oklch, var(--danger) 10%, var(--surface-2)); border-color: color-mix(in oklch, var(--danger) 18%, transparent); }
-.stats-status-pill[data-variant="warning"] { color: var(--amber); background: color-mix(in oklch, var(--amber) 10%, var(--surface-2)); border-color: color-mix(in oklch, var(--amber) 18%, transparent); }
-.stats-status-pill[data-variant="info"] { color: var(--link); background: color-mix(in oklch, var(--link) 10%, var(--surface-2)); border-color: color-mix(in oklch, var(--link) 18%, transparent); }
-.stats-status-pill[data-variant="default"] { color: var(--muted); background: var(--surface-2); }
+.stats-status-pill[data-variant="success"] {
+	color: var(--success);
+	background: color-mix(in oklch, var(--success) 10%, var(--surface-2));
+	border-color: color-mix(in oklch, var(--success) 18%, transparent);
+}
+.stats-status-pill[data-variant="danger"] {
+	color: var(--danger);
+	background: color-mix(in oklch, var(--danger) 10%, var(--surface-2));
+	border-color: color-mix(in oklch, var(--danger) 18%, transparent);
+}
+.stats-status-pill[data-variant="warning"] {
+	color: var(--amber);
+	background: color-mix(in oklch, var(--amber) 10%, var(--surface-2));
+	border-color: color-mix(in oklch, var(--amber) 18%, transparent);
+}
+.stats-status-pill[data-variant="info"] {
+	color: var(--link);
+	background: color-mix(in oklch, var(--link) 10%, var(--surface-2));
+	border-color: color-mix(in oklch, var(--link) 18%, transparent);
+}
+.stats-status-pill[data-variant="default"] {
+	color: var(--muted);
+	background: var(--surface-2);
+}
 
-.stats-segmented-control { display: flex; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 2px; gap: 1px; }
-.stats-segmented-control-btn { padding: 5px 10px; font-size: 11px; font-weight: 700; color: var(--muted); background: transparent; border: 1px solid transparent; border-radius: var(--radius-sm); cursor: pointer; font-family: var(--font-sans); }
-.stats-segmented-control-btn:hover { color: var(--text); }
-.stats-segmented-control-btn[data-active="true"] { background: var(--text); color: var(--surface); border-color: var(--text); }
+.stats-segmented-control {
+	display: flex;
+	background: var(--surface-2);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-md);
+	padding: 2px;
+	gap: 1px;
+}
+.stats-segmented-control-btn {
+	padding: 5px 10px;
+	font-size: 11px;
+	font-weight: 700;
+	color: var(--muted);
+	background: transparent;
+	border: 1px solid transparent;
+	border-radius: var(--radius-sm);
+	cursor: pointer;
+	font-family: var(--font-sans);
+}
+.stats-segmented-control-btn:hover {
+	color: var(--text);
+}
+.stats-segmented-control-btn[data-active="true"] {
+	background: var(--text);
+	color: var(--surface);
+	border-color: var(--text);
+}
 
 /* Drawer */
-.stats-drawer-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.42); backdrop-filter: blur(2px); z-index: 50; display: flex; justify-content: flex-end; }
-.stats-drawer { width: min(560px, 100%); background: var(--surface); border-left: 1px solid var(--border); display: flex; flex-direction: column; animation: drawerSlide 0.2s ease-out; }
-@keyframes drawerSlide { from { transform: translateX(100%); } to { transform: translateX(0); } }
-.stats-drawer-header { display: flex; align-items: center; justify-content: space-between; padding: 14px 16px; border-bottom: 1px solid var(--border); gap: 12px; }
-.stats-drawer-header-left { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.stats-drawer-title { font-family: var(--font-sans); font-size: 13px; font-weight: 700; color: var(--text); }
-.stats-drawer-id { font-family: var(--font-mono); font-size: 11px; color: var(--dim); }
-.stats-drawer-close-btn { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 6px; cursor: pointer; color: var(--muted); display: inline-flex; }
-.stats-drawer-close-btn:hover { color: var(--text); background: var(--surface-3); }
-.stats-drawer-body { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 14px; }
-.stats-drawer-content { display: flex; flex-direction: column; gap: 12px; }
+.stats-drawer-overlay {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.42);
+	backdrop-filter: blur(2px);
+	z-index: 50;
+	display: flex;
+	justify-content: flex-end;
+}
+.stats-drawer {
+	width: min(560px, 100%);
+	background: var(--surface);
+	border-left: 1px solid var(--border);
+	display: flex;
+	flex-direction: column;
+	animation: drawerSlide 0.2s ease-out;
+}
+@keyframes drawerSlide {
+	from {
+		transform: translateX(100%);
+	}
+	to {
+		transform: translateX(0);
+	}
+}
+.stats-drawer-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 14px 16px;
+	border-bottom: 1px solid var(--border);
+	gap: 12px;
+}
+.stats-drawer-header-left {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+}
+.stats-drawer-title {
+	font-family: var(--font-sans);
+	font-size: 13px;
+	font-weight: 700;
+	color: var(--text);
+}
+.stats-drawer-id {
+	font-family: var(--font-mono);
+	font-size: 11px;
+	color: var(--dim);
+}
+.stats-drawer-close-btn {
+	background: var(--surface-2);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-md);
+	padding: 6px;
+	cursor: pointer;
+	color: var(--muted);
+	display: inline-flex;
+}
+.stats-drawer-close-btn:hover {
+	color: var(--text);
+	background: var(--surface-3);
+}
+.stats-drawer-body {
+	flex: 1;
+	overflow-y: auto;
+	padding: 16px;
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+}
+.stats-drawer-content {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
 
 /* JSON block */
-.stats-json-block { border: 1px solid var(--border); border-radius: var(--radius-md); overflow: hidden; background: var(--surface-2); }
-.stats-json-block-header { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 8px 10px; background: transparent; border: none; cursor: pointer; text-align: left; }
-.stats-json-block-header:hover { background: var(--surface-3); }
-.stats-json-block-title { color: var(--text); font-size: 12px; font-weight: 600; font-family: var(--font-mono); }
-.stats-json-block-toggle-indicator { color: var(--muted); }
-.stats-json-block-content-wrapper { border-top: 1px solid var(--border); }
-.stats-json-block-content { margin: 0; padding: 10px; font-family: var(--font-mono); font-size: 11px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; max-height: 320px; overflow: auto; }
+.stats-json-block {
+	border: 1px solid var(--border);
+	border-radius: var(--radius-md);
+	overflow: hidden;
+	background: var(--surface-2);
+}
+.stats-json-block-header {
+	width: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 8px 10px;
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	text-align: left;
+}
+.stats-json-block-header:hover {
+	background: var(--surface-3);
+}
+.stats-json-block-title {
+	color: var(--text);
+	font-size: 12px;
+	font-weight: 600;
+	font-family: var(--font-mono);
+}
+.stats-json-block-toggle-indicator {
+	color: var(--muted);
+}
+.stats-json-block-content-wrapper {
+	border-top: 1px solid var(--border);
+}
+.stats-json-block-content {
+	margin: 0;
+	padding: 10px;
+	font-family: var(--font-mono);
+	font-size: 11px;
+	line-height: 1.5;
+	white-space: pre-wrap;
+	word-break: break-word;
+	max-height: 320px;
+	overflow: auto;
+}
 
 /* Skeleton */
-.stats-skeleton { background: var(--surface-2); border-radius: var(--radius-sm); position: relative; overflow: hidden; }
-.stats-skeleton[data-variant="text"] { border-radius: 4px; }
-.stats-skeleton[data-variant="circle"] { border-radius: 50%; }
-.stats-skeleton::after {
-  content: ""; position: absolute; inset: 0; transform: translateX(-100%);
-  background: linear-gradient(90deg, transparent, color-mix(in oklch, var(--border-strong) 45%, transparent), transparent);
-  animation: shimmer 1.4s infinite;
+.stats-skeleton {
+	background: var(--surface-2);
+	border-radius: var(--radius-sm);
+	position: relative;
+	overflow: hidden;
 }
-@keyframes shimmer { 100% { transform: translateX(100%); } }
-@media (prefers-reduced-motion: reduce) { .stats-skeleton::after { animation: none; } }
-.stats-boundary-skeleton { display: flex; flex-direction: column; gap: 10px; padding: 12px; }
+.stats-skeleton[data-variant="text"] {
+	border-radius: 4px;
+}
+.stats-skeleton[data-variant="circle"] {
+	border-radius: 50%;
+}
+.stats-skeleton::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	transform: translateX(-100%);
+	background: linear-gradient(
+		90deg,
+		transparent,
+		color-mix(in oklch, var(--border-strong) 45%, transparent),
+		transparent
+	);
+	animation: shimmer 1.4s infinite;
+}
+@keyframes shimmer {
+	100% {
+		transform: translateX(100%);
+	}
+}
+@media (prefers-reduced-motion: reduce) {
+	.stats-skeleton::after {
+		animation: none;
+	}
+}
+.stats-boundary-skeleton {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	padding: 12px;
+}
 
 /* Empty / Error */
-.stats-empty-state, .stats-error-state { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 10px; padding: 20px 14px; text-align: center; }
-.stats-empty-state-message {
-  font-family: var(--font-sans); font-size: 12.5px; color: var(--muted); border: 1px dashed var(--border); border-radius: var(--radius-md);
-  padding: 10px 12px; background: var(--surface-2);
+.stats-empty-state,
+.stats-error-state {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+	padding: 20px 14px;
+	text-align: center;
 }
-.stats-error-state-content { max-width: 360px; }
-.stats-error-state-title { font-family: var(--font-sans); font-size: 13px; font-weight: 700; color: var(--danger); }
-.stats-error-state-message { font-size: 12px; color: var(--muted); }
-.stats-empty-state-icon { color: var(--dim); opacity: 0.8; }
+.stats-empty-state-message {
+	font-family: var(--font-sans);
+	font-size: 12.5px;
+	color: var(--muted);
+	border: 1px dashed var(--border);
+	border-radius: var(--radius-md);
+	padding: 10px 12px;
+	background: var(--surface-2);
+}
+.stats-error-state-content {
+	max-width: 360px;
+}
+.stats-error-state-title {
+	font-family: var(--font-sans);
+	font-size: 13px;
+	font-weight: 700;
+	color: var(--danger);
+}
+.stats-error-state-message {
+	font-size: 12px;
+	color: var(--muted);
+}
+.stats-empty-state-icon {
+	color: var(--dim);
+	opacity: 0.8;
+}
 
 /* Command palette */
-.omp-palette-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.38); backdrop-filter: blur(2px); z-index: 120; display: grid; place-items: start center; padding-top: 18vh; }
-.omp-palette { width: min(560px, calc(100% - 24px)); background: var(--surface); border: 1px solid var(--border-strong); border-radius: 10px; box-shadow: 0 20px 48px rgba(0,0,0,0.22); overflow: hidden; }
-.omp-palette-input { width: 100%; padding: 14px 14px; border: none; border-bottom: 1px solid var(--border); background: var(--surface); color: var(--text); font-family: var(--font-sans); font-size: 14px; outline: none; }
-.omp-palette-input::placeholder { color: var(--dim); }
-.omp-palette-list { max-height: 320px; overflow-y: auto; padding: 6px; display: flex; flex-direction: column; gap: 2px; }
-.omp-palette-item { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 8px 10px; border-radius: var(--radius-md); cursor: pointer; font-family: var(--font-sans); font-size: 13px; color: var(--muted); border: 1px solid transparent; }
-.omp-palette-item[data-active="true"] { background: var(--surface-2); color: var(--text); border-color: var(--border); }
-.omp-palette-kbd { font-family: var(--font-mono); font-size: 10px; color: var(--dim); border: 1px solid var(--border); background: var(--surface-2); padding: 2px 5px; border-radius: 3px; }
+.omp-palette-overlay {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.38);
+	backdrop-filter: blur(2px);
+	z-index: 120;
+	display: grid;
+	place-items: start center;
+	padding-top: 18vh;
+}
+.omp-palette {
+	width: min(560px, calc(100% - 24px));
+	background: var(--surface);
+	border: 1px solid var(--border-strong);
+	border-radius: 10px;
+	box-shadow: 0 20px 48px rgba(0, 0, 0, 0.22);
+	overflow: hidden;
+}
+.omp-palette-input {
+	width: 100%;
+	padding: 14px 14px;
+	border: none;
+	border-bottom: 1px solid var(--border);
+	background: var(--surface);
+	color: var(--text);
+	font-family: var(--font-sans);
+	font-size: 14px;
+	outline: none;
+}
+.omp-palette-input::placeholder {
+	color: var(--dim);
+}
+.omp-palette-list {
+	max-height: 320px;
+	overflow-y: auto;
+	padding: 6px;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+.omp-palette-item {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	padding: 8px 10px;
+	border-radius: var(--radius-md);
+	cursor: pointer;
+	font-family: var(--font-sans);
+	font-size: 13px;
+	color: var(--muted);
+	border: 1px solid transparent;
+}
+.omp-palette-item[data-active="true"] {
+	background: var(--surface-2);
+	color: var(--text);
+	border-color: var(--border);
+}
+.omp-palette-kbd {
+	font-family: var(--font-mono);
+	font-size: 10px;
+	color: var(--dim);
+	border: 1px solid var(--border);
+	background: var(--surface-2);
+	padding: 2px 5px;
+	border-radius: 3px;
+}
 
 /* Utilities */
-.stats-text-primary { color: var(--text); }
-.stats-text-secondary { color: var(--muted); }
-.stats-text-muted { color: var(--dim); }
-.stats-text-warning { color: var(--amber); }
-.stats-text-xs { font-size: 11px; }
-.stats-font-medium { font-weight: 500; }
-.stats-font-semibold { font-weight: 600; }
-.stats-hidden { display: none !important; }
-[data-hidden="true"] { display: none !important; }
+.stats-text-primary {
+	color: var(--text);
+}
+.stats-text-secondary {
+	color: var(--muted);
+}
+.stats-text-muted {
+	color: var(--dim);
+}
+.stats-text-warning {
+	color: var(--amber);
+}
+.stats-text-xs {
+	font-size: 11px;
+}
+.stats-font-medium {
+	font-weight: 500;
+}
+.stats-font-semibold {
+	font-weight: 600;
+}
+.stats-hidden {
+	display: none !important;
+}
+[data-hidden="true"] {
+	display: none !important;
+}
 
 /* Legacy route helpers restored — used by Errors/Projects/Providers/Gain/Tools */
 .stats-select {
-  background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-md);
-  color: var(--text); font-family: var(--font-mono); font-size: 11px; padding: 6px 8px;
+	background: var(--surface-2);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-md);
+	color: var(--text);
+	font-family: var(--font-mono);
+	font-size: 11px;
+	padding: 6px 8px;
 }
 
 /* ===================================================================   Traces (session flamegraph)
    ========================================================================== */
 .stats-trace-view {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
 }
 
 .stats-trace-header {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
-  min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	flex-wrap: wrap;
+	min-width: 0;
 }
 
 .stats-trace-back {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  font-size: 12px;
-  color: var(--muted);
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  transition: color 0.14s ease, border-color 0.14s ease;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 12px;
+	font-size: 12px;
+	color: var(--muted);
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-md);
+	cursor: pointer;
+	transition:
+		color 0.14s ease,
+		border-color 0.14s ease;
 }
 
 .stats-trace-back:hover {
-  color: var(--text);
-  border-color: var(--border-strong);
+	color: var(--text);
+	border-color: var(--border-strong);
 }
 
 .stats-trace-back:focus-visible {
-  outline: 2px solid var(--link);
-  outline-offset: 2px;
+	outline: 2px solid var(--link);
+	outline-offset: 2px;
 }
 
 .stats-trace-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text);
-  margin: 0;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+	font-size: 15px;
+	font-weight: 600;
+	color: var(--text);
+	margin: 0;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .stats-trace-cwd {
-  font-size: 11px;
-  color: var(--dim);
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  padding: 3px 10px;
-  max-width: 280px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+	font-size: 11px;
+	color: var(--dim);
+	border: 1px solid var(--border);
+	border-radius: 999px;
+	padding: 3px 10px;
+	max-width: 280px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 /* Summary strip: one bordered card, hairline-divided stat columns. */
 .stats-trace-summary {
-  display: flex;
-  flex-wrap: wrap;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  overflow: hidden;
+	display: flex;
+	flex-wrap: wrap;
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-lg);
+	overflow: hidden;
 }
 
 .stats-trace-summary-cell {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  padding: 10px 16px;
-  border-right: 1px solid var(--border);
-  min-width: 76px;
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+	padding: 10px 16px;
+	border-right: 1px solid var(--border);
+	min-width: 76px;
 }
 
 .stats-trace-summary-cell:last-child {
-  border-right: none;
+	border-right: none;
 }
 
 .stats-trace-summary-label {
-  font-size: 9px;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: var(--dim);
+	font-size: 9px;
+	text-transform: uppercase;
+	letter-spacing: 0.07em;
+	color: var(--dim);
 }
 
 .stats-trace-summary-value {
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--text);
-  font-variant-numeric: tabular-nums;
+	font-size: 13px;
+	font-weight: 500;
+	color: var(--text);
+	font-variant-numeric: tabular-nums;
 }
 
 /* Toolbar row above the timeline. */
 .stats-trace-toolbar {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	flex-wrap: wrap;
 }
 
 .stats-trace-toolbar-hint {
-  font-size: 10px;
-  color: var(--dim);
-  margin-left: auto;
+	font-size: 10px;
+	color: var(--dim);
+	margin-left: auto;
 }
 
 .stats-trace-input {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  color: var(--text);
-  font-size: 12px;
-  padding: 6px 10px;
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-md);
+	color: var(--text);
+	font-size: 12px;
+	padding: 6px 10px;
 }
 
 .stats-trace-input:focus-visible {
-  outline: 2px solid var(--link);
-  outline-offset: 1px;
+	outline: 2px solid var(--link);
+	outline-offset: 1px;
 }
 
 .stats-trace-input::placeholder {
-  color: var(--dim);
+	color: var(--dim);
 }
 
 .stats-trace-check {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  color: var(--muted);
-  cursor: pointer;
-  user-select: none;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12px;
+	color: var(--muted);
+	cursor: pointer;
+	user-select: none;
 }
 
 .stats-trace-icon-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 26px;
-  height: 26px;
-  background: transparent;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  color: var(--muted);
-  cursor: pointer;
-  transition: color 0.14s ease, border-color 0.14s ease;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 26px;
+	height: 26px;
+	background: transparent;
+	border: 1px solid var(--border);
+	border-radius: var(--radius-md);
+	color: var(--muted);
+	cursor: pointer;
+	transition:
+		color 0.14s ease,
+		border-color 0.14s ease;
 }
 
 .stats-trace-icon-btn:hover:not(:disabled) {
-  color: var(--text);
-  border-color: var(--border-strong);
+	color: var(--text);
+	border-color: var(--border-strong);
 }
 
 .stats-trace-icon-btn:focus-visible {
-  outline: 2px solid var(--link);
-  outline-offset: 2px;
+	outline: 2px solid var(--link);
+	outline-offset: 2px;
 }
 
 .stats-trace-icon-btn:disabled {
-  opacity: 0.4;
-  cursor: default;
+	opacity: 0.4;
+	cursor: default;
 }
 
 /* Timeline card: minimap + canvas share one bordered surface. */
 .stats-trace-timeline-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-lg);
+	padding: 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
 }
 
 .stats-trace-timeline {
-  position: relative;
-  display: flex;
-  max-height: 560px;
-  overflow-y: auto;
-  overflow-x: hidden;
+	position: relative;
+	display: flex;
+	max-height: 560px;
+	overflow-y: auto;
+	overflow-x: hidden;
 }
 
 .stats-trace-canvas {
-  cursor: grab;
-  outline: none;
-  touch-action: none;
-  border-radius: var(--radius-sm);
+	cursor: grab;
+	outline: none;
+	touch-action: none;
+	border-radius: var(--radius-sm);
 }
 
 .stats-trace-canvas:focus-visible {
-  outline: 2px solid var(--link);
-  outline-offset: 2px;
+	outline: 2px solid var(--link);
+	outline-offset: 2px;
 }
 
 .stats-trace-canvas:active {
-  cursor: grabbing;
+	cursor: grabbing;
 }
 
 .stats-trace-chevron {
-  display: inline-flex;
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  color: var(--muted);
+	display: inline-flex;
+	background: none;
+	border: none;
+	padding: 0;
+	cursor: pointer;
+	color: var(--muted);
 }
 
 .stats-trace-chevron:hover {
-  color: var(--text);
+	color: var(--text);
 }
 
 .stats-trace-gutter-track {
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--text);
+	font-size: 11px;
+	font-weight: 500;
+	color: var(--text);
 }
 
 .stats-trace-gutter-model {
-  font-size: 9px;
-  color: var(--dim);
+	font-size: 9px;
+	color: var(--dim);
 }
 
 .stats-trace-gutter-lane {
-  position: absolute;
-  font-size: 8px;
-  color: var(--dim);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+	position: absolute;
+	font-size: 8px;
+	color: var(--dim);
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
 }
 
 /* Transcript list under the timeline. */
 .stats-trace-list {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  height: 340px;
-  overflow-y: auto;
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-lg);
+	height: 340px;
+	overflow-y: auto;
 }
 
 .stats-trace-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  height: 28px;
-  width: 100%;
-  padding: 0 12px;
-  background: transparent;
-  border: none;
-  border-bottom: 1px solid var(--border);
-  text-align: left;
-  cursor: pointer;
-  transition: background 0.1s ease;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	height: 28px;
+	width: 100%;
+	padding: 0 12px;
+	background: transparent;
+	border: none;
+	border-bottom: 1px solid var(--border);
+	text-align: left;
+	cursor: pointer;
+	transition: background 0.1s ease;
 }
 
 .stats-trace-row:hover {
-  background: var(--bg-hover);
+	background: var(--bg-hover);
 }
 
 .stats-trace-row:focus-visible {
-  outline: 2px solid var(--link);
-  outline-offset: -2px;
+	outline: 2px solid var(--link);
+	outline-offset: -2px;
 }
 
 .stats-trace-row[data-selected="true"] {
-  background: var(--accent-muted);
+	background: var(--accent-muted);
 }
 
 .stats-trace-row-static {
-  cursor: default;
+	cursor: default;
 }
 
 .stats-trace-row-static:hover {
-  background: transparent;
+	background: transparent;
 }
 
 .stats-trace-kind {
-  flex-shrink: 0;
-  width: 58px;
-  font-size: 8px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  border-radius: 3px;
-  padding: 2px 0;
-  text-align: center;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+	flex-shrink: 0;
+	width: 58px;
+	font-size: 8px;
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+	border-radius: 3px;
+	padding: 2px 0;
+	text-align: center;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .stats-trace-row-meta {
-  flex-shrink: 0;
-  margin-left: auto;
-  font-size: 10px;
-  color: var(--dim);
-  font-variant-numeric: tabular-nums;
-  display: flex;
-  gap: 10px;
+	flex-shrink: 0;
+	margin-left: auto;
+	font-size: 10px;
+	color: var(--dim);
+	font-variant-numeric: tabular-nums;
+	display: flex;
+	gap: 10px;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .stats-trace-back,
-  .stats-trace-icon-btn,
-  .stats-trace-row {
-    transition: none;
-  }
+	.stats-trace-back,
+	.stats-trace-icon-btn,
+	.stats-trace-row {
+		transition: none;
+	}
 }
-.stats-select:focus { outline: 2px solid var(--link); outline-offset: 1px; }
-=======
-.stats-select { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-md); color: var(--text); font-family: var(--font-sans); font-size: 12px; padding: 6px 8px; }
-.stats-select:focus { outline: 2px solid var(--focus); outline-offset: 1px; }
-.stats-text-danger { color: var(--danger); }
-.stats-text-success { color: var(--success); }
-.stats-border-danger { border-color: var(--danger) !important; }
-.stats-font-mono { font-family: var(--font-mono) !important; }
-.stats-truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.stats-max-w-md { max-width: 28rem; }
+.stats-select:focus {
+	outline: 2px solid var(--link);
+	outline-offset: 1px;
+}
+.stats-select:focus {
+	outline: 2px solid var(--focus);
+	outline-offset: 1px;
+}
+.stats-text-danger {
+	color: var(--danger);
+}
+.stats-text-success {
+	color: var(--success);
+}
+.stats-border-danger {
+	border-color: var(--danger) !important;
+}
+.stats-font-mono {
+	font-family: var(--font-mono) !important;
+}
+.stats-truncate {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.stats-max-w-md {
+	max-width: 28rem;
+}
 
-* { scrollbar-width: thin; scrollbar-color: var(--border-strong) transparent; }
-*::-webkit-scrollbar { width: 8px; height: 8px; }
-*::-webkit-scrollbar-track { background: transparent; }
-*::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; border: 2px solid transparent; background-clip: content-box; }
-*::-webkit-scrollbar-thumb:hover { background: color-mix(in oklch, var(--border-strong) 90%, var(--muted)); background-clip: content-box; }
+* {
+	scrollbar-width: thin;
+	scrollbar-color: var(--border-strong) transparent;
+}
+*::-webkit-scrollbar {
+	width: 8px;
+	height: 8px;
+}
+*::-webkit-scrollbar-track {
+	background: transparent;
+}
+*::-webkit-scrollbar-thumb {
+	background: var(--border-strong);
+	border-radius: 999px;
+	border: 2px solid transparent;
+	background-clip: content-box;
+}
+*::-webkit-scrollbar-thumb:hover {
+	background: color-mix(in oklch, var(--border-strong) 90%, var(--muted));
+	background-clip: content-box;
+}
 
 @media (prefers-reduced-motion: reduce) {
-  .stats-spin, .stats-skeleton::after { animation: none !important; }
-  .stats-nav-rail, .stats-nav-rail-item, .stats-range-control-btn, .stats-button { transition: none !important; }
+	.stats-spin,
+	.stats-skeleton::after {
+		animation: none !important;
+	}
+	.stats-nav-rail,
+	.stats-nav-rail-item,
+	.stats-range-control-btn,
+	.stats-button {
+		transition: none !important;
+	}
 }
-.stats-theme-toggle { display: inline-flex; align-items: center; justify-content: center; padding: 6px; border-radius: var(--radius-md); border: 1px solid var(--border); background: var(--surface-2); color: var(--muted); cursor: pointer; }
-.stats-theme-toggle:hover { color: var(--text); background: var(--surface-3); }
-.stats-json-actions { display: flex; gap: 6px; align-items: center; }
-.stats-json-copy-btn { display: inline-flex; align-items: center; gap: 6px; padding: 4px 8px; font-size: 11px; font-family: var(--font-mono); border: 1px solid var(--border); background: var(--surface-2); color: var(--muted); border-radius: var(--radius-sm); cursor: pointer; }
-.stats-json-copy-btn:hover { color: var(--text); background: var(--surface-3); }
+.stats-theme-toggle {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 6px;
+	border-radius: var(--radius-md);
+	border: 1px solid var(--border);
+	background: var(--surface-2);
+	color: var(--muted);
+	cursor: pointer;
+}
+.stats-theme-toggle:hover {
+	color: var(--text);
+	background: var(--surface-3);
+}
+.stats-json-actions {
+	display: flex;
+	gap: 6px;
+	align-items: center;
+}
+.stats-json-copy-btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 4px 8px;
+	font-size: 11px;
+	font-family: var(--font-mono);
+	border: 1px solid var(--border);
+	background: var(--surface-2);
+	color: var(--muted);
+	border-radius: var(--radius-sm);
+	cursor: pointer;
+}
+.stats-json-copy-btn:hover {
+	color: var(--text);
+	background: var(--surface-3);
+}

--- a/packages/stats/src/client/styles.css
+++ b/packages/stats/src/client/styles.css
@@ -1,32 +1,32 @@
 @import "tailwindcss/index.css";
 
 /* ==========================================================================
-   OMP Stats — Instrument Console
-   Family: htop / Grafana / Bloomberg — measurement, not marketing.
-   COLOR = SEMANTICS ONLY: neutral greys + red (errors) · amber (cost)
-   · green (cache/success) · one restrained accent for selection.
-   Flat 1px hairlines, radius ≤4px, type carries identity.
+   OMP Stats — Ledger / Instrument
+   Visual language: precise, calm, dense where useful. Not a card grid.
+   Tokens carry semantics, not decoration. Monospace is data-only.
    ========================================================================== */
 
 :root {
   color-scheme: dark;
-  --page: oklch(0.155 0.022 307);
+  --page: oklch(0.148 0.022 306);
   --surface: oklch(0.193 0.022 307);
-  --surface-2: oklch(0.235 0.026 307);
+  --surface-2: oklch(0.233 0.024 307);
   --surface-3: oklch(0.27 0.028 307);
-  --border: oklch(1 0 0 / 0.09);
-  --border-strong: oklch(1 0 0 / 0.135);
-  --text: oklch(0.925 0.008 307);
-  --muted: oklch(0.70 0.016 307);
-  --dim: oklch(0.53 0.018 307);
+  --raised: oklch(0.215 0.02 307);
+  --border: oklch(1 0 0 / 0.08);
+  --border-strong: oklch(1 0 0 / 0.13);
+  --text: oklch(0.93 0.008 307);
+  --muted: oklch(0.69 0.015 307);
+  --dim: oklch(0.52 0.018 307);
   --accent: oklch(0.72 0.04 230);
-  --accent-fg: oklch(0.16 0.02 307);
-  --accent-muted: oklch(0.72 0.04 230 / 0.12);
-  --link: oklch(0.817 0.112 205);
-  --success: oklch(0.76 0.14 150);
+  --accent-fg: oklch(0.14 0.02 307);
+  --accent-muted: oklch(0.72 0.04 230 / 0.11);
+  --focus: oklch(0.78 0.12 205);
+  --link: oklch(0.80 0.11 205);
+  --success: oklch(0.74 0.13 150);
   --danger: oklch(0.66 0.19 25);
-  --warning: oklch(0.79 0.14 85);
-  --amber: oklch(0.78 0.16 84);
+  --warning: oklch(0.78 0.14 85);
+  --amber: oklch(0.77 0.16 84);
   --text-primary: var(--text);
   --text-secondary: var(--muted);
   --text-muted: var(--dim);
@@ -38,44 +38,53 @@
   --bg-elevated: var(--surface-2);
   --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
 
-  --radius-sm: 2px;
-  --radius-md: 3px;
-  --radius-lg: 4px;
-  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  /* Semantics only: chart req = neutral, err = danger; tokens: input/output = neutral grey, read = success, write = dim */
+  --radius-sm: 3px;
+  --radius-md: 5px;
+  --radius-lg: 8px;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-display: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --raised: oklch(0.985 0.005 307);
   --chart-req: oklch(0.68 0.015 307);
   --chart-err: var(--danger);
-  --tok-input: oklch(0.62 0.015 307);
-  --tok-output: oklch(0.7 0.015 307);
+  --tok-input: oklch(0.60 0.015 307);
+  --tok-output: oklch(0.70 0.015 307);
   --tok-read: var(--success);
   --tok-write: var(--dim);
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --content-gap: 18px;
+  --content-pad: 22px;
 }
 
 @media (prefers-color-scheme: light) {
   :root:not([data-theme]) {
     color-scheme: light;
-    --page: oklch(0.985 0.004 307);
+    --page: oklch(0.99 0.004 307);
     --surface: oklch(1 0 0);
-    --surface-2: oklch(0.966 0.006 307);
+    --surface-2: oklch(0.968 0.006 307);
     --surface-3: oklch(0.94 0.008 307);
-    --border: oklch(0 0 0 / 0.1);
-    --border-strong: oklch(0 0 0 / 0.16);
-    --text: oklch(0.24 0.03 307);
-    --muted: oklch(0.46 0.03 307);
-    --dim: oklch(0.58 0.025 307);
-    --accent: oklch(0.55 0.05 230);
-    --accent-fg: oklch(0.98 0.01 230);
-    --accent-muted: oklch(0.55 0.05 230 / 0.14);
-    --link: oklch(0.58 0.13 230);
-    --success: oklch(0.55 0.13 150);
-    --danger: oklch(0.55 0.19 25);
+    --raised: oklch(0.985 0.005 307);
+    --border: oklch(0 0 0 / 0.08);
+    --border-strong: oklch(0 0 0 / 0.13);
+    --text: oklch(0.22 0.03 307);
+    --muted: oklch(0.45 0.025 307);
+    --dim: oklch(0.56 0.02 307);
+    --accent: oklch(0.57 0.06 230);
+    --accent-fg: oklch(0.99 0.01 230);
+    --accent-muted: oklch(0.57 0.06 230 / 0.10);
+    --focus: oklch(0.62 0.14 232);
+    --link: oklch(0.56 0.13 232);
+    --success: oklch(0.54 0.12 150);
+    --danger: oklch(0.56 0.18 25);
     --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23555' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
-    --warning: oklch(0.6 0.13 85);
+    --warning: oklch(0.62 0.13 85);
     --amber: oklch(0.66 0.15 80);
-    --chart-req: oklch(0.42 0.015 307);
+    --chart-req: oklch(0.43 0.015 307);
     --chart-err: var(--danger);
-    --tok-input: oklch(0.5 0.015 307);
+    --tok-input: oklch(0.50 0.015 307);
     --tok-output: oklch(0.58 0.015 307);
     --tok-read: var(--success);
     --tok-write: var(--dim);
@@ -83,33 +92,39 @@
 }
 [data-theme="light"] {
   color-scheme: light;
-  --page: oklch(0.985 0.004 307);
+  --page: oklch(0.99 0.004 307);
   --surface: oklch(1 0 0);
-  --surface-2: oklch(0.966 0.006 307);
+  --surface-2: oklch(0.968 0.006 307);
   --surface-3: oklch(0.94 0.008 307);
-  --border: oklch(0 0 0 / 0.1);
-  --border-strong: oklch(0 0 0 / 0.16);
-  --text: oklch(0.24 0.03 307);
-  --muted: oklch(0.46 0.03 307);
-  --dim: oklch(0.58 0.025 307);
-  --accent: oklch(0.55 0.05 230);
-  --accent-fg: oklch(0.98 0.01 230);
-  --accent-muted: oklch(0.55 0.05 230 / 0.14);
-  --link: oklch(0.58 0.13 230);
-  --success: oklch(0.55 0.13 150);
-  --danger: oklch(0.55 0.19 25);
+  --raised: oklch(0.985 0.005 307);
+  --border: oklch(0 0 0 / 0.08);
+  --border-strong: oklch(0 0 0 / 0.13);
+  --text: oklch(0.22 0.03 307);
+  --muted: oklch(0.45 0.025 307);
+  --dim: oklch(0.56 0.02 307);
+  --accent: oklch(0.57 0.06 230);
+  --accent-fg: oklch(0.99 0.01 230);
+  --accent-muted: oklch(0.57 0.06 230 / 0.10);
+  --focus: oklch(0.62 0.14 232);
+  --link: oklch(0.56 0.13 232);
+  --success: oklch(0.54 0.12 150);
+  --danger: oklch(0.56 0.18 25);
   --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23555' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
-  --warning: oklch(0.6 0.13 85);
+  --warning: oklch(0.62 0.13 85);
   --amber: oklch(0.66 0.15 80);
-  --chart-req: oklch(0.42 0.015 307);
+  --chart-req: oklch(0.43 0.015 307);
   --chart-err: var(--danger);
-  --tok-input: oklch(0.5 0.015 307);
+  --tok-input: oklch(0.50 0.015 307);
   --tok-output: oklch(0.58 0.015 307);
   --tok-read: var(--success);
   --tok-write: var(--dim);
 }
-[data-theme="dark"] {
-  color-scheme: dark;
+[data-theme="dark"] { color-scheme: dark; }
+[data-density="compact"] {
+  --content-gap: 12px;
+  --content-pad: 16px;
+  --space-3: 10px;
+  --space-4: 12px;
 }
 
 /* Base */
@@ -121,80 +136,107 @@
     background: var(--page);
     color: var(--text);
     margin: 0; min-height: 100vh;
-    font-size: 13.5px;
+    font-size: 13px;
     line-height: 1.5;
+    letter-spacing: -0.01em;
   }
   button:focus-visible, a:focus-visible, [tabindex]:focus-visible {
-    outline: 2px solid var(--link); outline-offset: 2px;
+    outline: 2px solid var(--focus); outline-offset: 2px;
   }
 }
 
 /* App shell */
 .stats-app-container { display: flex; min-height: 100vh; background: var(--page); color: var(--text); }
 
-/* Nav Rail */
+/* Nav Rail — collapsible */
 .stats-nav-rail {
-  width: 228px; background: var(--surface);
+  width: 220px; background: var(--surface);
   border-right: 1px solid var(--border);
   display: flex; flex-direction: column; flex-shrink: 0;
   position: sticky; top: 0; height: 100vh; overflow: hidden;
+  transition: width 0.18s ease;
 }
+.stats-nav-rail[data-collapsed="true"] { width: 56px; }
+.stats-nav-rail[data-collapsed="true"] .stats-nav-rail-item-label,
+.stats-nav-rail[data-collapsed="true"] .stats-logo-text,
+.stats-nav-rail[data-collapsed="true"] .stats-logo-subtext,
+.stats-nav-rail[data-collapsed="true"] .stats-version-tag,
+.stats-nav-rail[data-collapsed="true"] .stats-nav-rail-footer-label { display: none; }
+.stats-nav-rail[data-collapsed="true"] .stats-nav-rail-header { padding: 14px 0; justify-content: center; }
+.stats-nav-rail[data-collapsed="true"] .stats-nav-rail-item { justify-content: center; padding: 9px; }
 .stats-desktop-nav { display: flex; }
 @media (max-width: 1023px) { .stats-desktop-nav { display: none; } }
 .stats-nav-rail-header {
-  padding: 18px 20px; border-bottom: 1px solid var(--border);
-  height: 56px; display: flex; align-items: center; gap: 10px;
+  padding: 16px 16px 14px; border-bottom: 1px solid var(--border);
+  min-height: 56px; display: flex; align-items: center; gap: 10px; flex-shrink: 0;
 }
-.stats-logo-container { display: flex; flex-direction: column; gap: 1px; position: relative; padding-left: 12px; }
-.stats-logo-container::before {
-  content: ""; position: absolute; left: 0; top: 3px; bottom: 3px; width: 2px;
-  background: var(--border-strong); border-radius: 1px;
+.stats-logo-mark {
+  width: 28px; height: 28px; border-radius: 6px;
+  background: var(--text); color: var(--surface);
+  display: grid; place-items: center;
+  font-family: var(--font-mono); font-size: 11px; font-weight: 800; letter-spacing: -0.02em; flex-shrink: 0;
 }
-.stats-logo-text { font-family: var(--font-mono); font-size: 11px; font-weight: 700; letter-spacing: 0.08em; color: var(--text); line-height: 1; }
-.stats-logo-subtext { font-family: var(--font-mono); font-size: 9px; font-weight: 500; letter-spacing: 0.06em; color: var(--dim); line-height: 1; }
-.stats-nav-rail-menu { flex: 1; padding: 14px 10px; display: flex; flex-direction: column; gap: 3px; overflow-y: auto; }
+.stats-nav-rail[data-collapsed="true"] .stats-logo-mark { width: 28px; height: 28px; }
+.stats-logo-container { display: flex; flex-direction: column; gap: 0; min-width: 0; }
+.stats-logo-text { font-family: var(--font-sans); font-size: 12px; font-weight: 800; letter-spacing: -0.02em; color: var(--text); line-height: 1.1; }
+.stats-logo-subtext { font-family: var(--font-sans); font-size: 11px; font-weight: 500; letter-spacing: 0.02em; color: var(--dim); line-height: 1; }
+.stats-nav-collapse-btn {
+  margin-left: auto; width: 26px; height: 26px; display: grid; place-items: center;
+  border: 1px solid var(--border); background: var(--surface-2); color: var(--muted);
+  border-radius: var(--radius-sm); cursor: pointer; flex-shrink: 0;
+}
+.stats-nav-collapse-btn:hover { color: var(--text); border-color: var(--border-strong); background: var(--surface-3); }
+.stats-nav-rail-menu { flex: 1; padding: 10px 8px; display: flex; flex-direction: column; gap: 2px; overflow-y: auto; }
 .stats-nav-rail-item {
   display: flex; align-items: center; gap: 10px; padding: 8px 10px;
-  font-size: 12.5px; font-weight: 500; color: var(--muted);
-  background: transparent; border: 1px solid transparent; border-radius: var(--radius-sm);
+  font-size: 13px; font-weight: 500; color: var(--muted);
+  background: transparent; border: 1px solid transparent; border-radius: var(--radius-md);
   cursor: pointer; text-align: left; transition: all 0.14s ease; width: 100%;
+  font-family: var(--font-sans); letter-spacing: -0.01em;
 }
-.stats-nav-rail-item:hover { color: var(--text); background: var(--surface-2); border-color: var(--border); }
+.stats-nav-rail-item:hover { color: var(--text); background: var(--surface-2); }
 .stats-nav-rail-item[data-active="true"] {
-  color: var(--text); background: var(--surface-2); border-color: var(--border);
+  color: var(--text); background: var(--surface-2); border-color: transparent;
   box-shadow: inset 2px 0 0 var(--text);
 }
-.stats-nav-rail-item[data-active="true"] .stats-nav-rail-item-icon { color: var(--text); }
-.stats-nav-rail-item-icon { flex-shrink: 0; opacity: 0.9; }
+.stats-nav-rail-item-icon { flex-shrink: 0; opacity: 0.85; }
+.stats-nav-rail-item[data-active="true"] .stats-nav-rail-item-icon { opacity: 1; }
 .stats-nav-rail-item-label { flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.stats-nav-rail-footer { padding: 12px 16px; border-top: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.stats-nav-rail-footer { padding: 10px 12px; border-top: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; gap: 8px; flex-shrink: 0; }
+.stats-nav-rail-footer-label { font-family: var(--font-sans); font-size: 11px; color: var(--dim); letter-spacing: 0.01em; }
 .stats-version-tag {
   font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.06em; color: var(--dim);
   border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 2px 6px; background: var(--surface-2);
 }
+.stats-density-toggle {
+  display: inline-flex; align-items: center; gap: 4px; padding: 4px 6px; border-radius: var(--radius-sm);
+  border: 1px solid var(--border); background: var(--surface-2); color: var(--muted); cursor: pointer;
+  font-family: var(--font-sans); font-size: 11px; font-weight: 600;
+}
+.stats-density-toggle:hover { color: var(--text); background: var(--surface-3); }
 
 /* Main pane */
-.stats-main-pane { flex: 1; display: flex; flex-direction: column; min-width: 0; }
+.stats-main-pane { flex: 1; display: flex; flex-direction: column; min-width: 0; background: var(--page); }
 
 .stats-top-bar {
   height: 56px; background: var(--surface); border-bottom: 1px solid var(--border);
-  display: flex; align-items: center; justify-content: space-between; padding: 0 20px; gap: 16px;
+  display: flex; align-items: center; justify-content: space-between; padding: 0 18px; gap: 14px;
   position: sticky; top: 0; z-index: 10;
 }
 @media (max-width: 767px) {
-  .stats-top-bar { padding: 0 14px; flex-wrap: wrap; height: auto; min-height: 56px; padding-top: 8px; padding-bottom: 8px; gap: 10px; }
+  .stats-top-bar { padding: 0 12px; flex-wrap: wrap; height: auto; min-height: 56px; padding-top: 8px; padding-bottom: 8px; gap: 10px; }
 }
 .stats-top-bar-left { display: flex; align-items: center; gap: 10px; min-width: 0; }
 .stats-mobile-menu-btn { display: none; background: var(--surface-2); border: 1px solid var(--border); color: var(--text); padding: 6px; cursor: pointer; border-radius: var(--radius-md); }
 @media (max-width: 1023px) { .stats-mobile-menu-btn { display: inline-flex; align-items: center; justify-content: center; } }
 .stats-page-title {
-  font-size: 14px; font-weight: 700; color: var(--text); margin: 0; letter-spacing: -0.01em;
+  font-family: var(--font-sans); font-size: 13px; font-weight: 700; color: var(--text); margin: 0; letter-spacing: -0.02em;
   display: flex; align-items: center; gap: 8px; white-space: nowrap;
 }
-.stats-page-title::after {
-  content: ""; width: 8px; height: 2px; border-radius: 1px; background: var(--border-strong); display: inline-block;
+.stats-page-title-rule {
+  width: 18px; height: 1px; background: var(--border-strong); display: inline-block; opacity: 0.9;
 }
-.stats-top-bar-right { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.stats-top-bar-right { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 @media (max-width: 767px) { .stats-top-bar-right { width: 100%; justify-content: space-between; gap: 8px; } }
 .stats-top-bar-meta { display: flex; align-items: center; gap: 8px; }
 .stats-last-updated {
@@ -202,53 +244,49 @@
   background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 3px 6px;
 }
 .stats-content-area { flex: 1; overflow-y: auto; }
-.stats-content-inner { max-width: 1440px; margin: 0 auto; padding: 20px; display: flex; flex-direction: column; gap: 16px; }
+.stats-content-inner { max-width: 1360px; margin: 0 auto; padding: var(--content-pad); display: flex; flex-direction: column; gap: var(--content-gap); }
 @media (max-width: 767px) { .stats-content-inner { padding: 14px; gap: 14px; } }
 
 /* Mobile drawer */
-.stats-mobile-drawer-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.45); backdrop-filter: blur(2px); z-index: 100; }
+.stats-mobile-drawer-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.38); backdrop-filter: blur(2px); z-index: 100; }
 .stats-mobile-drawer { position: absolute; left: 0; top: 0; bottom: 0; width: 268px; background: var(--surface); border-right: 1px solid var(--border); display: flex; flex-direction: column; z-index: 101; animation: slideIn 0.2s ease-out; }
 @keyframes slideIn { from { transform: translateX(-100%); } to { transform: translateX(0); } }
-.stats-mobile-drawer-header { height: 56px; display: flex; align-items: center; justify-content: space-between; padding: 0 14px 0 18px; border-bottom: 1px solid var(--border); }
+.stats-mobile-drawer-header { height: 56px; display: flex; align-items: center; justify-content: space-between; padding: 0 14px 0 16px; border-bottom: 1px solid var(--border); }
 .stats-mobile-nav { display: flex; height: calc(100% - 56px); }
 
-/* Buttons */
+/* Buttons — text-forward, not pill-heavy */
 .stats-button {
   display: inline-flex; align-items: center; justify-content: center; gap: 6px;
-  padding: 7px 12px; font-size: 12.5px; font-weight: 600; border-radius: var(--radius-md);
-  border: 1px solid transparent; cursor: pointer; transition: all 0.14s ease; font-family: inherit;
+  padding: 7px 11px; font-size: 12.5px; font-weight: 600; border-radius: var(--radius-md);
+  border: 1px solid transparent; cursor: pointer; transition: all 0.14s ease; font-family: var(--font-sans);
   letter-spacing: -0.01em;
 }
 .stats-button:active:not(:disabled) { transform: translateY(1px); }
-.stats-button-primary { background: var(--success); color: var(--accent-fg); border-color: transparent; }
-.stats-button-primary:hover:not(:disabled) { background: var(--muted); border-color: var(--muted); }
+.stats-button-primary { background: var(--text); color: var(--surface); border-color: var(--text); }
+.stats-button-primary:hover:not(:disabled) { opacity: 0.9; }
 .stats-button-primary:disabled { opacity: 0.5; cursor: not-allowed; }
 .stats-button-secondary { background: var(--surface-2); color: var(--text); border-color: var(--border); }
 .stats-button-secondary:hover:not(:disabled) { background: var(--surface-3); border-color: var(--border-strong); }
 .stats-button-secondary:disabled { opacity: 0.5; cursor: not-allowed; }
-.stats-button-ghost {
-  background: transparent; color: var(--muted); border-color: var(--border);
-}
+.stats-button-ghost { background: transparent; color: var(--muted); border-color: var(--border); }
 .stats-button-ghost:hover { color: var(--text); background: var(--surface-2); }
-/* Sync DB — neutral inverted so green stays for DATA only */
 .stats-sync-btn { background: var(--surface); color: var(--text); border-color: var(--border-strong); }
-.stats-sync-btn:hover:not(:disabled) { background: var(--surface-2); border-color: var(--border-strong); color: var(--text); }
-/* RangeControl — segmented instrument switch */
+.stats-sync-btn:hover:not(:disabled) { background: var(--surface-2); }
 .stats-range-control {
   display: flex; background: var(--surface-2); border: 1px solid var(--border);
-  border-radius: var(--radius-sm); padding: 2px; gap: 1px;
+  border-radius: var(--radius-md); padding: 2px; gap: 1px;
 }
 .stats-range-control-btn {
-  padding: 4px 8px; font-size: 11px; font-weight: 600; letter-spacing: 0.02em;
-  color: var(--muted); background: transparent; border: 1px solid transparent; border-radius: 2px;
-  cursor: pointer; transition: all 0.14s ease; font-family: var(--font-mono); font-variant-numeric: tabular-nums;
+  padding: 5px 9px; font-size: 11px; font-weight: 650; letter-spacing: 0.01em;
+  color: var(--muted); background: transparent; border: 1px solid transparent; border-radius: 4px;
+  cursor: pointer; transition: all 0.14s ease; font-family: var(--font-sans);
 }
 .stats-range-control-btn:hover { color: var(--text); }
 .stats-range-control-btn[data-active="true"] { background: var(--text); color: var(--surface); border-color: var(--text); }
 
 /* Sync + Theme */
 .stats-sync-container { display: flex; align-items: center; gap: 8px; }
-.stats-sync-status-msg { font-size: 11px; font-family: var(--font-mono); }
+.stats-sync-status-msg { font-size: 11px; font-family: var(--font-sans); }
 .stats-sync-status-msg[data-type="success"] { color: var(--success); }
 .stats-sync-status-msg[data-type="error"] { color: var(--danger); }
 .stats-sync-icon { flex-shrink: 0; }
@@ -355,195 +393,305 @@
 
 /* Panel */
 /* Panel — instrument housing */
+/* ========== OVERVIEW — de-cardified ========== */
+.stats-route-container { display: flex; flex-direction: column; gap: var(--content-gap); }
+
+/* Hero metrics — open, typographic, not 6 equal cards */
+.omp-hero {
+  display: flex; flex-direction: column; gap: 14px;
+}
+.omp-hero-head {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 12px; flex-wrap: wrap;
+  border-bottom: 1px solid var(--border); padding-bottom: 12px;
+}
+.omp-hero-title {
+  font-family: var(--font-sans); font-size: 22px; font-weight: 800; letter-spacing: -0.03em; color: var(--text); line-height: 1;
+  display: flex; align-items: baseline; gap: 10px;
+}
+.omp-hero-title span { font-weight: 500; font-size: 12px; color: var(--dim); letter-spacing: 0.04em; text-transform: uppercase; font-family: var(--font-mono); }
+.omp-hero-range {
+  font-family: var(--font-mono); font-size: 11px; color: var(--muted); background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 4px 8px; font-variant-numeric: tabular-nums;
+}
+.omp-metrics-herd {
+  display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 18px; align-items: baseline;
+}
+@media (max-width: 1023px) { .omp-metrics-herd { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
+@media (max-width: 639px) { .omp-metrics-herd { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; } }
+.omp-kpi { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.omp-kpi-label {
+  font-family: var(--font-sans); font-size: 11px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--dim);
+}
+.omp-kpi-value {
+  font-family: var(--font-sans); font-size: 26px; font-weight: 800; letter-spacing: -0.035em; color: var(--text); line-height: 1; font-variant-numeric: tabular-nums;
+}
+@media (max-width: 767px) { .omp-kpi-value { font-size: 22px; } }
+.omp-kpi-value[data-mono="true"] { font-family: var(--font-mono); font-weight: 700; letter-spacing: -0.02em; }
+.omp-kpi-sub { font-family: var(--font-mono); font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.omp-kpi-accent { width: 24px; height: 2px; border-radius: 1px; background: var(--border-strong); margin-top: 6px; }
+.omp-kpi[data-tone="danger"] .omp-kpi-accent { background: var(--danger); }
+.omp-kpi[data-tone="success"] .omp-kpi-accent { background: var(--success); }
+.omp-kpi[data-tone="warning"] .omp-kpi-accent { background: var(--amber); }
+
+/* Legacy tape kept for compatibility but not used in new overview */
+.stats-overview-tape { display: none; }
+
+/* Overview toolbar — dashboards */
+.omp-dashboard-bar {
+  display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap;
+  padding: 8px 10px; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-md);
+}
+.omp-dashboard-tabs { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
+.omp-dashboard-tab {
+  padding: 5px 10px; font-size: 12px; font-weight: 600; font-family: var(--font-sans); letter-spacing: -0.01em;
+  color: var(--muted); background: transparent; border: 1px solid var(--border); border-radius: var(--radius-sm); cursor: pointer;
+}
+.omp-dashboard-tab[data-active="true"] { background: var(--text); color: var(--surface); border-color: var(--text); }
+.omp-dashboard-actions { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
+.omp-dashboard-input {
+  font-family: var(--font-sans); font-size: 12px; padding: 5px 8px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); color: var(--text); min-width: 140px;
+}
+.omp-dashboard-input:focus { outline: 2px solid var(--focus); outline-offset: 1px; }
+
+/* Section — open, not boxed */
+.omp-section {
+  display: flex; flex-direction: column; gap: 10px;
+}
+.omp-section-head {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; flex-wrap: wrap;
+}
+.omp-section-title {
+  font-family: var(--font-sans); font-size: 13px; font-weight: 700; color: var(--text); letter-spacing: -0.02em; line-height: 1.2;
+}
+.omp-section-desc {
+  font-family: var(--font-sans); font-size: 12px; color: var(--muted); line-height: 1.4; margin: 2px 0 0;
+}
+.omp-section-rule { height: 1px; background: var(--border); width: 100%; }
+.omp-section-body { min-width: 0; }
+
+/* Scope chart — restrained instrument, not card */
+.omp-scope-wrap {
+  display: grid; grid-template-columns: minmax(0, 1.6fr) minmax(280px, 0.95fr); gap: 16px; align-items: start;
+}
+@media (max-width: 1023px) { .omp-scope-wrap { grid-template-columns: 1fr; } }
+.omp-scope-main {
+  background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden; display: flex; flex-direction: column; min-width: 0;
+}
+.omp-scope-side { display: flex; flex-direction: column; gap: 12px; min-width: 0; }
+.omp-scope-header {
+  display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 10px 12px; border-bottom: 1px solid var(--border); background: var(--surface);
+}
+.omp-scope-title { font-family: var(--font-sans); font-size: 12px; font-weight: 700; letter-spacing: -0.015em; color: var(--text); display: flex; align-items: center; gap: 8px; }
+.omp-scope-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--success); box-shadow: 0 0 0 3px oklch(0.74 0.13 150 / 0.14); }
+.omp-scope-legend { display: flex; align-items: center; gap: 10px; font-family: var(--font-mono); font-size: 11px; color: var(--muted); }
+.omp-scope-legend span { display: inline-flex; align-items: center; gap: 5px; }
+.omp-scope-legend i { width: 12px; height: 2px; border-radius: 999px; display: inline-block; }
+.omp-scope-body { padding: 12px 10px 8px; position: relative; min-width: 0; min-height: 260px; }
+[data-theme="light"] .stats-scope-wrap .stats-scope-grid { opacity: 0.14; }
+
+/* Token breakdown — 4-up, muted, not heavy cards */
+.omp-token-grid {
+  display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px;
+}
+@media (max-width: 767px) { .omp-token-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+.omp-token-item {
+  padding: 10px 0; border-top: 1px solid var(--border); display: flex; flex-direction: column; gap: 6px;
+}
+.omp-token-label { font-family: var(--font-sans); font-size: 11px; font-weight: 650; letter-spacing: 0.05em; text-transform: uppercase; color: var(--dim); }
+.omp-token-value { font-family: var(--font-mono); font-size: 16px; font-weight: 700; letter-spacing: -0.02em; color: var(--text); font-variant-numeric: tabular-nums; }
+.omp-token-bar { height: 3px; border-radius: 999px; background: var(--surface-3); overflow: hidden; }
+.omp-token-bar-fill { height: 100%; border-radius: 999px; }
+
+/* Row lists — model/provider/tool — open list, not cards */
+.omp-list { display: flex; flex-direction: column; }
+.omp-row {
+  display: flex; align-items: center; gap: 10px; padding: 9px 0; border-bottom: 1px solid var(--border); min-width: 0;
+}
+.omp-row:last-child { border-bottom: none; }
+.omp-row-rank { font-family: var(--font-mono); font-size: 10px; font-weight: 700; color: var(--dim); width: 18px; text-align: right; flex-shrink: 0; }
+.omp-row-main { flex: 1; min-width: 0; }
+.omp-row-title { font-family: var(--font-sans); font-size: 12.5px; font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.omp-row-sub { font-family: var(--font-mono); font-size: 11px; color: var(--dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.omp-row-bar { width: 84px; height: 3px; border-radius: 999px; background: var(--surface-3); overflow: hidden; flex-shrink: 0; }
+.omp-row-bar-fill { height: 100%; border-radius: 999px; background: var(--text); opacity: 0.9; }
+.omp-row-metric { font-family: var(--font-mono); font-size: 11px; font-variant-numeric: tabular-nums; color: var(--muted); min-width: 56px; text-align: right; flex-shrink: 0; }
+.omp-provider-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+@media (max-width: 639px) { .omp-provider-grid { grid-template-columns: 1fr; } }
+.omp-provider-item { padding: 10px 0; border-top: 1px solid var(--border); display: flex; flex-direction: column; gap: 6px; }
+.omp-provider-name { font-family: var(--font-sans); font-size: 12px; font-weight: 700; color: var(--text); letter-spacing: -0.01em; }
+
+/* ======================================================================
+   Inner routes — ranked lists, explorer tables, error groups
+   Reuses tokens, mono only for values, open layouts
+   ====================================================================== */
+
+.omp-ranked-head {
+  display: flex; align-items: center; gap: 8px; padding: 6px 0 8px; border-bottom: 1px solid var(--border);
+  font-family: var(--font-sans); font-size: 11px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--dim);
+}
+.omp-ranked-head button {
+  background: transparent; border: 1px solid transparent; border-radius: var(--radius-sm);
+  padding: 3px 6px; font: inherit; color: inherit; cursor: pointer; display: inline-flex; align-items: center; gap: 4px;
+}
+.omp-ranked-head button:hover { color: var(--text); background: var(--surface-2); border-color: var(--border); }
+.omp-ranked-head button[data-active="true"] { color: var(--text); background: var(--surface-3); border-color: var(--border-strong); }
+
+.omp-ranked-list { display: flex; flex-direction: column; }
+.omp-ranked-row {
+  display: grid; grid-template-columns: 22px minmax(0, 1.6fr) 84px repeat(4, 82px) minmax(0, 0.8fr) 28px;
+  align-items: center; gap: 10px; padding: 10px 0; border-bottom: 1px solid var(--border); min-width: 0;
+}
+.omp-ranked-row:last-child { border-bottom: none; }
+.omp-ranked-row:hover { background: color-mix(in oklch, var(--surface-2) 60%, transparent); }
+.omp-ranked-row[data-expanded="true"] { background: var(--surface-2); margin: 0 -8px; padding: 10px 8px; border: 1px solid var(--border); border-radius: var(--radius-md); }
+.omp-ranked-row:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; }
+.omp-ranked-row-rank { font-family: var(--font-mono); font-size: 10px; font-weight: 700; color: var(--dim); text-align: right; }
+.omp-ranked-row-main { min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.omp-ranked-row-title { font-family: var(--font-mono); font-size: 12.5px; font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.omp-ranked-row-sub { font-family: var(--font-sans); font-size: 11px; color: var(--dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.omp-ranked-bar { height: 3px; border-radius: 999px; background: var(--surface-3); overflow: hidden; }
+.omp-ranked-bar-fill { height: 100%; border-radius: 999px; background: var(--text); opacity: 0.85; }
+.omp-ranked-metric { font-family: var(--font-mono); font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; text-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: 1.4; }
+.omp-ranked-metric strong { color: var(--text); font-weight: 700; }
+.omp-ranked-metric small { display: block; font-size: 10px; color: var(--dim); font-family: var(--font-sans); }
+.omp-ranked-expand { width: 22px; height: 22px; display: grid; place-items: center; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); color: var(--muted); cursor: pointer; }
+.omp-ranked-expand:hover { color: var(--text); border-color: var(--border-strong); }
+
+@media (max-width: 1023px) {
+  .omp-ranked-row { grid-template-columns: 22px minmax(0, 1.2fr) 72px repeat(3, 74px) 28px; }
+  .omp-ranked-row .omp-ranked-hide-md { display: none; }
+}
+@media (max-width: 767px) {
+  .omp-ranked-row { grid-template-columns: 18px minmax(0, 1fr) 28px; }
+  .omp-ranked-row .omp-ranked-hide-sm { display: none; }
+  .omp-ranked-bar { display: none; }
+}
+
+.omp-ranked-detail {
+  grid-column: 1 / -1; margin-top: 8px; padding: 12px; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-md);
+  display: flex; flex-direction: column; gap: 12px;
+}
+.omp-ranked-detail-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; }
+@media (max-width: 767px) { .omp-ranked-detail-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+.omp-ranked-detail-label { font-family: var(--font-sans); font-size: 11px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--dim); }
+.omp-ranked-detail-value { font-family: var(--font-mono); font-size: 12px; font-weight: 600; color: var(--text); font-variant-numeric: tabular-nums; }
+
+/* Provider tones */
+.omp-provider-row[data-tone="danger"] { background: color-mix(in oklch, var(--danger) 7%, var(--surface)); }
+.omp-provider-row[data-tone="warning"] { background: color-mix(in oklch, var(--warning) 6%, var(--surface)); }
+.omp-provider-row[data-tone="danger"] .omp-ranked-row-title,
+.omp-provider-row[data-tone="warning"] .omp-ranked-row-title { color: var(--text); }
+
+/* Errors — grouped explorer */
+.omp-error-controls { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+.omp-error-group {
+  display: grid; grid-template-columns: 1fr auto; gap: 8px; padding: 10px 12px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface);
+}
+.omp-error-group + .omp-error-group { margin-top: 8px; }
+.omp-error-group[data-expanded="true"] { border-color: var(--border-strong); background: var(--surface-2); }
+.omp-error-sig { font-family: var(--font-sans); font-size: 13px; font-weight: 600; color: var(--text); line-height: 1.3; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.omp-error-meta { font-family: var(--font-mono); font-size: 11px; color: var(--muted); display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+.omp-error-meta strong { color: var(--text); }
+.omp-error-occ { margin-top: 10px; border-top: 1px solid var(--border); padding-top: 10px; display: flex; flex-direction: column; gap: 6px; max-height: 280px; overflow-y: auto; }
+.omp-error-occ-row { display: grid; grid-template-columns: 120px 1.2fr 80px auto; gap: 8px; font-family: var(--font-mono); font-size: 11px; color: var(--muted); padding: 4px 0; border-bottom: 1px solid var(--border); }
+.omp-error-occ-row span:first-child { color: var(--dim); }
+@media (max-width: 767px) { .omp-error-occ-row { grid-template-columns: 1fr auto; } .omp-error-occ-row .hide-sm { display: none; } }
+
+/* Requests explorer */
+.omp-explorer-wrap { border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--surface); overflow: hidden; }
+.omp-explorer-head { display: grid; grid-template-columns: 132px minmax(0, 1.2fr) 110px 84px 84px 72px 84px 68px 56px; gap: 0; padding: 8px 10px; border-bottom: 1px solid var(--border); font-family: var(--font-sans); font-size: 11px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--dim); }
+.omp-explorer-head button { font: inherit; color: inherit; background: transparent; border: none; cursor: pointer; text-align: left; padding: 0; }
+.omp-explorer-head button:hover { color: var(--text); }
+.omp-explorer-head button[data-active="true"] { color: var(--text); }
+.omp-explorer-row { display: grid; grid-template-columns: 132px minmax(0, 1.2fr) 110px 84px 84px 72px 84px 68px 56px; gap: 0; padding: 7px 10px; border-bottom: 1px solid var(--border); align-items: center; cursor: pointer; font-size: 12px; }
+.omp-explorer-row:last-child { border-bottom: none; }
+.omp-explorer-row:hover { background: var(--surface-2); }
+.omp-explorer-row span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.omp-explorer-row .mono { font-family: var(--font-mono); font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; }
+.omp-explorer-row .mono strong { color: var(--text); }
+.omp-explorer-pager { display: flex; gap: 8px; align-items: center; justify-content: space-between; padding: 10px 12px; border-top: 1px solid var(--border); background: var(--surface-2); font-family: var(--font-sans); font-size: 12px; color: var(--muted); flex-wrap: wrap; }
+@media (max-width: 1023px) {
+  .omp-explorer-head, .omp-explorer-row { grid-template-columns: 110px minmax(0, 1fr) 96px 68px 56px; }
+  .omp-explorer-head .hide-md, .omp-explorer-row .hide-md { display: none; }
+}
+@media (max-width: 767px) {
+  .omp-explorer-head { display: none; }
+  .omp-explorer-row { grid-template-columns: 1fr; gap: 6px; padding: 10px 12px; }
+  .omp-explorer-row .hide-sm { display: none; }
+  .omp-explorer-metrics { display: flex; gap: 10px; flex-wrap: wrap; }
+}
+
+/* Gain methodology */
+.omp-method { font-family: var(--font-sans); font-size: 11px; color: var(--muted); background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 8px 10px; line-height: 1.5; }
+.omp-method strong { color: var(--text); }
+
+/* Behavior inline */
+.omp-behavior-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; }
+@media (max-width: 767px) { .omp-behavior-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+.omp-behavior-kpi { padding: 10px 0; border-top: 1px solid var(--border); }
+.omp-behavior-kpi-label { font-family: var(--font-sans); font-size: 11px; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase; color: var(--dim); }
+.omp-behavior-kpi-value { font-family: var(--font-mono); font-size: 15px; font-weight: 700; color: var(--text); font-variant-numeric: tabular-nums; }
+.omp-behavior-kpi-sub { font-family: var(--font-mono); font-size: 11px; color: var(--muted); }
+
+/* Density compact overrides for inner rows */
+[data-density="compact"] .omp-ranked-row { padding: 7px 0; }
+[data-density="compact"] .omp-explorer-row { padding: 5px 10px; }
+[data-density="compact"] .omp-error-group { padding: 8px 10px; }
+
+/* Focus and reduced motion */
+.omp-ranked-expand:focus-visible, .omp-error-group:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; }
+@media (prefers-reduced-motion: reduce) { .omp-ranked-row, .omp-error-group, .omp-explorer-row { transition: none !important; } }
+
+
+/* Panels — retained for non-overview routes, lightened */
 .stats-panel {
   background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg);
   overflow: hidden; display: flex; flex-direction: column;
 }
 .stats-panel-header {
   display: flex; align-items: flex-start; justify-content: space-between; gap: 12px;
-  padding: 12px 14px; border-bottom: 1px solid var(--border); background: var(--surface);
+  padding: 11px 12px; border-bottom: 1px solid var(--border); background: var(--surface);
 }
 @media (max-width: 480px) { .stats-panel-header { flex-direction: column; } }
 .stats-panel-header-titles { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .stats-panel-eyebrow {
-  font-size: 10px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: var(--dim); font-family: var(--font-mono);
-  display: flex; align-items: center; gap: 6px;
+  font-size: 11px; font-weight: 600; letter-spacing: 0.06em; color: var(--dim); font-family: var(--font-sans);
 }
-.stats-panel-eyebrow::before {
-  content: ""; width: 8px; height: 2px; border-radius: 2px; background: var(--success); opacity: 0.9;
-}
-.stats-panel-title { font-size: 13px; font-weight: 700; color: var(--text); letter-spacing: -0.015em; line-height: 1.2; }
-.stats-panel-subtitle { font-size: 11.5px; color: var(--muted); line-height: 1.4; margin: 0; }
+.stats-panel-title { font-family: var(--font-sans); font-size: 12.5px; font-weight: 700; color: var(--text); letter-spacing: -0.015em; line-height: 1.2; }
+.stats-panel-subtitle { font-family: var(--font-sans); font-size: 12px; color: var(--muted); line-height: 1.4; margin: 0; }
 .stats-panel-actions { display: flex; align-items: center; gap: 6px; flex-shrink: 0; flex-wrap: wrap; }
-.stats-panel-body { padding: 16px; }
-@media (max-width: 767px) { .stats-panel-body { padding: 14px; } }
+.stats-panel-body { padding: 14px; }
+@media (max-width: 767px) { .stats-panel-body { padding: 12px; } }
 
-/* Overview-specific */
-.stats-route-container { display: flex; flex-direction: column; gap: 16px; }
-
-/* KPI Tape — the signature instrument */
-.stats-overview-tape {
-  display: grid; grid-template-columns: repeat(6, minmax(0, 1fr));
-  background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg);
-  overflow: hidden;
-}
-@media (max-width: 1279px) { .stats-overview-tape { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
-@media (max-width: 639px) { .stats-overview-tape { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
-.stats-tape-cell {
-  padding: 14px 14px 12px; border-right: 1px solid var(--border); border-bottom: 1px solid var(--border);
-  display: flex; flex-direction: column; gap: 6px; position: relative; min-width: 0;
-}
-.stats-tape-cell:last-child { border-right: none; }
-/* no top accent — separators handle structure */
-.stats-tape-label {
-  font-size: 10px; font-weight: 700; letter-spacing: 0.11em; text-transform: uppercase; color: var(--dim); font-family: var(--font-mono);
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-}
-.stats-tape-value {
-  font-family: var(--font-mono); font-size: 20px; font-weight: 700; letter-spacing: -0.03em; color: var(--text);
-  line-height: 1; font-variant-numeric: tabular-nums; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-}
-@media (max-width: 767px) { .stats-tape-value { font-size: 18px; } }
-.stats-tape-sub {
-  font-size: 11px; color: var(--muted); font-family: var(--font-mono); font-variant-numeric: tabular-nums;
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-}
-.stats-tape-badge {
-  display: inline-flex; align-items: center; gap: 4px; font-size: 9px; font-weight: 600; letter-spacing: 0.06em;
-  text-transform: uppercase; padding: 2px 5px; border-radius: var(--radius-sm); border: 1px solid var(--border);
-  background: var(--surface-2); color: var(--muted); font-family: var(--font-mono); width: fit-content;
-}
-.stats-tape-badge[data-tone="danger"] { color: var(--danger); border-color: color-mix(in oklch, var(--danger) 30%, transparent); background: color-mix(in oklch, var(--danger) 10%, var(--surface-2)); }
-.stats-tape-badge[data-tone="success"] { color: var(--success); border-color: color-mix(in oklch, var(--success) 30%, transparent); background: color-mix(in oklch, var(--success) 10%, var(--surface-2)); }
-.stats-tape-badge[data-tone="warning"] { color: var(--amber); border-color: color-mix(in oklch, var(--amber) 30%, transparent); background: color-mix(in oklch, var(--amber) 10%, var(--surface-2)); }
-
-/* Overview toolbar — presets + customize */
-.stats-overview-toolbar {
-  display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap;
-}
-.stats-preset-group { display: flex; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 2px; gap: 1px; }
-.stats-preset-btn {
-  padding: 4px 8px; font-size: 10px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; font-family: var(--font-mono);
-  color: var(--muted); background: transparent; border: 1px solid transparent; border-radius: var(--radius-sm); cursor: pointer;
-}
-.stats-preset-btn[data-active="true"] { background: var(--text); color: var(--surface); border-color: var(--text); }
-.stats-overview-customize {
-  display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
-}
-.stats-customize-chip {
-  display: inline-flex; align-items: center; gap: 6px; padding: 5px 8px; border-radius: var(--radius-sm);
-  border: 1px solid var(--border); background: var(--surface); color: var(--muted); font-size: 11px; font-weight: 600;
-  cursor: pointer; font-family: var(--font-mono); letter-spacing: 0.02em;
-}
-.stats-customize-chip[data-on="true"] { color: var(--text); background: var(--surface-2); border-color: var(--border-strong); }
-.stats-customize-chip input { accent-color: var(--success); }
-
-/* Oscilloscope chart shell — flex column without stretching to row height */
-.stats-scope-wrap {
-  position: relative; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden; min-width: 0;
-  display: flex; flex-direction: column; align-self: start;
-}
-.stats-scope-grid {
-  position: absolute; inset: 0; pointer-events: none; opacity: 0.22;
-  background-image:
-    linear-gradient(to right, var(--border) 1px, transparent 1px),
-    linear-gradient(to bottom, var(--border) 1px, transparent 1px);
-  background-size: 48px 32px;
-  mask-image: radial-gradient(ellipse at center, black 65%, transparent 100%);
-}
-[data-theme="light"] .stats-scope-wrap .stats-scope-grid { opacity: 0.14; }
-.stats-scope-header {
-  display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 12px 14px;
-  border-bottom: 1px solid var(--border); background: var(--surface); flex-shrink: 0;
-}
-.stats-scope-title { font-size: 12px; font-weight: 700; letter-spacing: -0.01em; color: var(--text); display: flex; align-items: center; gap: 8px; }
-.stats-scope-dot { width: 6px; height: 6px; border-radius: 1px; background: var(--success); }
-
-.stats-scope-legend { display: flex; align-items: center; gap: 10px; font-family: var(--font-mono); font-size: 11px; color: var(--muted); }
-.stats-scope-legend span { display: inline-flex; align-items: center; gap: 5px; }
-.stats-scope-legend i { width: 12px; height: 3px; border-radius: 999px; display: inline-block; }
-.stats-scope-body { padding: 10px 10px 6px; position: relative; min-width: 0; flex: 1; display: flex; flex-direction: column; min-height: 272px; max-height: 480px; }
-.stats-overview-grid {
-  display: grid; grid-template-columns: minmax(0, 1.55fr) minmax(0, 0.95fr); gap: 16px; align-items: start;
-}
-.stats-overview-grid > * { min-width: 0; }
-@media (max-width: 1023px) { .stats-overview-grid { grid-template-columns: 1fr; } }
-.stats-overview-stack { display: flex; flex-direction: column; gap: 16px; min-width: 0; }
-
-/* Token breakdown: four-quadrant */
-.stats-token-grid {
-  display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px;
-}
-@media (max-width: 767px) { .stats-token-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
-.stats-token-card {
-  background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-md);
-  padding: 12px 12px 10px; display: flex; flex-direction: column; gap: 6px;
-}
-.stats-token-card-label { font-size: 10px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--dim); font-family: var(--font-mono); }
-.stats-token-card-value { font-family: var(--font-mono); font-size: 16px; font-weight: 700; letter-spacing: -0.02em; color: var(--text); font-variant-numeric: tabular-nums; }
-.stats-token-card-share { display: flex; align-items: center; gap: 8px; }
-.stats-token-bar { flex: 1; height: 4px; border-radius: 999px; background: var(--surface-3); overflow: hidden; }
-.stats-token-bar-fill { height: 100%; border-radius: 999px; }
-.stats-token-share-label { font-size: 11px; font-family: var(--font-mono); color: var(--muted); font-variant-numeric: tabular-nums; }
-
-/* Models mini */
-.stats-model-row { display: flex; align-items: center; gap: 10px; padding: 10px 0; border-bottom: 1px solid var(--border); }
-.stats-model-row:last-child { border-bottom: none; }
-.stats-model-rank { font-family: var(--font-mono); font-size: 10px; font-weight: 700; color: var(--dim); width: 18px; text-align: right; }
-.stats-model-name { flex: 1; min-width: 0; }
-.stats-model-title { font-size: 12.5px; font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.stats-model-sub { font-size: 11px; color: var(--dim); font-family: var(--font-mono); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.stats-model-bar { width: 84px; height: 4px; border-radius: 999px; background: var(--surface-3); overflow: hidden; flex-shrink: 0; }
-.stats-model-bar-fill { height: 100%; border-radius: 2px; background: var(--success); }
-.stats-model-metric { font-family: var(--font-mono); font-size: 11px; font-variant-numeric: tabular-nums; color: var(--muted); min-width: 58px; text-align: right; flex-shrink: 0; }
-
-/* Provider chips */
-.stats-provider-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
-@media (max-width: 639px) { .stats-provider-grid { grid-template-columns: 1fr; } }
-.stats-provider-card { border: 1px solid var(--border); background: var(--surface-2); border-radius: var(--radius-md); padding: 12px; display: flex; flex-direction: column; gap: 8px; }
-.stats-provider-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
-.stats-provider-name { font-size: 12px; font-weight: 700; color: var(--text); letter-spacing: -0.01em; }
-.stats-provider-cost { font-family: var(--font-mono); font-size: 12px; font-weight: 700; color: var(--amber); font-variant-numeric: tabular-nums; }
-
-/* Agent bars reuse existing but tighten */
-.stats-agent-share-bar { height: 6px; }
-.stats-hidden { display: none !important; }
-
-/* Metric cluster legacy - keep for other routes but tighten */
-.stats-metric-cluster { display: flex; flex-direction: column; gap: 12px; }
+/* Metric cluster legacy — keep but de-emphasized */
+.stats-metric-cluster { display: flex; flex-direction: column; gap: 10px; }
 .stats-metric-primary-grid { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 10px; }
 @media (max-width: 1023px) { .stats-metric-primary-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
 @media (max-width: 480px) { .stats-metric-primary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 .stats-metric-secondary-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; }
-@media (max-width: 1279px) { .stats-metric-secondary-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); } }
 @media (max-width: 767px) { .stats-metric-secondary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
-.stats-metric-card { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 12px 12px 10px; overflow: hidden; position: relative; }
-.stats-metric-card.primary { padding: 14px 12px; }
-.stats-metric-card.primary .stats-metric-label { color: var(--dim); font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.09em; text-transform: uppercase; font-weight: 700; }
-.stats-metric-card.secondary { padding: 10px 12px; }
-.stats-metric-label { font-size: 11px; color: var(--muted); margin-bottom: 4px; }
-.stats-metric-value { font-family: var(--font-mono); font-size: 16px; font-weight: 700; color: var(--text); letter-spacing: -0.02em; font-variant-numeric: tabular-nums; }
-.stats-metric-card.secondary .stats-metric-value { font-size: 14px; }
+.stats-metric-card { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 11px; overflow: hidden; }
+.stats-metric-label { font-family: var(--font-sans); font-size: 11px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--dim); margin-bottom: 4px; }
+.stats-metric-value { font-family: var(--font-mono); font-size: 15px; font-weight: 700; color: var(--text); letter-spacing: -0.02em; font-variant-numeric: tabular-nums; }
 
 /* Data table — densified */
 .stats-table-wrapper { width: 100%; }
 .stats-table-container { overflow-x: auto; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface); }
 .stats-table { width: 100%; border-collapse: collapse; font-size: 12.5px; }
 .stats-table-th {
-  text-align: left; padding: 8px 12px; font-size: 10px; font-weight: 700; letter-spacing: 0.09em; text-transform: uppercase;
-  color: var(--dim); background: var(--surface-2); border-bottom: 1px solid var(--border); white-space: nowrap; font-family: var(--font-mono);
+  text-align: left; padding: 8px 10px; font-size: 11px; font-weight: 650; letter-spacing: 0.03em;
+  color: var(--dim); background: var(--surface-2); border-bottom: 1px solid var(--border); white-space: nowrap; font-family: var(--font-sans);
 }
-.stats-table-td { padding: 9px 12px; border-bottom: 1px solid var(--border); color: var(--muted); vertical-align: middle; }
+.stats-table-th[data-numeric="true"] { text-align: right; }
+.stats-table-td { padding: 8px 10px; border-bottom: 1px solid var(--border); color: var(--muted); vertical-align: middle; font-family: var(--font-sans); }
+.stats-table-td[data-mono="true"] { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
 .stats-table-tr { background: transparent; }
 .stats-table-tr-clickable { cursor: pointer; }
 .stats-table-tr-clickable:hover { background: var(--surface-2); }
 .stats-text-left { text-align: left; }
 .stats-text-right { text-align: right; }
 .stats-table-empty { padding: 28px 16px; text-align: center; color: var(--muted); font-size: 12.5px; }
-.stats-progress-bar-track { height: 4px; border-radius: 999px; background: var(--surface-3); overflow: hidden; }
-.stats-progress-bar-fill { height: 100%; border-radius: 2px; background: var(--success); }
-.stats-progress-bar-fill[data-variant="link"] { background: var(--link); }
-.stats-progress-bar-fill[data-variant="success"] { background: var(--success); }
+.stats-progress-bar-track { height: 3px; border-radius: 999px; background: var(--surface-3); overflow: hidden; }
+.stats-progress-bar-fill { height: 100%; border-radius: 999px; background: var(--text); opacity: 0.85; }
 .stats-table-mobile-only { display: none; }
 .stats-table-desktop-only { width: 100%; }
 @media (max-width: 767px) {
@@ -552,58 +700,42 @@
 }
 .stats-table-mobile-list { display: flex; flex-direction: column; gap: 10px; }
 .stats-table-mobile-card-wrapper { border: 1px solid var(--border); border-radius: var(--radius-md); overflow: hidden; background: var(--surface); }
-/* Mobile card polish for telemetry */
 .stats-mobile-card { padding: 12px; display: flex; flex-direction: column; gap: 10px; }
 .stats-mobile-card-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 8px; }
 .stats-mobile-card-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
-.stats-mobile-card-label { font-size: 10px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--dim); font-family: var(--font-mono); }
-.stats-mobile-card-value { font-size: 12.5px; color: var(--text); font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
-.stats-mobile-card-error { font-size: 11px; color: var(--danger); background: color-mix(in oklch, var(--danger) 10%, var(--surface-2)); border: 1px solid color-mix(in oklch, var(--danger) 18%, transparent); border-radius: var(--radius-sm); padding: 6px 8px; }
+.stats-mobile-card-label { font-family: var(--font-sans); font-size: 11px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--dim); }
+.stats-mobile-card-value { font-family: var(--font-mono); font-size: 12px; color: var(--text); font-variant-numeric: tabular-nums; }
+.stats-mobile-card-error { font-size: 11px; color: var(--danger); background: color-mix(in oklch, var(--danger) 8%, var(--surface-2)); border: 1px solid color-mix(in oklch, var(--danger) 14%, transparent); border-radius: var(--radius-sm); padding: 6px 8px; }
 
-/* Status pill — flat tag, not a candy */
+/* Status pill — flat tag */
 .stats-status-pill {
   display: inline-flex; align-items: center; gap: 4px; padding: 2px 7px; border-radius: var(--radius-sm);
-  font-size: 11px; font-weight: 700; letter-spacing: 0.02em; font-family: var(--font-mono); border: 1px solid var(--border);
+  font-size: 11px; font-weight: 700; letter-spacing: 0.01em; font-family: var(--font-mono); border: 1px solid var(--border);
   line-height: 1.4;
 }
-.stats-status-pill[data-variant="success"] { color: var(--success); background: color-mix(in oklch, var(--success) 12%, var(--surface-2)); border-color: color-mix(in oklch, var(--success) 22%, transparent); }
-.stats-status-pill[data-variant="danger"] { color: var(--danger); background: color-mix(in oklch, var(--danger) 12%, var(--surface-2)); border-color: color-mix(in oklch, var(--danger) 22%, transparent); }
-.stats-status-pill[data-variant="warning"] { color: var(--amber); background: color-mix(in oklch, var(--amber) 12%, var(--surface-2)); border-color: color-mix(in oklch, var(--amber) 22%, transparent); }
-.stats-status-pill[data-variant="info"] { color: var(--link); background: color-mix(in oklch, var(--link) 12%, var(--surface-2)); border-color: color-mix(in oklch, var(--link) 22%, transparent); }
+.stats-status-pill[data-variant="success"] { color: var(--success); background: color-mix(in oklch, var(--success) 10%, var(--surface-2)); border-color: color-mix(in oklch, var(--success) 18%, transparent); }
+.stats-status-pill[data-variant="danger"] { color: var(--danger); background: color-mix(in oklch, var(--danger) 10%, var(--surface-2)); border-color: color-mix(in oklch, var(--danger) 18%, transparent); }
+.stats-status-pill[data-variant="warning"] { color: var(--amber); background: color-mix(in oklch, var(--amber) 10%, var(--surface-2)); border-color: color-mix(in oklch, var(--amber) 18%, transparent); }
+.stats-status-pill[data-variant="info"] { color: var(--link); background: color-mix(in oklch, var(--link) 10%, var(--surface-2)); border-color: color-mix(in oklch, var(--link) 18%, transparent); }
 .stats-status-pill[data-variant="default"] { color: var(--muted); background: var(--surface-2); }
 
-/* Segmented — instrument switch, rectangular */
-.stats-segmented-control { display: flex; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 2px; gap: 1px; }
-.stats-segmented-control-btn { padding: 5px 10px; font-size: 11px; font-weight: 700; color: var(--muted); background: transparent; border: 1px solid transparent; border-radius: var(--radius-sm); cursor: pointer; font-family: var(--font-mono); }
+.stats-segmented-control { display: flex; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 2px; gap: 1px; }
+.stats-segmented-control-btn { padding: 5px 10px; font-size: 11px; font-weight: 700; color: var(--muted); background: transparent; border: 1px solid transparent; border-radius: var(--radius-sm); cursor: pointer; font-family: var(--font-sans); }
 .stats-segmented-control-btn:hover { color: var(--text); }
 .stats-segmented-control-btn[data-active="true"] { background: var(--text); color: var(--surface); border-color: var(--text); }
 
 /* Drawer */
-.stats-drawer-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.45); backdrop-filter: blur(2px); z-index: 50; display: flex; justify-content: flex-end; }
+.stats-drawer-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.42); backdrop-filter: blur(2px); z-index: 50; display: flex; justify-content: flex-end; }
 .stats-drawer { width: min(560px, 100%); background: var(--surface); border-left: 1px solid var(--border); display: flex; flex-direction: column; animation: drawerSlide 0.2s ease-out; }
 @keyframes drawerSlide { from { transform: translateX(100%); } to { transform: translateX(0); } }
 .stats-drawer-header { display: flex; align-items: center; justify-content: space-between; padding: 14px 16px; border-bottom: 1px solid var(--border); gap: 12px; }
 .stats-drawer-header-left { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.stats-drawer-title { font-size: 13px; font-weight: 700; color: var(--text); }
-.stats-drawer-id { font-size: 11px; color: var(--dim); font-family: var(--font-mono); }
+.stats-drawer-title { font-family: var(--font-sans); font-size: 13px; font-weight: 700; color: var(--text); }
+.stats-drawer-id { font-family: var(--font-mono); font-size: 11px; color: var(--dim); }
 .stats-drawer-close-btn { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 6px; cursor: pointer; color: var(--muted); display: inline-flex; }
 .stats-drawer-close-btn:hover { color: var(--text); background: var(--surface-3); }
 .stats-drawer-body { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 14px; }
 .stats-drawer-content { display: flex; flex-direction: column; gap: 12px; }
-.stats-drawer-status-card { border: 1px solid var(--border); background: var(--surface-2); border-radius: var(--radius-md); padding: 12px; display: flex; flex-direction: column; gap: 8px; }
-.stats-drawer-status-row { display: flex; justify-content: space-between; gap: 12px; font-size: 12.5px; }
-.stats-drawer-model { font-weight: 600; color: var(--text); }
-.stats-drawer-provider { font-family: var(--font-mono); font-size: 11px; color: var(--dim); }
-.stats-drawer-error-block { border: 1px solid color-mix(in oklch, var(--danger) 18%, transparent); background: color-mix(in oklch, var(--danger) 10%, var(--surface-2)); border-radius: var(--radius-md); padding: 10px 12px; }
-.stats-drawer-error-label { font-size: 10px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--danger); font-family: var(--font-mono); margin-bottom: 4px; }
-.stats-drawer-error-text { font-size: 12px; color: var(--danger); font-family: var(--font-mono); word-break: break-word; }
-.stats-drawer-metrics-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
-.stats-drawer-metric-card { border: 1px solid var(--border); background: var(--surface-2); border-radius: var(--radius-md); padding: 10px 12px; }
-.stats-drawer-metric-label { font-size: 10px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--dim); font-family: var(--font-mono); display: flex; align-items: center; gap: 6px; }
-.stats-drawer-metric-icon { color: var(--dim); }
-.stats-drawer-metric-value { font-family: var(--font-mono); font-size: 14px; font-weight: 700; color: var(--text); font-variant-numeric: tabular-nums; }
-.stats-drawer-metric-sub { font-size: 11px; color: var(--muted); }
-.stats-drawer-json-blocks { display: flex; flex-direction: column; gap: 10px; }
 
 /* JSON block */
 .stats-json-block { border: 1px solid var(--border); border-radius: var(--radius-md); overflow: hidden; background: var(--surface-2); }
@@ -620,32 +752,35 @@
 .stats-skeleton[data-variant="circle"] { border-radius: 50%; }
 .stats-skeleton::after {
   content: ""; position: absolute; inset: 0; transform: translateX(-100%);
-  background: linear-gradient(90deg, transparent, color-mix(in oklch, var(--border-strong) 50%, transparent), transparent);
+  background: linear-gradient(90deg, transparent, color-mix(in oklch, var(--border-strong) 45%, transparent), transparent);
   animation: shimmer 1.4s infinite;
 }
-@media (prefers-color-scheme: light) { .stats-skeleton::after { background: linear-gradient(90deg, transparent, rgba(0,0,0,0.06), transparent); } }
 @keyframes shimmer { 100% { transform: translateX(100%); } }
 @media (prefers-reduced-motion: reduce) { .stats-skeleton::after { animation: none; } }
 .stats-boundary-skeleton { display: flex; flex-direction: column; gap: 10px; padding: 12px; }
 
 /* Empty / Error */
-.stats-empty-state, .stats-error-state { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 10px; padding: 28px 16px; text-align: center; }
+.stats-empty-state, .stats-error-state { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 10px; padding: 20px 14px; text-align: center; }
 .stats-empty-state-message {
-  font-size: 12.5px; color: var(--muted); border: 1px dashed var(--border); border-radius: var(--radius-md);
-  padding: 12px 14px; background: var(--surface-2); font-family: var(--font-mono);
+  font-family: var(--font-sans); font-size: 12.5px; color: var(--muted); border: 1px dashed var(--border); border-radius: var(--radius-md);
+  padding: 10px 12px; background: var(--surface-2);
 }
 .stats-error-state-content { max-width: 360px; }
-.stats-error-state-title { font-size: 13px; font-weight: 700; color: var(--danger); }
+.stats-error-state-title { font-family: var(--font-sans); font-size: 13px; font-weight: 700; color: var(--danger); }
 .stats-error-state-message { font-size: 12px; color: var(--muted); }
-.stats-error-state-btn { margin: 0 auto; }
 .stats-empty-state-icon { color: var(--dim); opacity: 0.8; }
 
-/* Feed ledger */
-.stats-feed-ledger { scrollbar-width: thin; }
-.stats-feed-item { border-bottom: 1px solid var(--border); }
-.stats-feed-item:last-child { border-bottom: none; }
+/* Command palette */
+.omp-palette-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.38); backdrop-filter: blur(2px); z-index: 120; display: grid; place-items: start center; padding-top: 18vh; }
+.omp-palette { width: min(560px, calc(100% - 24px)); background: var(--surface); border: 1px solid var(--border-strong); border-radius: 10px; box-shadow: 0 20px 48px rgba(0,0,0,0.22); overflow: hidden; }
+.omp-palette-input { width: 100%; padding: 14px 14px; border: none; border-bottom: 1px solid var(--border); background: var(--surface); color: var(--text); font-family: var(--font-sans); font-size: 14px; outline: none; }
+.omp-palette-input::placeholder { color: var(--dim); }
+.omp-palette-list { max-height: 320px; overflow-y: auto; padding: 6px; display: flex; flex-direction: column; gap: 2px; }
+.omp-palette-item { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 8px 10px; border-radius: var(--radius-md); cursor: pointer; font-family: var(--font-sans); font-size: 13px; color: var(--muted); border: 1px solid transparent; }
+.omp-palette-item[data-active="true"] { background: var(--surface-2); color: var(--text); border-color: var(--border); }
+.omp-palette-kbd { font-family: var(--font-mono); font-size: 10px; color: var(--dim); border: 1px solid var(--border); background: var(--surface-2); padding: 2px 5px; border-radius: 3px; }
 
-/* Utilities bridge */
+/* Utilities */
 .stats-text-primary { color: var(--text); }
 .stats-text-secondary { color: var(--muted); }
 .stats-text-muted { color: var(--dim); }
@@ -653,30 +788,7 @@
 .stats-text-xs { font-size: 11px; }
 .stats-font-medium { font-weight: 500; }
 .stats-font-semibold { font-weight: 600; }
-
-/* Scrollbars — thin, tinted */
-* { scrollbar-width: thin; scrollbar-color: var(--border-strong) transparent; }
-*::-webkit-scrollbar { width: 8px; height: 8px; }
-*::-webkit-scrollbar-track { background: transparent; }
-*::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; border: 2px solid transparent; background-clip: content-box; }
-*::-webkit-scrollbar-thumb:hover { background: color-mix(in oklch, var(--border-strong) 90%, var(--muted)); background-clip: content-box; }
-*::-webkit-scrollbar-corner { background: transparent; }
-
-@media (prefers-reduced-motion: reduce) {
-  .stats-spin, .stats-scope-dot, .stats-skeleton::after { animation: none !important; }
-  .stats-nav-rail-item, .stats-range-control-btn, .stats-button { transition: none !important; }
-}
-
-/* Brand mark — consolidated above */
-.stats-logo-text, .stats-logo-subtext { grid-column: 2; }
-.stats-json-actions { display: flex; gap: 6px; align-items: center; }
-.stats-json-copy-btn { display: inline-flex; align-items: center; gap: 6px; padding: 4px 8px; font-size: 11px; font-family: var(--font-mono); border: 1px solid var(--border); background: var(--surface-2); color: var(--muted); border-radius: var(--radius-sm); cursor: pointer; }
-.stats-json-copy-btn:hover { color: var(--text); background: var(--surface-3); }
-.stats-theme-toggle { display: inline-flex; align-items: center; justify-content: center; padding: 6px; border-radius: var(--radius-md); border: 1px solid var(--border); background: var(--surface-2); color: var(--muted); cursor: pointer; }
-.stats-theme-toggle:hover { color: var(--text); background: var(--surface-3); }
-@media (prefers-reduced-motion: reduce) { .stats-theme-toggle { transition: none; } }
-
-/* Helper hide for section persistence */
+.stats-hidden { display: none !important; }
 [data-hidden="true"] { display: none !important; }
 
 /* Legacy route helpers restored — used by Errors/Projects/Providers/Gain/Tools */
@@ -685,8 +797,7 @@
   color: var(--text); font-family: var(--font-mono); font-size: 11px; padding: 6px 8px;
 }
 
-/* ==========================================================================
-   Traces (session flamegraph)
+/* ===================================================================   Traces (session flamegraph)
    ========================================================================== */
 .stats-trace-view {
   display: flex;
@@ -1001,9 +1112,28 @@
   }
 }
 .stats-select:focus { outline: 2px solid var(--link); outline-offset: 1px; }
+=======
+.stats-select { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-md); color: var(--text); font-family: var(--font-sans); font-size: 12px; padding: 6px 8px; }
+.stats-select:focus { outline: 2px solid var(--focus); outline-offset: 1px; }
 .stats-text-danger { color: var(--danger); }
 .stats-text-success { color: var(--success); }
 .stats-border-danger { border-color: var(--danger) !important; }
 .stats-font-mono { font-family: var(--font-mono) !important; }
 .stats-truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .stats-max-w-md { max-width: 28rem; }
+
+* { scrollbar-width: thin; scrollbar-color: var(--border-strong) transparent; }
+*::-webkit-scrollbar { width: 8px; height: 8px; }
+*::-webkit-scrollbar-track { background: transparent; }
+*::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; border: 2px solid transparent; background-clip: content-box; }
+*::-webkit-scrollbar-thumb:hover { background: color-mix(in oklch, var(--border-strong) 90%, var(--muted)); background-clip: content-box; }
+
+@media (prefers-reduced-motion: reduce) {
+  .stats-spin, .stats-skeleton::after { animation: none !important; }
+  .stats-nav-rail, .stats-nav-rail-item, .stats-range-control-btn, .stats-button { transition: none !important; }
+}
+.stats-theme-toggle { display: inline-flex; align-items: center; justify-content: center; padding: 6px; border-radius: var(--radius-md); border: 1px solid var(--border); background: var(--surface-2); color: var(--muted); cursor: pointer; }
+.stats-theme-toggle:hover { color: var(--text); background: var(--surface-3); }
+.stats-json-actions { display: flex; gap: 6px; align-items: center; }
+.stats-json-copy-btn { display: inline-flex; align-items: center; gap: 6px; padding: 4px 8px; font-size: 11px; font-family: var(--font-mono); border: 1px solid var(--border); background: var(--surface-2); color: var(--muted); border-radius: var(--radius-sm); cursor: pointer; }
+.stats-json-copy-btn:hover { color: var(--text); background: var(--surface-3); }

--- a/packages/stats/src/client/styles.css
+++ b/packages/stats/src/client/styles.css
@@ -1,465 +1,259 @@
 @import "tailwindcss/index.css";
 
 /* ==========================================================================
-   OMP Theme Variables & Color Scheme
+   OMP Stats — Instrument Console
+   Family: htop / Grafana / Bloomberg — measurement, not marketing.
+   COLOR = SEMANTICS ONLY: neutral greys + red (errors) · amber (cost)
+   · green (cache/success) · one restrained accent for selection.
+   Flat 1px hairlines, radius ≤4px, type carries identity.
    ========================================================================== */
+
 :root {
   color-scheme: dark;
-  /* OMP brand palette — packages/collab-web/src/styles/tokens.css:
-     deep-purple surfaces (hue 307), pink accent #ed4abf, cyan focus ring #5ad8e6. */
-  --page: oklch(0.16 0.02 307);
-  --surface: oklch(0.19 0.022 307);
+  --page: oklch(0.155 0.022 307);
+  --surface: oklch(0.193 0.022 307);
   --surface-2: oklch(0.235 0.026 307);
-  --border: oklch(1 0 0 / 9%);
-  --border-strong: oklch(1 0 0 / 13%);
-  --text: oklch(0.92 0.01 307);
-  --muted: oklch(0.71 0.016 307);
+  --surface-3: oklch(0.27 0.028 307);
+  --border: oklch(1 0 0 / 0.09);
+  --border-strong: oklch(1 0 0 / 0.135);
+  --text: oklch(0.925 0.008 307);
+  --muted: oklch(0.70 0.016 307);
   --dim: oklch(0.53 0.018 307);
-  --accent: oklch(0.674 0.23 341);          /* brand pink #ed4abf */
-  --accent-fg: oklch(0.2 0.07 341);         /* ink on accent fills */
-  --accent-muted: oklch(0.674 0.23 341 / 18%);
-  --link: oklch(0.817 0.112 205);           /* brand cyan #5ad8e6 */
+  --accent: oklch(0.72 0.04 230);
+  --accent-fg: oklch(0.16 0.02 307);
+  --accent-muted: oklch(0.72 0.04 230 / 0.12);
+  --link: oklch(0.817 0.112 205);
   --success: oklch(0.76 0.14 150);
   --danger: oklch(0.66 0.19 25);
   --warning: oklch(0.79 0.14 85);
-
-  /* Bridge the view components' token vocabulary to the OMP base tokens so
-     muted/secondary text and semantic accents resolve instead of silently
-     falling back to inherited text color. Re-resolve per theme via var(). */
+  --amber: oklch(0.78 0.16 84);
   --text-primary: var(--text);
   --text-secondary: var(--muted);
   --text-muted: var(--dim);
   --border-subtle: var(--border);
   --accent-red: var(--danger);
   --accent-green: var(--success);
-  --accent-cyan: var(--link);
+  --accent-cyan: var(--success);
   --bg-hover: var(--surface-2);
   --bg-elevated: var(--surface-2);
   --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
 
-  --radius-sm: 3px;
-  --radius-md: 6px;
-  --radius-lg: 8px;
+  --radius-sm: 2px;
+  --radius-md: 3px;
+  --radius-lg: 4px;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  /* Semantics only: chart req = neutral, err = danger; tokens: input/output = neutral grey, read = success, write = dim */
+  --chart-req: oklch(0.68 0.015 307);
+  --chart-err: var(--danger);
+  --tok-input: oklch(0.62 0.015 307);
+  --tok-output: oklch(0.7 0.015 307);
+  --tok-read: var(--success);
+  --tok-write: var(--dim);
 }
 
-/* System-default fallback before JS sets data-theme; an explicit data-theme
-   (set by the toggle / anti-flash script) opts out so the override wins. */
 @media (prefers-color-scheme: light) {
   :root:not([data-theme]) {
     color-scheme: light;
     --page: oklch(0.985 0.004 307);
     --surface: oklch(1 0 0);
-    --surface-2: oklch(0.965 0.006 307);
-    --border: oklch(0 0 0 / 10%);
-    --border-strong: oklch(0 0 0 / 15%);
-    --text: oklch(0.26 0.03 307);
+    --surface-2: oklch(0.966 0.006 307);
+    --surface-3: oklch(0.94 0.008 307);
+    --border: oklch(0 0 0 / 0.1);
+    --border-strong: oklch(0 0 0 / 0.16);
+    --text: oklch(0.24 0.03 307);
     --muted: oklch(0.46 0.03 307);
     --dim: oklch(0.58 0.025 307);
-    --accent: oklch(0.62 0.23 341);
-    --accent-fg: oklch(0.99 0.01 341);
-    --accent-muted: oklch(0.62 0.23 341 / 14%);
+    --accent: oklch(0.55 0.05 230);
+    --accent-fg: oklch(0.98 0.01 230);
+    --accent-muted: oklch(0.55 0.05 230 / 0.14);
     --link: oklch(0.58 0.13 230);
     --success: oklch(0.55 0.13 150);
     --danger: oklch(0.55 0.19 25);
     --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23555' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
     --warning: oklch(0.6 0.13 85);
+    --amber: oklch(0.66 0.15 80);
+    --chart-req: oklch(0.42 0.015 307);
+    --chart-err: var(--danger);
+    --tok-input: oklch(0.5 0.015 307);
+    --tok-output: oklch(0.58 0.015 307);
+    --tok-read: var(--success);
+    --tok-write: var(--dim);
   }
 }
-
-/* Explicit theme override (toggle or persisted preference). */
 [data-theme="light"] {
   color-scheme: light;
   --page: oklch(0.985 0.004 307);
   --surface: oklch(1 0 0);
-  --surface-2: oklch(0.965 0.006 307);
-  --border: oklch(0 0 0 / 10%);
-  --border-strong: oklch(0 0 0 / 15%);
-  --text: oklch(0.26 0.03 307);
+  --surface-2: oklch(0.966 0.006 307);
+  --surface-3: oklch(0.94 0.008 307);
+  --border: oklch(0 0 0 / 0.1);
+  --border-strong: oklch(0 0 0 / 0.16);
+  --text: oklch(0.24 0.03 307);
   --muted: oklch(0.46 0.03 307);
   --dim: oklch(0.58 0.025 307);
-  --accent: oklch(0.62 0.23 341);
-  --accent-fg: oklch(0.99 0.01 341);
-  --accent-muted: oklch(0.62 0.23 341 / 14%);
+  --accent: oklch(0.55 0.05 230);
+  --accent-fg: oklch(0.98 0.01 230);
+  --accent-muted: oklch(0.55 0.05 230 / 0.14);
   --link: oklch(0.58 0.13 230);
   --success: oklch(0.55 0.13 150);
   --danger: oklch(0.55 0.19 25);
   --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23555' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
   --warning: oklch(0.6 0.13 85);
+  --amber: oklch(0.66 0.15 80);
+  --chart-req: oklch(0.42 0.015 307);
+  --chart-err: var(--danger);
+  --tok-input: oklch(0.5 0.015 307);
+  --tok-output: oklch(0.58 0.015 307);
+  --tok-read: var(--success);
+  --tok-write: var(--dim);
+}
+[data-theme="dark"] {
+  color-scheme: dark;
 }
 
-/* ==========================================================================
-   Base Styles
-   ========================================================================== */
+/* Base */
 @layer base {
-  * {
-    box-sizing: border-box;
-  }
-
-  html {
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
-
+  * { box-sizing: border-box; }
+  html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
   body {
-    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-family: var(--font-sans);
     background: var(--page);
     color: var(--text);
-    margin: 0;
-    min-height: 100vh;
+    margin: 0; min-height: 100vh;
+    font-size: 13.5px;
+    line-height: 1.5;
   }
-
-  /* Accessible focus ring style */
-  button:focus-visible,
-  a:focus-visible,
-  [tabindex]:focus-visible {
-    outline: 2px solid var(--link);
-    outline-offset: 2px;
+  button:focus-visible, a:focus-visible, [tabindex]:focus-visible {
+    outline: 2px solid var(--link); outline-offset: 2px;
   }
 }
 
-/* ==========================================================================
-   Layout Components
-   ========================================================================== */
-.stats-app-container {
-  display: flex;
-  min-height: 100vh;
-  background: var(--page);
-  color: var(--text);
-}
+/* App shell */
+.stats-app-container { display: flex; min-height: 100vh; background: var(--page); color: var(--text); }
 
-/* Navigation Rail (Sidebar) */
+/* Nav Rail */
 .stats-nav-rail {
-  width: 240px;
-  background: var(--surface);
+  width: 228px; background: var(--surface);
   border-right: 1px solid var(--border);
-  display: flex;
-  flex-direction: column;
-  flex-shrink: 0;
+  display: flex; flex-direction: column; flex-shrink: 0;
+  position: sticky; top: 0; height: 100vh; overflow: hidden;
 }
-
-.stats-desktop-nav {
-  display: flex;
-}
-
-@media (max-width: 1023px) {
-  .stats-desktop-nav {
-    display: none;
-  }
-}
-
+.stats-desktop-nav { display: flex; }
+@media (max-width: 1023px) { .stats-desktop-nav { display: none; } }
 .stats-nav-rail-header {
-  padding: 20px 24px;
-  border-bottom: 1px solid var(--border);
-  height: 56px;
-  display: flex;
-  align-items: center;
+  padding: 18px 20px; border-bottom: 1px solid var(--border);
+  height: 56px; display: flex; align-items: center; gap: 10px;
 }
-
-.stats-logo-container {
-  display: flex;
-  flex-direction: column;
+.stats-logo-container { display: flex; flex-direction: column; gap: 1px; position: relative; padding-left: 12px; }
+.stats-logo-container::before {
+  content: ""; position: absolute; left: 0; top: 3px; bottom: 3px; width: 2px;
+  background: var(--border-strong); border-radius: 1px;
 }
-
-.stats-logo-text {
-  font-size: 14px;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  color: var(--text);
-}
-
-.stats-logo-subtext {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--muted);
-}
-
-.stats-nav-rail-menu {
-  flex: 1;
-  padding: 16px 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
+.stats-logo-text { font-family: var(--font-mono); font-size: 11px; font-weight: 700; letter-spacing: 0.08em; color: var(--text); line-height: 1; }
+.stats-logo-subtext { font-family: var(--font-mono); font-size: 9px; font-weight: 500; letter-spacing: 0.06em; color: var(--dim); line-height: 1; }
+.stats-nav-rail-menu { flex: 1; padding: 14px 10px; display: flex; flex-direction: column; gap: 3px; overflow-y: auto; }
 .stats-nav-rail-item {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 16px;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--muted);
-  background: transparent;
-  border: none;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  text-align: left;
-  transition: all 0.15s ease;
+  display: flex; align-items: center; gap: 10px; padding: 8px 10px;
+  font-size: 12.5px; font-weight: 500; color: var(--muted);
+  background: transparent; border: 1px solid transparent; border-radius: var(--radius-sm);
+  cursor: pointer; text-align: left; transition: all 0.14s ease; width: 100%;
 }
-
-.stats-nav-rail-item:hover {
-  color: var(--text);
-  background: var(--surface-2);
-}
-
+.stats-nav-rail-item:hover { color: var(--text); background: var(--surface-2); border-color: var(--border); }
 .stats-nav-rail-item[data-active="true"] {
-  color: var(--accent);
-  background: var(--accent-muted);
-  position: relative;
+  color: var(--text); background: var(--surface-2); border-color: var(--border);
+  box-shadow: inset 2px 0 0 var(--text);
 }
-
-.stats-nav-rail-item[data-active="true"]::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 50%;
-  height: 18px;
-  width: 3px;
-  border-radius: 0 3px 3px 0;
-  background: var(--accent);
-  transform: translateY(-50%);
-}
-
-.stats-nav-rail-item-icon {
-  flex-shrink: 0;
-}
-
-.stats-nav-rail-footer {
-  padding: 16px 24px;
-  border-top: 1px solid var(--border);
-}
-
+.stats-nav-rail-item[data-active="true"] .stats-nav-rail-item-icon { color: var(--text); }
+.stats-nav-rail-item-icon { flex-shrink: 0; opacity: 0.9; }
+.stats-nav-rail-item-label { flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.stats-nav-rail-footer { padding: 12px 16px; border-top: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .stats-version-tag {
-  font-size: 11px;
-  color: var(--dim);
+  font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.06em; color: var(--dim);
+  border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 2px 6px; background: var(--surface-2);
 }
 
-/* Main Content Area */
-.stats-main-pane {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-}
+/* Main pane */
+.stats-main-pane { flex: 1; display: flex; flex-direction: column; min-width: 0; }
 
 .stats-top-bar {
-  height: 56px;
-  background: var(--surface);
-  border-bottom: 1px solid var(--border);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 24px;
+  height: 56px; background: var(--surface); border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; justify-content: space-between; padding: 0 20px; gap: 16px;
+  position: sticky; top: 0; z-index: 10;
 }
-
 @media (max-width: 767px) {
-  .stats-top-bar {
-    padding: 0 16px;
-    flex-wrap: wrap;
-    height: auto;
-    min-height: 56px;
-    padding-top: 8px;
-    padding-bottom: 8px;
-    gap: 12px;
-  }
+  .stats-top-bar { padding: 0 14px; flex-wrap: wrap; height: auto; min-height: 56px; padding-top: 8px; padding-bottom: 8px; gap: 10px; }
 }
-
-.stats-top-bar-left {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.stats-mobile-menu-btn {
-  display: none;
-  background: transparent;
-  border: none;
-  color: var(--text);
-  padding: 4px;
-  cursor: pointer;
-}
-
-@media (max-width: 1023px) {
-  .stats-mobile-menu-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-}
-
+.stats-top-bar-left { display: flex; align-items: center; gap: 10px; min-width: 0; }
+.stats-mobile-menu-btn { display: none; background: var(--surface-2); border: 1px solid var(--border); color: var(--text); padding: 6px; cursor: pointer; border-radius: var(--radius-md); }
+@media (max-width: 1023px) { .stats-mobile-menu-btn { display: inline-flex; align-items: center; justify-content: center; } }
 .stats-page-title {
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text);
-  margin: 0;
+  font-size: 14px; font-weight: 700; color: var(--text); margin: 0; letter-spacing: -0.01em;
+  display: flex; align-items: center; gap: 8px; white-space: nowrap;
 }
-
-.stats-top-bar-right {
-  display: flex;
-  align-items: center;
-  gap: 16px;
+.stats-page-title::after {
+  content: ""; width: 8px; height: 2px; border-radius: 1px; background: var(--border-strong); display: inline-block;
 }
-
-@media (max-width: 767px) {
-  .stats-top-bar-right {
-    width: 100%;
-    justify-content: space-between;
-    gap: 8px;
-  }
-}
-
-.stats-top-bar-meta {
-  display: flex;
-  align-items: center;
-}
-
+.stats-top-bar-right { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+@media (max-width: 767px) { .stats-top-bar-right { width: 100%; justify-content: space-between; gap: 8px; } }
+.stats-top-bar-meta { display: flex; align-items: center; gap: 8px; }
 .stats-last-updated {
-  font-size: 11px;
-  color: var(--dim);
-  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono); font-size: 10px; color: var(--dim); font-variant-numeric: tabular-nums;
+  background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 3px 6px;
 }
+.stats-content-area { flex: 1; overflow-y: auto; }
+.stats-content-inner { max-width: 1440px; margin: 0 auto; padding: 20px; display: flex; flex-direction: column; gap: 16px; }
+@media (max-width: 767px) { .stats-content-inner { padding: 14px; gap: 14px; } }
 
-.stats-content-area {
-  flex: 1;
-  overflow-y: auto;
-}
+/* Mobile drawer */
+.stats-mobile-drawer-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.45); backdrop-filter: blur(2px); z-index: 100; }
+.stats-mobile-drawer { position: absolute; left: 0; top: 0; bottom: 0; width: 268px; background: var(--surface); border-right: 1px solid var(--border); display: flex; flex-direction: column; z-index: 101; animation: slideIn 0.2s ease-out; }
+@keyframes slideIn { from { transform: translateX(-100%); } to { transform: translateX(0); } }
+.stats-mobile-drawer-header { height: 56px; display: flex; align-items: center; justify-content: space-between; padding: 0 14px 0 18px; border-bottom: 1px solid var(--border); }
+.stats-mobile-nav { display: flex; height: calc(100% - 56px); }
 
-.stats-content-inner {
-  max-width: 1560px;
-  margin: 0 auto;
-  padding: 24px;
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-}
-
-@media (max-width: 767px) {
-  .stats-content-inner {
-    padding: 16px;
-    gap: 16px;
-  }
-}
-
-/* Mobile Nav Drawer */
-.stats-mobile-drawer-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  backdrop-filter: none; /* No decorative blurs */
-  z-index: 100;
-}
-
-.stats-mobile-drawer {
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 260px;
-  background: var(--surface);
-  border-right: 1px solid var(--border);
-  display: flex;
-  flex-direction: column;
-  z-index: 101;
-  animation: slideIn 0.2s ease-out;
-}
-
-@keyframes slideIn {
-  from { transform: translateX(-100%); }
-  to { transform: translateX(0); }
-}
-
-.stats-mobile-drawer-header {
-  height: 56px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 16px 0 24px;
-  border-bottom: 1px solid var(--border);
-}
-
-.stats-mobile-nav {
-  display: flex;
-  height: calc(100% - 56px);
-}
-
-/* ==========================================================================
-   UI Primitives & Styles
-   ========================================================================== */
-
-/* Button */
+/* Buttons */
 .stats-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 8px 14px;
-  font-size: 13px;
-  font-weight: 500;
-  border-radius: var(--radius-md);
-  border: 1px solid transparent;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  font-family: inherit;
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  padding: 7px 12px; font-size: 12.5px; font-weight: 600; border-radius: var(--radius-md);
+  border: 1px solid transparent; cursor: pointer; transition: all 0.14s ease; font-family: inherit;
+  letter-spacing: -0.01em;
 }
-
-.stats-button:active:not(:disabled) {
-  transform: translateY(1px);
+.stats-button:active:not(:disabled) { transform: translateY(1px); }
+.stats-button-primary { background: var(--success); color: var(--accent-fg); border-color: transparent; }
+.stats-button-primary:hover:not(:disabled) { background: var(--muted); border-color: var(--muted); }
+.stats-button-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+.stats-button-secondary { background: var(--surface-2); color: var(--text); border-color: var(--border); }
+.stats-button-secondary:hover:not(:disabled) { background: var(--surface-3); border-color: var(--border-strong); }
+.stats-button-secondary:disabled { opacity: 0.5; cursor: not-allowed; }
+.stats-button-ghost {
+  background: transparent; color: var(--muted); border-color: var(--border);
 }
-
-.stats-button-primary {
-  background: var(--accent);
-  color: var(--accent-fg);
-}
-
-.stats-button-primary:hover:not(:disabled) {
-  opacity: 0.9;
-}
-
-.stats-button-primary:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.stats-button-secondary {
-  background: var(--surface-2);
-  color: var(--text);
-  border-color: var(--border);
-}
-
-.stats-button-secondary:hover:not(:disabled) {
-  background: var(--border);
-}
-
-.stats-button-secondary:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-/* RangeControl */
+.stats-button-ghost:hover { color: var(--text); background: var(--surface-2); }
+/* Sync DB — neutral inverted so green stays for DATA only */
+.stats-sync-btn { background: var(--surface); color: var(--text); border-color: var(--border-strong); }
+.stats-sync-btn:hover:not(:disabled) { background: var(--surface-2); border-color: var(--border-strong); color: var(--text); }
+/* RangeControl — segmented instrument switch */
 .stats-range-control {
-  display: flex;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  padding: 2px;
+  display: flex; background: var(--surface-2); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); padding: 2px; gap: 1px;
 }
-
 .stats-range-control-btn {
-  padding: 4px 10px;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--muted);
-  background: transparent;
-  border: none;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  transition: all 0.1s ease;
+  padding: 4px 8px; font-size: 11px; font-weight: 600; letter-spacing: 0.02em;
+  color: var(--muted); background: transparent; border: 1px solid transparent; border-radius: 2px;
+  cursor: pointer; transition: all 0.14s ease; font-family: var(--font-mono); font-variant-numeric: tabular-nums;
 }
+.stats-range-control-btn:hover { color: var(--text); }
+.stats-range-control-btn[data-active="true"] { background: var(--text); color: var(--surface); border-color: var(--text); }
 
-.stats-range-control-btn:hover {
-  color: var(--text);
-}
+/* Sync + Theme */
+.stats-sync-container { display: flex; align-items: center; gap: 8px; }
+.stats-sync-status-msg { font-size: 11px; font-family: var(--font-mono); }
+.stats-sync-status-msg[data-type="success"] { color: var(--success); }
+.stats-sync-status-msg[data-type="error"] { color: var(--danger); }
+.stats-sync-icon { flex-shrink: 0; }
+.stats-spin { animation: spin 1s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
 
 .stats-range-control-btn[data-active="true"] {
   color: var(--text);
@@ -560,833 +354,335 @@
 }
 
 /* Panel */
+/* Panel — instrument housing */
 .stats-panel {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  display: flex;
-  flex-direction: column;
+  background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg);
+  overflow: hidden; display: flex; flex-direction: column;
 }
-
 .stats-panel-header {
-  padding: 16px 20px;
-  border-bottom: 1px solid var(--border);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 12px;
+  padding: 12px 14px; border-bottom: 1px solid var(--border); background: var(--surface);
 }
-
-@media (max-width: 480px) {
-  .stats-panel-header {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 8px;
-  }
+@media (max-width: 480px) { .stats-panel-header { flex-direction: column; } }
+.stats-panel-header-titles { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.stats-panel-eyebrow {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: var(--dim); font-family: var(--font-mono);
+  display: flex; align-items: center; gap: 6px;
 }
-
-.stats-panel-header-titles {
-  display: flex;
-  flex-direction: column;
+.stats-panel-eyebrow::before {
+  content: ""; width: 8px; height: 2px; border-radius: 2px; background: var(--success); opacity: 0.9;
 }
+.stats-panel-title { font-size: 13px; font-weight: 700; color: var(--text); letter-spacing: -0.015em; line-height: 1.2; }
+.stats-panel-subtitle { font-size: 11.5px; color: var(--muted); line-height: 1.4; margin: 0; }
+.stats-panel-actions { display: flex; align-items: center; gap: 6px; flex-shrink: 0; flex-wrap: wrap; }
+.stats-panel-body { padding: 16px; }
+@media (max-width: 767px) { .stats-panel-body { padding: 14px; } }
 
-.stats-panel-title {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text);
-  margin: 0;
+/* Overview-specific */
+.stats-route-container { display: flex; flex-direction: column; gap: 16px; }
+
+/* KPI Tape — the signature instrument */
+.stats-overview-tape {
+  display: grid; grid-template-columns: repeat(6, minmax(0, 1fr));
+  background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg);
+  overflow: hidden;
 }
-
-.stats-panel-subtitle {
-  font-size: 12px;
-  color: var(--muted);
-  margin: 2px 0 0 0;
+@media (max-width: 1279px) { .stats-overview-tape { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
+@media (max-width: 639px) { .stats-overview-tape { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+.stats-tape-cell {
+  padding: 14px 14px 12px; border-right: 1px solid var(--border); border-bottom: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 6px; position: relative; min-width: 0;
 }
-
-.stats-panel-actions {
-  display: flex;
-  align-items: center;
-  gap: 12px;
+.stats-tape-cell:last-child { border-right: none; }
+/* no top accent — separators handle structure */
+.stats-tape-label {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.11em; text-transform: uppercase; color: var(--dim); font-family: var(--font-mono);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-
-.stats-panel-body {
-  padding: 20px;
+.stats-tape-value {
+  font-family: var(--font-mono); font-size: 20px; font-weight: 700; letter-spacing: -0.03em; color: var(--text);
+  line-height: 1; font-variant-numeric: tabular-nums; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-
-/* Metric Cluster (Overview Dashboard KPI Grid) */
-.stats-metric-cluster {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
+@media (max-width: 767px) { .stats-tape-value { font-size: 18px; } }
+.stats-tape-sub {
+  font-size: 11px; color: var(--muted); font-family: var(--font-mono); font-variant-numeric: tabular-nums;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-
-.stats-metric-primary-grid {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 16px;
+.stats-tape-badge {
+  display: inline-flex; align-items: center; gap: 4px; font-size: 9px; font-weight: 600; letter-spacing: 0.06em;
+  text-transform: uppercase; padding: 2px 5px; border-radius: var(--radius-sm); border: 1px solid var(--border);
+  background: var(--surface-2); color: var(--muted); font-family: var(--font-mono); width: fit-content;
 }
+.stats-tape-badge[data-tone="danger"] { color: var(--danger); border-color: color-mix(in oklch, var(--danger) 30%, transparent); background: color-mix(in oklch, var(--danger) 10%, var(--surface-2)); }
+.stats-tape-badge[data-tone="success"] { color: var(--success); border-color: color-mix(in oklch, var(--success) 30%, transparent); background: color-mix(in oklch, var(--success) 10%, var(--surface-2)); }
+.stats-tape-badge[data-tone="warning"] { color: var(--amber); border-color: color-mix(in oklch, var(--amber) 30%, transparent); background: color-mix(in oklch, var(--amber) 10%, var(--surface-2)); }
 
-@media (max-width: 1023px) {
-  .stats-metric-primary-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
+/* Overview toolbar — presets + customize */
+.stats-overview-toolbar {
+  display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap;
 }
-
-@media (max-width: 480px) {
-  .stats-metric-primary-grid {
-    grid-template-columns: 1fr;
-  }
+.stats-preset-group { display: flex; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 2px; gap: 1px; }
+.stats-preset-btn {
+  padding: 4px 8px; font-size: 10px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; font-family: var(--font-mono);
+  color: var(--muted); background: transparent; border: 1px solid transparent; border-radius: var(--radius-sm); cursor: pointer;
 }
-
-.stats-metric-secondary-grid {
-  display: grid;
-  grid-template-columns: repeat(8, 1fr);
-  gap: 12px;
+.stats-preset-btn[data-active="true"] { background: var(--text); color: var(--surface); border-color: var(--text); }
+.stats-overview-customize {
+  display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
 }
-
-@media (max-width: 1279px) {
-  .stats-metric-secondary-grid {
-    grid-template-columns: repeat(4, 1fr);
-  }
+.stats-customize-chip {
+  display: inline-flex; align-items: center; gap: 6px; padding: 5px 8px; border-radius: var(--radius-sm);
+  border: 1px solid var(--border); background: var(--surface); color: var(--muted); font-size: 11px; font-weight: 600;
+  cursor: pointer; font-family: var(--font-mono); letter-spacing: 0.02em;
 }
+.stats-customize-chip[data-on="true"] { color: var(--text); background: var(--surface-2); border-color: var(--border-strong); }
+.stats-customize-chip input { accent-color: var(--success); }
 
-@media (max-width: 767px) {
-  .stats-metric-secondary-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
+/* Oscilloscope chart shell — flex column without stretching to row height */
+.stats-scope-wrap {
+  position: relative; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden; min-width: 0;
+  display: flex; flex-direction: column; align-self: start;
 }
-
-.stats-metric-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
+.stats-scope-grid {
+  position: absolute; inset: 0; pointer-events: none; opacity: 0.22;
+  background-image:
+    linear-gradient(to right, var(--border) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--border) 1px, transparent 1px);
+  background-size: 48px 32px;
+  mask-image: radial-gradient(ellipse at center, black 65%, transparent 100%);
 }
-
-.stats-metric-card.primary {
-  padding: 20px 18px;
+[data-theme="light"] .stats-scope-wrap .stats-scope-grid { opacity: 0.14; }
+.stats-scope-header {
+  display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 12px 14px;
+  border-bottom: 1px solid var(--border); background: var(--surface); flex-shrink: 0;
 }
+.stats-scope-title { font-size: 12px; font-weight: 700; letter-spacing: -0.01em; color: var(--text); display: flex; align-items: center; gap: 8px; }
+.stats-scope-dot { width: 6px; height: 6px; border-radius: 1px; background: var(--success); }
 
-.stats-metric-card.primary .stats-metric-label {
-  color: var(--accent);
+.stats-scope-legend { display: flex; align-items: center; gap: 10px; font-family: var(--font-mono); font-size: 11px; color: var(--muted); }
+.stats-scope-legend span { display: inline-flex; align-items: center; gap: 5px; }
+.stats-scope-legend i { width: 12px; height: 3px; border-radius: 999px; display: inline-block; }
+.stats-scope-body { padding: 10px 10px 6px; position: relative; min-width: 0; flex: 1; display: flex; flex-direction: column; min-height: 272px; max-height: 480px; }
+.stats-overview-grid {
+  display: grid; grid-template-columns: minmax(0, 1.55fr) minmax(0, 0.95fr); gap: 16px; align-items: start;
 }
+.stats-overview-grid > * { min-width: 0; }
+@media (max-width: 1023px) { .stats-overview-grid { grid-template-columns: 1fr; } }
+.stats-overview-stack { display: flex; flex-direction: column; gap: 16px; min-width: 0; }
 
-.stats-metric-card.secondary {
-  padding: 12px 14px;
+/* Token breakdown: four-quadrant */
+.stats-token-grid {
+  display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px;
 }
-
-.stats-metric-label {
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--muted);
-  margin-bottom: 8px;
+@media (max-width: 767px) { .stats-token-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+.stats-token-card {
+  background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-md);
+  padding: 12px 12px 10px; display: flex; flex-direction: column; gap: 6px;
 }
+.stats-token-card-label { font-size: 10px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--dim); font-family: var(--font-mono); }
+.stats-token-card-value { font-family: var(--font-mono); font-size: 16px; font-weight: 700; letter-spacing: -0.02em; color: var(--text); font-variant-numeric: tabular-nums; }
+.stats-token-card-share { display: flex; align-items: center; gap: 8px; }
+.stats-token-bar { flex: 1; height: 4px; border-radius: 999px; background: var(--surface-3); overflow: hidden; }
+.stats-token-bar-fill { height: 100%; border-radius: 999px; }
+.stats-token-share-label { font-size: 11px; font-family: var(--font-mono); color: var(--muted); font-variant-numeric: tabular-nums; }
 
-.stats-metric-value {
-  font-size: 20px;
-  font-weight: 700;
-  color: var(--text);
-  font-variant-numeric: tabular-nums;
-}
+/* Models mini */
+.stats-model-row { display: flex; align-items: center; gap: 10px; padding: 10px 0; border-bottom: 1px solid var(--border); }
+.stats-model-row:last-child { border-bottom: none; }
+.stats-model-rank { font-family: var(--font-mono); font-size: 10px; font-weight: 700; color: var(--dim); width: 18px; text-align: right; }
+.stats-model-name { flex: 1; min-width: 0; }
+.stats-model-title { font-size: 12.5px; font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.stats-model-sub { font-size: 11px; color: var(--dim); font-family: var(--font-mono); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.stats-model-bar { width: 84px; height: 4px; border-radius: 999px; background: var(--surface-3); overflow: hidden; flex-shrink: 0; }
+.stats-model-bar-fill { height: 100%; border-radius: 2px; background: var(--success); }
+.stats-model-metric { font-family: var(--font-mono); font-size: 11px; font-variant-numeric: tabular-nums; color: var(--muted); min-width: 58px; text-align: right; flex-shrink: 0; }
 
-.stats-metric-card.secondary .stats-metric-value {
-  font-size: 15px;
-  font-weight: 600;
-}
+/* Provider chips */
+.stats-provider-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+@media (max-width: 639px) { .stats-provider-grid { grid-template-columns: 1fr; } }
+.stats-provider-card { border: 1px solid var(--border); background: var(--surface-2); border-radius: var(--radius-md); padding: 12px; display: flex; flex-direction: column; gap: 8px; }
+.stats-provider-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.stats-provider-name { font-size: 12px; font-weight: 700; color: var(--text); letter-spacing: -0.01em; }
+.stats-provider-cost { font-family: var(--font-mono); font-size: 12px; font-weight: 700; color: var(--amber); font-variant-numeric: tabular-nums; }
 
-/* Data Table Component */
-.stats-table-wrapper {
-  width: 100%;
-}
+/* Agent bars reuse existing but tighten */
+.stats-agent-share-bar { height: 6px; }
+.stats-hidden { display: none !important; }
 
-.stats-table-container {
-  width: 100%;
-  overflow-x: auto;
-}
+/* Metric cluster legacy - keep for other routes but tighten */
+.stats-metric-cluster { display: flex; flex-direction: column; gap: 12px; }
+.stats-metric-primary-grid { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 10px; }
+@media (max-width: 1023px) { .stats-metric-primary-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
+@media (max-width: 480px) { .stats-metric-primary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+.stats-metric-secondary-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; }
+@media (max-width: 1279px) { .stats-metric-secondary-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); } }
+@media (max-width: 767px) { .stats-metric-secondary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+.stats-metric-card { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 12px 12px 10px; overflow: hidden; position: relative; }
+.stats-metric-card.primary { padding: 14px 12px; }
+.stats-metric-card.primary .stats-metric-label { color: var(--dim); font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.09em; text-transform: uppercase; font-weight: 700; }
+.stats-metric-card.secondary { padding: 10px 12px; }
+.stats-metric-label { font-size: 11px; color: var(--muted); margin-bottom: 4px; }
+.stats-metric-value { font-family: var(--font-mono); font-size: 16px; font-weight: 700; color: var(--text); letter-spacing: -0.02em; font-variant-numeric: tabular-nums; }
+.stats-metric-card.secondary .stats-metric-value { font-size: 14px; }
 
-.stats-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 13px;
-  font-variant-numeric: tabular-nums;
-}
-
+/* Data table — densified */
+.stats-table-wrapper { width: 100%; }
+.stats-table-container { overflow-x: auto; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface); }
+.stats-table { width: 100%; border-collapse: collapse; font-size: 12.5px; }
 .stats-table-th {
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--muted);
-  padding: 12px 16px;
-  border-bottom: 2px solid var(--border);
+  text-align: left; padding: 8px 12px; font-size: 10px; font-weight: 700; letter-spacing: 0.09em; text-transform: uppercase;
+  color: var(--dim); background: var(--surface-2); border-bottom: 1px solid var(--border); white-space: nowrap; font-family: var(--font-mono);
 }
-
-.stats-table-td {
-  padding: 10px 16px;
-  border-bottom: 1px solid var(--border);
-  color: var(--text);
-}
-
-.stats-table-tr {
-  background: transparent;
-}
-
-.stats-table-tr-clickable {
-  cursor: pointer;
-  transition: background 0.12s ease, box-shadow 0.12s ease;
-}
-
-.stats-table-tr-clickable:hover {
-  background: var(--surface-2);
-  box-shadow: inset 2px 0 0 var(--accent);
-}
-
-.stats-text-left {
-  text-align: left;
-}
-
-.stats-text-right {
-  text-align: right;
-}
-
-.stats-table-empty {
-  padding: 40px;
-  text-align: center;
-  color: var(--muted);
-  font-size: 13px;
-  border: 1px dashed var(--border);
-  border-radius: var(--radius-lg);
-}
-
-/* Project progress bars */
-.stats-progress-bar-track {
-  background: var(--surface-2);
-  border-radius: 999px;
-  overflow: hidden;
-}
-
-.stats-progress-bar-fill {
-  height: 100%;
-  border-radius: inherit;
-  transition: width 0.18s ease;
-}
-
-.stats-progress-bar-fill[data-variant="link"] {
-  background: var(--link);
-}
-
-.stats-progress-bar-fill[data-variant="success"] {
-  background: var(--success);
-}
-
-.stats-table-mobile-only {
-  display: none;
-}
-
-/* Match .stats-table-container so mobile-card tables also contain horizontal
-   overflow instead of spilling the page body on narrow desktops (768-1023px). */
-.stats-table-desktop-only {
-  width: 100%;
-  overflow-x: auto;
-}
-
+.stats-table-td { padding: 9px 12px; border-bottom: 1px solid var(--border); color: var(--muted); vertical-align: middle; }
+.stats-table-tr { background: transparent; }
+.stats-table-tr-clickable { cursor: pointer; }
+.stats-table-tr-clickable:hover { background: var(--surface-2); }
+.stats-text-left { text-align: left; }
+.stats-text-right { text-align: right; }
+.stats-table-empty { padding: 28px 16px; text-align: center; color: var(--muted); font-size: 12.5px; }
+.stats-progress-bar-track { height: 4px; border-radius: 999px; background: var(--surface-3); overflow: hidden; }
+.stats-progress-bar-fill { height: 100%; border-radius: 2px; background: var(--success); }
+.stats-progress-bar-fill[data-variant="link"] { background: var(--link); }
+.stats-progress-bar-fill[data-variant="success"] { background: var(--success); }
+.stats-table-mobile-only { display: none; }
+.stats-table-desktop-only { width: 100%; }
 @media (max-width: 767px) {
-  .stats-table-desktop-only {
-    display: none;
-  }
-  .stats-table-mobile-only {
-    display: block;
-  }
+  .stats-table-mobile-only { display: block; }
+  .stats-table-desktop-only { display: none; }
 }
+.stats-table-mobile-list { display: flex; flex-direction: column; gap: 10px; }
+.stats-table-mobile-card-wrapper { border: 1px solid var(--border); border-radius: var(--radius-md); overflow: hidden; background: var(--surface); }
+/* Mobile card polish for telemetry */
+.stats-mobile-card { padding: 12px; display: flex; flex-direction: column; gap: 10px; }
+.stats-mobile-card-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 8px; }
+.stats-mobile-card-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+.stats-mobile-card-label { font-size: 10px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--dim); font-family: var(--font-mono); }
+.stats-mobile-card-value { font-size: 12.5px; color: var(--text); font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+.stats-mobile-card-error { font-size: 11px; color: var(--danger); background: color-mix(in oklch, var(--danger) 10%, var(--surface-2)); border: 1px solid color-mix(in oklch, var(--danger) 18%, transparent); border-radius: var(--radius-sm); padding: 6px 8px; }
 
-.stats-table-mobile-list {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.stats-table-mobile-card-wrapper {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 14px;
-}
-
-/* Status Pill */
+/* Status pill — flat tag, not a candy */
 .stats-status-pill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2px 8px;
-  font-size: 11px;
-  font-weight: 600;
-  border-radius: 100px;
-  line-height: 1.2;
+  display: inline-flex; align-items: center; gap: 4px; padding: 2px 7px; border-radius: var(--radius-sm);
+  font-size: 11px; font-weight: 700; letter-spacing: 0.02em; font-family: var(--font-mono); border: 1px solid var(--border);
+  line-height: 1.4;
 }
+.stats-status-pill[data-variant="success"] { color: var(--success); background: color-mix(in oklch, var(--success) 12%, var(--surface-2)); border-color: color-mix(in oklch, var(--success) 22%, transparent); }
+.stats-status-pill[data-variant="danger"] { color: var(--danger); background: color-mix(in oklch, var(--danger) 12%, var(--surface-2)); border-color: color-mix(in oklch, var(--danger) 22%, transparent); }
+.stats-status-pill[data-variant="warning"] { color: var(--amber); background: color-mix(in oklch, var(--amber) 12%, var(--surface-2)); border-color: color-mix(in oklch, var(--amber) 22%, transparent); }
+.stats-status-pill[data-variant="info"] { color: var(--link); background: color-mix(in oklch, var(--link) 12%, var(--surface-2)); border-color: color-mix(in oklch, var(--link) 22%, transparent); }
+.stats-status-pill[data-variant="default"] { color: var(--muted); background: var(--surface-2); }
 
-.stats-status-pill[data-variant="success"] {
-  background: color-mix(in srgb, var(--success) 18%, transparent);
-  color: var(--success);
-}
+/* Segmented — instrument switch, rectangular */
+.stats-segmented-control { display: flex; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 2px; gap: 1px; }
+.stats-segmented-control-btn { padding: 5px 10px; font-size: 11px; font-weight: 700; color: var(--muted); background: transparent; border: 1px solid transparent; border-radius: var(--radius-sm); cursor: pointer; font-family: var(--font-mono); }
+.stats-segmented-control-btn:hover { color: var(--text); }
+.stats-segmented-control-btn[data-active="true"] { background: var(--text); color: var(--surface); border-color: var(--text); }
 
-.stats-status-pill[data-variant="danger"] {
-  background: color-mix(in srgb, var(--danger) 18%, transparent);
-  color: var(--danger);
-}
+/* Drawer */
+.stats-drawer-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.45); backdrop-filter: blur(2px); z-index: 50; display: flex; justify-content: flex-end; }
+.stats-drawer { width: min(560px, 100%); background: var(--surface); border-left: 1px solid var(--border); display: flex; flex-direction: column; animation: drawerSlide 0.2s ease-out; }
+@keyframes drawerSlide { from { transform: translateX(100%); } to { transform: translateX(0); } }
+.stats-drawer-header { display: flex; align-items: center; justify-content: space-between; padding: 14px 16px; border-bottom: 1px solid var(--border); gap: 12px; }
+.stats-drawer-header-left { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.stats-drawer-title { font-size: 13px; font-weight: 700; color: var(--text); }
+.stats-drawer-id { font-size: 11px; color: var(--dim); font-family: var(--font-mono); }
+.stats-drawer-close-btn { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 6px; cursor: pointer; color: var(--muted); display: inline-flex; }
+.stats-drawer-close-btn:hover { color: var(--text); background: var(--surface-3); }
+.stats-drawer-body { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 14px; }
+.stats-drawer-content { display: flex; flex-direction: column; gap: 12px; }
+.stats-drawer-status-card { border: 1px solid var(--border); background: var(--surface-2); border-radius: var(--radius-md); padding: 12px; display: flex; flex-direction: column; gap: 8px; }
+.stats-drawer-status-row { display: flex; justify-content: space-between; gap: 12px; font-size: 12.5px; }
+.stats-drawer-model { font-weight: 600; color: var(--text); }
+.stats-drawer-provider { font-family: var(--font-mono); font-size: 11px; color: var(--dim); }
+.stats-drawer-error-block { border: 1px solid color-mix(in oklch, var(--danger) 18%, transparent); background: color-mix(in oklch, var(--danger) 10%, var(--surface-2)); border-radius: var(--radius-md); padding: 10px 12px; }
+.stats-drawer-error-label { font-size: 10px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--danger); font-family: var(--font-mono); margin-bottom: 4px; }
+.stats-drawer-error-text { font-size: 12px; color: var(--danger); font-family: var(--font-mono); word-break: break-word; }
+.stats-drawer-metrics-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+.stats-drawer-metric-card { border: 1px solid var(--border); background: var(--surface-2); border-radius: var(--radius-md); padding: 10px 12px; }
+.stats-drawer-metric-label { font-size: 10px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--dim); font-family: var(--font-mono); display: flex; align-items: center; gap: 6px; }
+.stats-drawer-metric-icon { color: var(--dim); }
+.stats-drawer-metric-value { font-family: var(--font-mono); font-size: 14px; font-weight: 700; color: var(--text); font-variant-numeric: tabular-nums; }
+.stats-drawer-metric-sub { font-size: 11px; color: var(--muted); }
+.stats-drawer-json-blocks { display: flex; flex-direction: column; gap: 10px; }
 
-.stats-status-pill[data-variant="warning"] {
-  background: color-mix(in srgb, var(--warning) 18%, transparent);
-  color: var(--warning);
-}
+/* JSON block */
+.stats-json-block { border: 1px solid var(--border); border-radius: var(--radius-md); overflow: hidden; background: var(--surface-2); }
+.stats-json-block-header { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 8px 10px; background: transparent; border: none; cursor: pointer; text-align: left; }
+.stats-json-block-header:hover { background: var(--surface-3); }
+.stats-json-block-title { color: var(--text); font-size: 12px; font-weight: 600; font-family: var(--font-mono); }
+.stats-json-block-toggle-indicator { color: var(--muted); }
+.stats-json-block-content-wrapper { border-top: 1px solid var(--border); }
+.stats-json-block-content { margin: 0; padding: 10px; font-family: var(--font-mono); font-size: 11px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; max-height: 320px; overflow: auto; }
 
-.stats-status-pill[data-variant="info"] {
-  background: color-mix(in srgb, var(--link) 18%, transparent);
-  color: var(--link);
-}
-
-.stats-status-pill[data-variant="default"] {
-  background: var(--surface-2);
-  color: var(--muted);
-}
-
-/* Segmented Control */
-.stats-segmented-control {
-  display: flex;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  padding: 2px;
-  gap: 2px;
-}
-
-.stats-segmented-control-btn {
-  padding: 6px 12px;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--muted);
-  background: transparent;
-  border: none;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  transition: all 0.1s ease;
-  white-space: nowrap;
-}
-
-.stats-segmented-control-btn:hover {
-  color: var(--text);
-}
-
-.stats-segmented-control-btn[data-active="true"] {
-  color: var(--text);
-  background: var(--surface);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
-}
-
-/* Drawer Detail Component */
-.stats-drawer-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  z-index: 100;
-  display: flex;
-  justify-content: flex-end;
-}
-
-.stats-drawer {
-  width: 600px;
-  max-width: 100%;
-  height: 100%;
-  background: var(--surface);
-  border-left: 1px solid var(--border);
-  display: flex;
-  flex-direction: column;
-  animation: drawerSlide 0.25s cubic-bezier(0.16, 1, 0.3, 1);
-  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.25);
-}
-
-@keyframes drawerSlide {
-  from { transform: translateX(100%); }
-  to { transform: translateX(0); }
-}
-
-.stats-drawer-header {
-  height: 56px;
-  border-bottom: 1px solid var(--border);
-  padding: 0 24px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  background: var(--surface);
-  flex-shrink: 0;
-}
-
-.stats-drawer-header-left {
-  display: flex;
-  align-items: baseline;
-  gap: 12px;
-}
-
-.stats-drawer-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text);
-  margin: 0;
-}
-
-.stats-drawer-id {
-  font-size: 11px;
-  color: var(--muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-}
-
-.stats-drawer-close-btn {
-  background: transparent;
-  border: none;
-  color: var(--muted);
-  cursor: pointer;
-  padding: 4px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--radius-sm);
-  transition: all 0.1s ease;
-}
-
-.stats-drawer-close-btn:hover {
-  color: var(--text);
-  background: var(--surface-2);
-}
-
-.stats-drawer-body {
-  flex: 1;
-  overflow-y: auto;
-  padding: 24px;
-}
-
-.stats-drawer-content {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-}
-
-.stats-drawer-status-card {
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 16px;
-}
-
-.stats-drawer-status-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 16px;
-}
-
-.stats-drawer-model {
-  font-size: 16px;
-  font-weight: 700;
-  color: var(--text);
-}
-
-.stats-drawer-provider {
-  font-size: 12px;
-  color: var(--muted);
-  margin-top: 2px;
-}
-
-.stats-drawer-error-block {
-  margin-top: 14px;
-  border-top: 1px solid var(--border);
-  padding-top: 12px;
-}
-
-.stats-drawer-error-label {
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--danger);
-  margin-bottom: 4px;
-}
-
-.stats-drawer-error-text {
-  font-size: 12px;
-  color: var(--text);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  white-space: pre-wrap;
-  word-break: break-all;
-}
-
-.stats-drawer-metrics-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 12px;
-}
-
-.stats-drawer-metric-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 14px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-}
-
-.stats-drawer-metric-label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--muted);
-  margin-bottom: 6px;
-}
-
-.stats-drawer-metric-icon {
-  color: var(--dim);
-}
-
-.stats-drawer-metric-value {
-  font-size: 16px;
-  font-weight: 700;
-  color: var(--text);
-  font-variant-numeric: tabular-nums;
-}
-
-.stats-drawer-metric-sub {
-  font-size: 11px;
-  color: var(--muted);
-  margin-top: 2px;
-  font-variant-numeric: tabular-nums;
-}
-
-.stats-drawer-json-blocks {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-/* Collapsible JSON Block */
-.stats-json-block {
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--surface);
-  overflow: hidden;
-}
-
-.stats-json-block-header {
-  padding: 10px 16px;
-  background: var(--surface-2);
-  border-bottom: 1px solid var(--border);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  cursor: pointer;
-  user-select: none;
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.stats-json-block-header:hover {
-  background: var(--border);
-}
-
-.stats-json-block-title {
-  color: var(--text);
-}
-
-.stats-json-block-toggle-indicator {
-  color: var(--muted);
-}
-
-.stats-json-block-content-wrapper {
-  padding: 16px;
-  background: var(--page);
-  overflow-x: auto;
-}
-
-.stats-json-block-content {
-  margin: 0;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 12px;
-  color: var(--text);
-  line-height: 1.5;
-}
-
-/* Skeleton Loading Element */
-.stats-skeleton {
-  background: var(--surface-2);
-  position: relative;
-  overflow: hidden;
-  border-radius: var(--radius-sm);
-}
-
-.stats-skeleton[data-variant="text"] {
-  height: 14px;
-  margin-top: 4px;
-  margin-bottom: 4px;
-}
-
-.stats-skeleton[data-variant="circle"] {
-  border-radius: 50%;
-}
-
-/* Subtle Shimmer effect, respecting media queries for reduced motion */
+/* Skeleton */
+.stats-skeleton { background: var(--surface-2); border-radius: var(--radius-sm); position: relative; overflow: hidden; }
+.stats-skeleton[data-variant="text"] { border-radius: 4px; }
+.stats-skeleton[data-variant="circle"] { border-radius: 50%; }
 .stats-skeleton::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  transform: translateX(-100%);
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(255, 255, 255, 0.05) 50%,
-    transparent 100%
-  );
-  animation: shimmer 1.5s infinite;
+  content: ""; position: absolute; inset: 0; transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, color-mix(in oklch, var(--border-strong) 50%, transparent), transparent);
+  animation: shimmer 1.4s infinite;
 }
+@media (prefers-color-scheme: light) { .stats-skeleton::after { background: linear-gradient(90deg, transparent, rgba(0,0,0,0.06), transparent); } }
+@keyframes shimmer { 100% { transform: translateX(100%); } }
+@media (prefers-reduced-motion: reduce) { .stats-skeleton::after { animation: none; } }
+.stats-boundary-skeleton { display: flex; flex-direction: column; gap: 10px; padding: 12px; }
 
-@media (prefers-color-scheme: light) {
-  .stats-skeleton::after {
-    background: linear-gradient(
-      90deg,
-      transparent 0%,
-      rgba(0, 0, 0, 0.03) 50%,
-      transparent 100%
-    );
-  }
-}
-
-@keyframes shimmer {
-  100% { transform: translateX(100%); }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .stats-skeleton::after {
-    animation: none;
-  }
-}
-
-.stats-boundary-skeleton {
-  padding: 20px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--surface);
-}
-
-/* Empty State / Error State */
-.stats-empty-state,
-.stats-error-state {
-  padding: 48px 24px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  background: var(--surface);
-  border: 1px dashed var(--border);
-  border-radius: var(--radius-lg);
-}
-
+/* Empty / Error */
+.stats-empty-state, .stats-error-state { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 10px; padding: 28px 16px; text-align: center; }
 .stats-empty-state-message {
-  font-size: 13px;
-  color: var(--muted);
-  margin: 0;
+  font-size: 12.5px; color: var(--muted); border: 1px dashed var(--border); border-radius: var(--radius-md);
+  padding: 12px 14px; background: var(--surface-2); font-family: var(--font-mono);
 }
+.stats-error-state-content { max-width: 360px; }
+.stats-error-state-title { font-size: 13px; font-weight: 700; color: var(--danger); }
+.stats-error-state-message { font-size: 12px; color: var(--muted); }
+.stats-error-state-btn { margin: 0 auto; }
+.stats-empty-state-icon { color: var(--dim); opacity: 0.8; }
 
-.stats-error-state-content {
-  max-width: 360px;
-}
+/* Feed ledger */
+.stats-feed-ledger { scrollbar-width: thin; }
+.stats-feed-item { border-bottom: 1px solid var(--border); }
+.stats-feed-item:last-child { border-bottom: none; }
 
-.stats-error-state-title {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text);
-  margin: 0 0 8px 0;
-}
-
-.stats-error-state-message {
-  font-size: 12px;
-  color: var(--danger);
-  margin: 0 0 16px 0;
-  word-break: break-word;
-}
-
-.stats-error-state-btn {
-  margin: 0 auto;
-}
-
-/* ==========================================================================
-   Token-vocabulary bridge utility classes (used across route components)
-   ========================================================================== */
+/* Utilities bridge */
 .stats-text-primary { color: var(--text); }
 .stats-text-secondary { color: var(--muted); }
 .stats-text-muted { color: var(--dim); }
-.stats-text-warning { color: var(--warning); }
-.stats-text-xs { font-size: 12px; }
+.stats-text-warning { color: var(--amber); }
+.stats-text-xs { font-size: 11px; }
 .stats-font-medium { font-weight: 500; }
 .stats-font-semibold { font-weight: 600; }
 
-/* ==========================================================================
-   Owned scrollbars — thin, brand-tinted, app-wide (ComPress convention)
-   ========================================================================== */
-* {
-  scrollbar-width: thin;
-  scrollbar-color: var(--border-strong) transparent;
-}
-
-*::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
-}
-
-*::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-*::-webkit-scrollbar-thumb {
-  background: var(--border-strong);
-  border: 2px solid transparent;
-  background-clip: padding-box;
-  border-radius: 999px;
-}
-
-*::-webkit-scrollbar-thumb:hover {
-  background: var(--dim);
-  border: 2px solid transparent;
-  background-clip: padding-box;
-}
-
-*::-webkit-scrollbar-corner {
-  background: transparent;
-}
-
-/* ==========================================================================
-   Comprehensive reduced-motion fallback for all interaction motion
-   ========================================================================== */
-@media (prefers-reduced-motion: reduce) {
-  .stats-button,
-  .stats-table-tr-clickable,
-  .stats-nav-rail-item,
-  .stats-range-control-btn,
-  .stats-segmented-control-btn {
-    transition: none;
-  }
-
-  .stats-button:active:not(:disabled) {
-    transform: none;
-  }
-
-  .stats-mobile-drawer,
-  .stats-drawer {
-    animation: none;
-  }
-}
-
-/* ==========================================================================
-   Brand mark on the OMP wordmark (both rail + mobile drawer headers)
-   ========================================================================== */
-.stats-logo-container {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  align-items: center;
-  column-gap: 10px;
-}
-
-.stats-logo-container::before {
-  content: "";
-  grid-row: 1 / 3;
-  width: 16px;
-  height: 16px;
-  border-radius: 4px;
-  background: linear-gradient(135deg, #ed4abf 0%, #9b4dff 50%, #5ad8e6 100%); /* OMP brand gradient mark */
-}
-
-.stats-logo-text,
-.stats-logo-subtext {
-  grid-column: 2;
-}
-
-/* ==========================================================================
-   JSON block copy affordance
-   ========================================================================== */
-.stats-json-actions {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.stats-json-copy-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--muted);
-  background: transparent;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  padding: 3px 8px;
-  cursor: pointer;
-  font-family: inherit;
-  transition: color 0.12s ease, background 0.12s ease;
-}
-
-.stats-json-copy-btn:hover {
-  color: var(--text);
-  background: var(--surface-2);
-}
-
-/* ==========================================================================
-   Empty-state icon
-   ========================================================================== */
-.stats-empty-state-icon {
-  color: var(--dim);
-  margin-bottom: 12px;
-}
+/* Scrollbars — thin, tinted */
+* { scrollbar-width: thin; scrollbar-color: var(--border-strong) transparent; }
+*::-webkit-scrollbar { width: 8px; height: 8px; }
+*::-webkit-scrollbar-track { background: transparent; }
+*::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; border: 2px solid transparent; background-clip: content-box; }
+*::-webkit-scrollbar-thumb:hover { background: color-mix(in oklch, var(--border-strong) 90%, var(--muted)); background-clip: content-box; }
+*::-webkit-scrollbar-corner { background: transparent; }
 
 @media (prefers-reduced-motion: reduce) {
-  .stats-json-copy-btn {
-    transition: none;
-  }
+  .stats-spin, .stats-scope-dot, .stats-skeleton::after { animation: none !important; }
+  .stats-nav-rail-item, .stats-range-control-btn, .stats-button { transition: none !important; }
 }
 
-/* ==========================================================================
-   Theme toggle (system / light / dark)
-   ========================================================================== */
-.stats-theme-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  flex-shrink: 0;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: var(--surface);
-  color: var(--muted);
-  cursor: pointer;
-  transition: color 0.14s ease, background 0.14s ease, border-color 0.14s ease;
-}
+/* Brand mark — consolidated above */
+.stats-logo-text, .stats-logo-subtext { grid-column: 2; }
+.stats-json-actions { display: flex; gap: 6px; align-items: center; }
+.stats-json-copy-btn { display: inline-flex; align-items: center; gap: 6px; padding: 4px 8px; font-size: 11px; font-family: var(--font-mono); border: 1px solid var(--border); background: var(--surface-2); color: var(--muted); border-radius: var(--radius-sm); cursor: pointer; }
+.stats-json-copy-btn:hover { color: var(--text); background: var(--surface-3); }
+.stats-theme-toggle { display: inline-flex; align-items: center; justify-content: center; padding: 6px; border-radius: var(--radius-md); border: 1px solid var(--border); background: var(--surface-2); color: var(--muted); cursor: pointer; }
+.stats-theme-toggle:hover { color: var(--text); background: var(--surface-3); }
+@media (prefers-reduced-motion: reduce) { .stats-theme-toggle { transition: none; } }
 
-.stats-theme-toggle:hover {
-  color: var(--text);
-  border-color: var(--border-strong);
-}
+/* Helper hide for section persistence */
+[data-hidden="true"] { display: none !important; }
 
-@media (prefers-reduced-motion: reduce) {
-  .stats-theme-toggle {
-    transition: none;
-  }
+/* Legacy route helpers restored — used by Errors/Projects/Providers/Gain/Tools */
+.stats-select {
+  background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-md);
+  color: var(--text); font-family: var(--font-mono); font-size: 11px; padding: 6px 8px;
 }
 
 /* ==========================================================================
@@ -1704,3 +1000,10 @@
     transition: none;
   }
 }
+.stats-select:focus { outline: 2px solid var(--link); outline-offset: 1px; }
+.stats-text-danger { color: var(--danger); }
+.stats-text-success { color: var(--success); }
+.stats-border-danger { border-color: var(--danger) !important; }
+.stats-font-mono { font-family: var(--font-mono) !important; }
+.stats-truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.stats-max-w-md { max-width: 28rem; }

--- a/packages/stats/src/client/types.ts
+++ b/packages/stats/src/client/types.ts
@@ -63,7 +63,7 @@ export interface RequestDetails extends MessageStats {
 	output: unknown;
 }
 
-export type TimeRange = "1h" | "24h" | "7d" | "30d" | "90d" | "all";
+export type TimeRange = "today" | "1h" | "24h" | "7d" | "30d" | "90d" | "all";
 
 export interface OverviewStats {
 	overall: AggregatedStats;

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -1321,7 +1321,7 @@ export function getToolCallCountsBySession(): Map<string, number> {
 		counts.set(row.sessionFile, row.calls);
 	}
 	return counts;
-export function getRequestsPaginated(limit: number, offset: number): { items: MessageStats[]; total: number } {
+}
 export function getRequestsPaginated(
 	limit: number,
 	offset: number,
@@ -1348,8 +1348,16 @@ export function getRequestsPaginated(
 /**
  * Get daily cost time series data for the last N days, broken down by model.
  * @param origin - Bucket anchor (ms); 0 keeps Unix-epoch alignment.
+ * @param bucketMs - Bucket width (ms); defaults to a calendar day. A local-
+ *   midnight origin with a fixed 24h width mislabels DST-fallback days, so
+ *   Today's hourly series passes its own bucket width.
  */
-export function getCostTimeSeries(days = 90, cutoff?: number | null, origin = 0): CostTimeSeriesPoint[] {
+export function getCostTimeSeries(
+	days = 90,
+	cutoff?: number | null,
+	origin = 0,
+	bucketMs = 86_400_000,
+): CostTimeSeriesPoint[] {
 	if (!db) return [];
 
 	const hasCutoff = cutoff !== null;
@@ -1357,7 +1365,7 @@ export function getCostTimeSeries(days = 90, cutoff?: number | null, origin = 0)
 
 	const stmt = db.prepare(`
 		SELECT
-			((timestamp - ?) / 86400000) * 86400000 + ? as bucket,
+			((timestamp - ?) / ?) * ? + ? as bucket,
 			model,
 			provider,
 			SUM(cost_total) as cost,
@@ -1373,7 +1381,11 @@ export function getCostTimeSeries(days = 90, cutoff?: number | null, origin = 0)
 		ORDER BY bucket ASC
 	`);
 
-	const rows = (hasCutoff ? stmt.all(origin, origin, seriesCutoff) : stmt.all(origin, origin)) as CostTimeSeriesRow[];
+	const rows = (
+		hasCutoff
+			? stmt.all(origin, bucketMs, bucketMs, origin, seriesCutoff)
+			: stmt.all(origin, bucketMs, bucketMs, origin)
+	) as CostTimeSeriesRow[];
 	return rows.map(row => ({
 		timestamp: row.bucket,
 		model: row.model,
@@ -1775,12 +1787,16 @@ interface BehaviorSeriesRow {
  * Daily behavioral time series, grouped by responding model+provider.
  * @param origin - Bucket anchor (ms); 0 keeps Unix-epoch day alignment.
  */
-export function getBehaviorTimeSeries(cutoff?: number | null, origin = 0): BehaviorTimeSeriesPoint[] {
+export function getBehaviorTimeSeries(
+	cutoff?: number | null,
+	origin = 0,
+	bucketMs = 86_400_000,
+): BehaviorTimeSeriesPoint[] {
 	if (!db) return [];
 	const hasCutoff = cutoff !== null && cutoff !== undefined && cutoff > 0;
 	const stmt = db.prepare(`
 		SELECT
-			((timestamp - ?) / 86400000) * 86400000 + ? as bucket,
+			((timestamp - ?) / ?) * ? + ? as bucket,
 			COALESCE(model, ?) as model,
 			COALESCE(provider, ?) as provider,
 			COUNT(*) as messages,
@@ -1798,8 +1814,8 @@ export function getBehaviorTimeSeries(cutoff?: number | null, origin = 0): Behav
 	`);
 	const rows = (
 		hasCutoff
-			? stmt.all(origin, origin, UNKNOWN_MODEL, UNKNOWN_MODEL, cutoff)
-			: stmt.all(origin, origin, UNKNOWN_MODEL, UNKNOWN_MODEL)
+			? stmt.all(origin, bucketMs, bucketMs, origin, UNKNOWN_MODEL, UNKNOWN_MODEL, cutoff)
+			: stmt.all(origin, bucketMs, bucketMs, origin, UNKNOWN_MODEL, UNKNOWN_MODEL)
 	) as BehaviorSeriesRow[];
 	return rows.map(row => ({
 		timestamp: row.bucket,

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -1771,16 +1771,16 @@ interface BehaviorSeriesRow {
 	blame: number | null;
 	chars: number | null;
 }
-
 /**
  * Daily behavioral time series, grouped by responding model+provider.
+ * @param origin - Bucket anchor (ms); 0 keeps Unix-epoch day alignment.
  */
-export function getBehaviorTimeSeries(cutoff?: number | null): BehaviorTimeSeriesPoint[] {
+export function getBehaviorTimeSeries(cutoff?: number | null, origin = 0): BehaviorTimeSeriesPoint[] {
 	if (!db) return [];
 	const hasCutoff = cutoff !== null && cutoff !== undefined && cutoff > 0;
 	const stmt = db.prepare(`
 		SELECT
-			(timestamp / 86400000) * 86400000 as bucket,
+			((timestamp - ?) / 86400000) * 86400000 + ? as bucket,
 			COALESCE(model, ?) as model,
 			COALESCE(provider, ?) as provider,
 			COUNT(*) as messages,
@@ -1797,7 +1797,9 @@ export function getBehaviorTimeSeries(cutoff?: number | null): BehaviorTimeSerie
 		ORDER BY bucket ASC
 	`);
 	const rows = (
-		hasCutoff ? stmt.all(UNKNOWN_MODEL, UNKNOWN_MODEL, cutoff) : stmt.all(UNKNOWN_MODEL, UNKNOWN_MODEL)
+		hasCutoff
+			? stmt.all(origin, origin, UNKNOWN_MODEL, UNKNOWN_MODEL, cutoff)
+			: stmt.all(origin, origin, UNKNOWN_MODEL, UNKNOWN_MODEL)
 	) as BehaviorSeriesRow[];
 	return rows.map(row => ({
 		timestamp: row.bucket,

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -1303,6 +1303,17 @@ export function getToolCallCountsBySession(): Map<string, number> {
 		counts.set(row.sessionFile, row.calls);
 	}
 	return counts;
+export function getRequestsPaginated(limit: number, offset: number): { items: MessageStats[]; total: number } {
+	if (!db) return { items: [], total: 0 };
+	const countRow = db.prepare("SELECT COUNT(*) as total FROM messages").get() as { total: number };
+	const total = countRow?.total ?? 0;
+	const stmt = db.prepare(`
+		SELECT * FROM messages
+		ORDER BY timestamp DESC
+		LIMIT ? OFFSET ?
+	`);
+	const items = (stmt.all(limit, offset) as any[]).map(rowToMessageStats);
+	return { items, total };
 }
 
 /**

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -917,8 +917,14 @@ export function getStatsByAgentType(cutoff?: number): AgentTypeStats[] {
 
 /**
  * Get time series data.
+ * @param origin - Bucket anchor (ms); 0 keeps Unix-epoch alignment.
  */
-export function getTimeSeries(hours = 24, cutoff?: number | null, bucketMs = 60 * 60 * 1000): TimeSeriesPoint[] {
+export function getTimeSeries(
+	hours = 24,
+	cutoff?: number | null,
+	bucketMs = 60 * 60 * 1000,
+	origin = 0,
+): TimeSeriesPoint[] {
 	if (!db) return [];
 
 	const hasCutoff = cutoff !== null;
@@ -926,7 +932,7 @@ export function getTimeSeries(hours = 24, cutoff?: number | null, bucketMs = 60 
 
 	const stmt = db.prepare(`
 		SELECT
-			(timestamp / ?) * ? as bucket,
+			((timestamp - ?) / ?) * ? + ? as bucket,
 			COUNT(*) as requests,
 			SUM(CASE WHEN stop_reason = 'error' THEN 1 ELSE 0 END) as errors,
 			SUM(total_tokens) as tokens,
@@ -938,8 +944,8 @@ export function getTimeSeries(hours = 24, cutoff?: number | null, bucketMs = 60 
 	`);
 
 	const rows = hasCutoff
-		? (stmt.all(bucketMs, bucketMs, seriesCutoff) as any[])
-		: (stmt.all(bucketMs, bucketMs) as any[]);
+		? (stmt.all(origin, bucketMs, bucketMs, origin, seriesCutoff) as any[])
+		: (stmt.all(origin, bucketMs, bucketMs, origin) as any[]);
 	return rows.map(row => ({
 		timestamp: row.bucket,
 		requests: row.requests,
@@ -954,11 +960,13 @@ export function getTimeSeries(hours = 24, cutoff?: number | null, bucketMs = 60 
  */
 /**
  * Get daily model usage time series data for the last N days.
+ * @param origin - Bucket anchor (ms); 0 keeps Unix-epoch alignment.
  */
 export function getModelTimeSeries(
 	days = 14,
 	cutoff?: number | null,
 	bucketMs = 24 * 60 * 60 * 1000,
+	origin = 0,
 ): ModelTimeSeriesPoint[] {
 	if (!db) return [];
 
@@ -967,7 +975,7 @@ export function getModelTimeSeries(
 
 	const stmt = db.prepare(`
 		SELECT
-			(timestamp / ?) * ? as bucket,
+			((timestamp - ?) / ?) * ? + ? as bucket,
 			model,
 			provider,
 			COUNT(*) as requests
@@ -977,7 +985,9 @@ export function getModelTimeSeries(
 		ORDER BY bucket ASC
 	`);
 
-	const rowsRaw = hasCutoff ? stmt.all(bucketMs, bucketMs, seriesCutoff) : stmt.all(bucketMs, bucketMs);
+	const rowsRaw = hasCutoff
+		? stmt.all(origin, bucketMs, bucketMs, origin, seriesCutoff)
+		: stmt.all(origin, bucketMs, bucketMs, origin);
 	const rows = rowsRaw as Array<{ bucket: number; model: string; provider: string; requests: number }>;
 	return rows.map(row => ({
 		timestamp: row.bucket,
@@ -1087,11 +1097,13 @@ export function getProviderHourlyBurn(cutoff?: number | null): ProviderHourlyPoi
 
 /**
  * Get token/cost time series grouped by provider (bucketed like the model series).
+ * @param origin - Bucket anchor (ms); 0 keeps Unix-epoch alignment.
  */
 export function getProviderTimeSeries(
 	days = 14,
 	cutoff?: number | null,
 	bucketMs = 24 * 60 * 60 * 1000,
+	origin = 0,
 ): ProviderTimeSeriesPoint[] {
 	if (!db) return [];
 
@@ -1100,7 +1112,7 @@ export function getProviderTimeSeries(
 
 	const stmt = db.prepare(`
 		SELECT
-			(timestamp / ?) * ? as bucket,
+			((timestamp - ?) / ?) * ? + ? as bucket,
 			provider,
 			SUM(input_tokens + output_tokens + cache_read_tokens + cache_write_tokens) as total_tokens,
 			SUM(cost_total) as cost,
@@ -1112,7 +1124,9 @@ export function getProviderTimeSeries(
 		ORDER BY bucket ASC
 	`);
 
-	const rowsRaw = hasCutoff ? stmt.all(bucketMs, bucketMs, seriesCutoff) : stmt.all(bucketMs, bucketMs);
+	const rowsRaw = hasCutoff
+		? stmt.all(origin, bucketMs, bucketMs, origin, seriesCutoff)
+		: stmt.all(origin, bucketMs, bucketMs, origin);
 	const rows = rowsRaw as Array<{
 		bucket: number;
 		provider: string;
@@ -1133,11 +1147,13 @@ export function getProviderTimeSeries(
 
 /**
  * Get daily model performance time series data for the last N days.
+ * @param origin - Bucket anchor (ms); 0 keeps Unix-epoch alignment.
  */
 export function getModelPerformanceSeries(
 	days = 14,
 	cutoff?: number | null,
 	bucketMs = 24 * 60 * 60 * 1000,
+	origin = 0,
 ): ModelPerformancePoint[] {
 	if (!db) return [];
 
@@ -1146,7 +1162,7 @@ export function getModelPerformanceSeries(
 
 	const stmt = db.prepare(`
 		SELECT
-			(timestamp / ?) * ? as bucket,
+			((timestamp - ?) / ?) * ? + ? as bucket,
 			model,
 			provider,
 			COUNT(*) as requests,
@@ -1158,7 +1174,9 @@ export function getModelPerformanceSeries(
 		ORDER BY bucket ASC
 	`);
 
-	const rowsRaw = hasCutoff ? stmt.all(bucketMs, bucketMs, seriesCutoff) : stmt.all(bucketMs, bucketMs);
+	const rowsRaw = hasCutoff
+		? stmt.all(origin, bucketMs, bucketMs, origin, seriesCutoff)
+		: stmt.all(origin, bucketMs, bucketMs, origin);
 	const rows = rowsRaw as Array<{
 		bucket: number;
 		model: string;
@@ -1304,22 +1322,34 @@ export function getToolCallCountsBySession(): Map<string, number> {
 	}
 	return counts;
 export function getRequestsPaginated(limit: number, offset: number): { items: MessageStats[]; total: number } {
+export function getRequestsPaginated(
+	limit: number,
+	offset: number,
+	cutoff?: number | null,
+): { items: MessageStats[]; total: number } {
 	if (!db) return { items: [], total: 0 };
-	const countRow = db.prepare("SELECT COUNT(*) as total FROM messages").get() as { total: number };
+	const hasCutoff = cutoff !== undefined && cutoff !== null;
+	const countRow = hasCutoff
+		? (db.prepare("SELECT COUNT(*) as total FROM messages WHERE timestamp >= ?").get(cutoff) as { total: number })
+		: (db.prepare("SELECT COUNT(*) as total FROM messages").get() as { total: number });
 	const total = countRow?.total ?? 0;
 	const stmt = db.prepare(`
 		SELECT * FROM messages
+		${hasCutoff ? "WHERE timestamp >= ?" : ""}
 		ORDER BY timestamp DESC
 		LIMIT ? OFFSET ?
 	`);
-	const items = (stmt.all(limit, offset) as any[]).map(rowToMessageStats);
+	const items = ((hasCutoff ? stmt.all(cutoff, limit, offset) : stmt.all(limit, offset)) as any[]).map(
+		rowToMessageStats,
+	);
 	return { items, total };
 }
 
 /**
  * Get daily cost time series data for the last N days, broken down by model.
+ * @param origin - Bucket anchor (ms); 0 keeps Unix-epoch alignment.
  */
-export function getCostTimeSeries(days = 90, cutoff?: number | null): CostTimeSeriesPoint[] {
+export function getCostTimeSeries(days = 90, cutoff?: number | null, origin = 0): CostTimeSeriesPoint[] {
 	if (!db) return [];
 
 	const hasCutoff = cutoff !== null;
@@ -1327,7 +1357,7 @@ export function getCostTimeSeries(days = 90, cutoff?: number | null): CostTimeSe
 
 	const stmt = db.prepare(`
 		SELECT
-			(timestamp / 86400000) * 86400000 as bucket,
+			((timestamp - ?) / 86400000) * 86400000 + ? as bucket,
 			model,
 			provider,
 			SUM(cost_total) as cost,
@@ -1343,7 +1373,7 @@ export function getCostTimeSeries(days = 90, cutoff?: number | null): CostTimeSe
 		ORDER BY bucket ASC
 	`);
 
-	const rows = (hasCutoff ? stmt.all(seriesCutoff) : stmt.all()) as CostTimeSeriesRow[];
+	const rows = (hasCutoff ? stmt.all(origin, origin, seriesCutoff) : stmt.all(origin, origin)) as CostTimeSeriesRow[];
 	return rows.map(row => ({
 		timestamp: row.bucket,
 		model: row.model,
@@ -2078,11 +2108,13 @@ export function getToolStatsByModel(cutoff?: number): ToolModelStats[] {
 
 /**
  * Get tool-call time series (one point per bucket per tool).
+ * @param origin - Bucket anchor (ms); 0 keeps Unix-epoch alignment.
  */
 export function getToolTimeSeries(
 	days = 14,
 	cutoff?: number | null,
 	bucketMs = 24 * 60 * 60 * 1000,
+	origin = 0,
 ): ToolTimeSeriesPoint[] {
 	if (!db) return [];
 
@@ -2091,7 +2123,7 @@ export function getToolTimeSeries(
 
 	const stmt = db.prepare(`
 		SELECT
-			(timestamp / ?) * ? as bucket,
+			((timestamp - ?) / ?) * ? + ? as bucket,
 			tool_name,
 			COUNT(*) as calls,
 			SUM(CASE WHEN is_error = 1 THEN 1 ELSE 0 END) as errors
@@ -2101,7 +2133,9 @@ export function getToolTimeSeries(
 		ORDER BY bucket ASC
 	`);
 
-	const rowsRaw = hasCutoff ? stmt.all(bucketMs, bucketMs, seriesCutoff) : stmt.all(bucketMs, bucketMs);
+	const rowsRaw = hasCutoff
+		? stmt.all(origin, bucketMs, bucketMs, origin, seriesCutoff)
+		: stmt.all(origin, bucketMs, bucketMs, origin);
 	const rows = rowsRaw as Array<{ bucket: number; tool_name: string; calls: number; errors: number }>;
 	return rows.map(row => ({
 		timestamp: row.bucket,

--- a/packages/stats/src/index.ts
+++ b/packages/stats/src/index.ts
@@ -8,6 +8,7 @@ import { formatStatsDashboardUrl, startServer } from "./server";
 
 export {
 	getDashboardStats,
+	getRequestsPaginated,
 	getToolDashboardStats,
 	getTotalMessageCount,
 	type SyncOptions,

--- a/packages/stats/src/server.ts
+++ b/packages/stats/src/server.ts
@@ -19,6 +19,7 @@ import {
 	getTotalMessageCount,
 	syncAllSessions,
 } from "./aggregator";
+import { handleApiV1 } from "./api-v1";
 import { decodeEmbeddedClientArchive } from "./embedded-client";
 import embeddedClientArchiveTxt from "./embedded-client.generated.txt";
 import { getGainDashboardStats } from "./gain-aggregator";
@@ -31,6 +32,14 @@ import {
 	STATS_DASHBOARD_SECURITY_VERSION,
 } from "./port-conflict";
 import { buildSessionTrace, getTraceEntry, listSessionSummaries, TRACE_ETAG_VERSION, TracePathError } from "./trace";
+
+/** CORS headers for v1 API loopback development. */
+const V1_CORS_HEADERS: Record<string, string> = {
+	"Access-Control-Allow-Origin": "http://localhost:3000",
+	"Access-Control-Allow-Methods": "GET, OPTIONS",
+	"Access-Control-Allow-Headers": "Content-Type",
+	"Access-Control-Max-Age": "86400",
+};
 
 const EMBEDDED_CLIENT_ARCHIVE = decodeEmbeddedClientArchive(embeddedClientArchiveTxt);
 
@@ -199,6 +208,11 @@ export async function handleApi(req: Request): Promise<Response> {
 	const url = new URL(req.url);
 	const path = url.pathname;
 
+	// Versioned API v1 — delegate to dedicated router
+	if (path.startsWith("/api/v1/")) {
+		return handleApiV1(req);
+	}
+
 	// Stats reads are DB-only; explicit /api/sync does the expensive session scan.
 	const range = url.searchParams.get("range");
 
@@ -364,6 +378,11 @@ function createDashboardServer(port: number, hostname: string): Server<undefined
 				[STATS_DASHBOARD_HEADER]: STATS_DASHBOARD_SECURITY_VERSION,
 				[STATS_DASHBOARD_HOSTNAME_HEADER]: hostname,
 			};
+
+			// Versioned API v1 OPTIONS gets CORS + dashboard identity headers.
+			if (path.startsWith("/api/v1/") && req.method === "OPTIONS") {
+				return new Response(null, { status: 204, headers: { ...dashboardHeaders, ...V1_CORS_HEADERS } });
+			}
 
 			if (req.method === "OPTIONS") {
 				return new Response(null, { headers: dashboardHeaders });

--- a/packages/stats/test/api-v1.test.ts
+++ b/packages/stats/test/api-v1.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "bun:test";
+import { initDb, insertMessageStats } from "@oh-my-pi/omp-stats/db";
+import type { MessageStats } from "@oh-my-pi/omp-stats/types";
+import { handleApi } from "../src/server";
+import { installStatsTestIsolation } from "./helpers/temp-agent";
+
+installStatsTestIsolation("@pi-stats-api-v1-");
+
+function makeMessage(timestamp: number, entryId: string, folder = "/tmp/project"): MessageStats {
+	return {
+		sessionFile: "/tmp/session.jsonl",
+		entryId,
+		folder,
+		model: "gpt-5.4",
+		provider: "openai-codex",
+		api: "openai-codex-responses",
+		timestamp,
+		duration: 1000,
+		ttft: 100,
+		stopReason: "stop",
+		errorMessage: null,
+		usage: {
+			input: 1000,
+			output: 500,
+			cacheRead: 200,
+			cacheWrite: 0,
+			totalTokens: 1700,
+			cost: { input: 0.01, output: 0.02, cacheRead: 0.001, cacheWrite: 0, total: 0.031 },
+		},
+		agentType: "main",
+	};
+}
+
+function makeError(timestamp: number, entryId: string): MessageStats {
+	return {
+		sessionFile: "/tmp/error-session.jsonl",
+		entryId,
+		folder: "/tmp/project",
+		model: "gpt-5.4",
+		provider: "openai-codex",
+		api: "openai-codex-responses",
+		timestamp,
+		duration: 1000,
+		ttft: 100,
+		stopReason: "error",
+		errorMessage: `failure ${entryId}`,
+		usage: {
+			input: 1000,
+			output: 500,
+			cacheRead: 200,
+			cacheWrite: 0,
+			totalTokens: 1700,
+			cost: { input: 0.01, output: 0.02, cacheRead: 0.001, cacheWrite: 0, total: 0.031 },
+		},
+		agentType: "main",
+	};
+}
+
+describe("API v1 meta endpoint", () => {
+	it("returns version, ranges, and endpoints", async () => {
+		const res = await handleApi(new Request("http://stats.test/api/v1/meta"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(body.version).toBe(1);
+		expect(body.ranges).toContain("24h");
+		expect(body.ranges).toContain("7d");
+		expect(body.ranges).toContain("all");
+		expect(body.endpoints).toContain("/api/v1/meta");
+		expect(body.endpoints).toContain("/api/v1/overview");
+		expect(body.serverTime).toBeGreaterThan(0);
+	});
+});
+
+describe("API v1 overview endpoint", () => {
+	it("returns overview stats with default range", async () => {
+		await initDb();
+		const now = Date.now();
+		insertMessageStats([
+			makeMessage(now, "v1-overview-1"),
+			makeMessage(now - 48 * 60 * 60 * 1000, "v1-overview-old"),
+		]);
+
+		const res = await handleApi(new Request("http://stats.test/api/v1/overview?range=24h"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(body.overall).toBeDefined();
+		expect((body.overall as Record<string, number>).totalRequests).toBe(1);
+	});
+});
+
+describe("API v1 errors endpoint", () => {
+	it("returns errors as MessageStats[]", async () => {
+		await initDb();
+		const now = Date.now();
+		insertMessageStats([makeError(now, "v1-err-1"), makeError(now - 1000, "v1-err-2")]);
+
+		const res = await handleApi(new Request("http://stats.test/api/v1/errors?limit=20"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as MessageStats[];
+		expect(Array.isArray(body)).toBe(true);
+		expect(body.length).toBe(2);
+		expect(body[0].entryId).toBe("v1-err-1");
+	});
+});
+
+describe("API v1 requests endpoint with real pagination", () => {
+	it("returns requests with real total count and offset", async () => {
+		await initDb();
+		const now = Date.now();
+		const msgs = Array.from({ length: 10 }, (_, i) => makeMessage(now - i * 1000, `v1-req-${i}`));
+		insertMessageStats(msgs);
+
+		const res = await handleApi(new Request("http://stats.test/api/v1/requests?limit=3&offset=0"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { requests: MessageStats[]; total: number };
+		expect(body.requests.length).toBe(3);
+		expect(body.total).toBe(10);
+		expect(body.requests[0].entryId).toBe("v1-req-0");
+
+		const page2 = await handleApi(new Request("http://stats.test/api/v1/requests?limit=3&offset=3"));
+		const body2 = (await page2.json()) as { requests: MessageStats[]; total: number };
+		expect(body2.requests.length).toBe(3);
+		expect(body2.total).toBe(10);
+		expect(body2.requests[0].entryId).toBe("v1-req-3");
+	});
+});
+
+describe("API v1 404 for unknown endpoint", () => {
+	it("returns 404 for unknown v1 endpoint", async () => {
+		const res = await handleApi(new Request("http://stats.test/api/v1/unknown"));
+		expect(res.status).toBe(404);
+		const body = (await res.json()) as Record<string, string>;
+		expect(body.error).toBe("Unknown v1 endpoint");
+	});
+});
+
+describe("API v1 CORS headers", () => {
+	it("returns CORS headers on v1 responses", async () => {
+		const res = await handleApi(new Request("http://stats.test/api/v1/meta"));
+		expect(res.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:3000");
+		expect(res.headers.get("Access-Control-Allow-Methods")).toBe("GET, OPTIONS");
+	});
+});
+
+describe("API v1 range parameter validation", () => {
+	it("rejects unknown range with 400", async () => {
+		const res = await handleApi(new Request("http://stats.test/api/v1/overview?range=invalid"));
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(String(body.error)).toContain("Invalid range");
+	});
+});

--- a/packages/stats/test/api-v1.test.ts
+++ b/packages/stats/test/api-v1.test.ts
@@ -123,6 +123,27 @@ describe("API v1 requests endpoint with real pagination", () => {
 		expect(body2.total).toBe(10);
 		expect(body2.requests[0].entryId).toBe("v1-req-3");
 	});
+
+	it("filters requests by range for both total and page", async () => {
+		await initDb();
+		const now = Date.now();
+		insertMessageStats([
+			makeMessage(now, "v1-range-recent"),
+			makeMessage(now - 48 * 60 * 60 * 1000, "v1-range-2d-old"),
+		]);
+
+		const res = await handleApi(new Request("http://stats.test/api/v1/requests?range=24h&limit=10&offset=0"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { requests: MessageStats[]; total: number };
+		expect(body.total).toBe(1);
+		expect(body.requests).toHaveLength(1);
+		expect(body.requests[0].entryId).toBe("v1-range-recent");
+
+		const all = await handleApi(new Request("http://stats.test/api/v1/requests?range=all&limit=10&offset=0"));
+		const bodyAll = (await all.json()) as { requests: MessageStats[]; total: number };
+		expect(bodyAll.total).toBe(2);
+		expect(bodyAll.requests).toHaveLength(2);
+	});
 });
 
 describe("API v1 404 for unknown endpoint", () => {

--- a/packages/stats/test/client-inner-view-models.test.ts
+++ b/packages/stats/test/client-inner-view-models.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "bun:test";
+import {
+	buildModelRows,
+	groupErrors,
+	normalizeErrorMessage,
+	providerFailureTone,
+	sortModelRows,
+	sortProviderRows,
+	sortRequests,
+} from "../src/client/data/view-models";
+import type { MessageStats, ModelStats, ProviderAggregate } from "../src/shared-types";
+
+function msg(
+	overrides: Partial<MessageStats> & { errorMessage: string | null; provider: string; model: string },
+): MessageStats {
+	return {
+		id: overrides.id ?? Math.floor(Math.random() * 100000),
+		sessionFile: "/tmp/test.jsonl",
+		entryId: "e1",
+		folder: "-tmp",
+		api: "openai-completions",
+		timestamp: overrides.timestamp ?? Date.now(),
+		duration: overrides.duration ?? 1000,
+		ttft: null,
+		stopReason: overrides.errorMessage ? "error" : "stop",
+		errorMessage: overrides.errorMessage,
+		provider: overrides.provider,
+		model: overrides.model,
+		usage: {
+			input: 10,
+			output: 10,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 20,
+			premiumRequests: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		agentType: "main",
+	};
+}
+
+function modelStats(overrides: Partial<ModelStats> & { model: string; provider: string }): ModelStats {
+	return {
+		model: overrides.model,
+		provider: overrides.provider,
+		totalRequests: overrides.totalRequests ?? 1,
+		successfulRequests: overrides.successfulRequests ?? 1,
+		failedRequests: overrides.failedRequests ?? 0,
+		errorRate: overrides.errorRate ?? 0,
+		totalInputTokens: overrides.totalInputTokens ?? 100,
+		totalOutputTokens: overrides.totalOutputTokens ?? 50,
+		totalCacheReadTokens: overrides.totalCacheReadTokens ?? 0,
+		totalCacheWriteTokens: overrides.totalCacheWriteTokens ?? 0,
+		cacheRate: overrides.cacheRate ?? 0,
+		cacheSavings: overrides.cacheSavings ?? 0,
+		totalCost: overrides.totalCost ?? 0,
+		unpricedRequests: overrides.unpricedRequests ?? 0,
+		totalPremiumRequests: overrides.totalPremiumRequests ?? 0,
+		avgDuration: overrides.avgDuration ?? null,
+		avgTtft: overrides.avgTtft ?? null,
+		avgTokensPerSecond: overrides.avgTokensPerSecond ?? null,
+		firstTimestamp: 0,
+		lastTimestamp: 0,
+	};
+}
+
+describe("normalizeErrorMessage", () => {
+	it("collapses whitespace and takes first line", () => {
+		expect(normalizeErrorMessage("  403   Key limit   exceeded\nsecond line ignored  ")).toBe(
+			"403 Key limit exceeded",
+		);
+	});
+	it("returns Unknown error for null/empty", () => {
+		expect(normalizeErrorMessage(null)).toBe("Unknown error");
+		expect(normalizeErrorMessage("   ")).toBe("Unknown error");
+	});
+	it("truncates long messages to 160 chars", () => {
+		const long = "a".repeat(300);
+		expect(normalizeErrorMessage(long).length).toBeLessThanOrEqual(160);
+	});
+});
+
+describe("groupErrors", () => {
+	it("groups same provider+normalized message into one row with count", () => {
+		const messages = [
+			msg({ errorMessage: "403 Key limit exceeded", provider: "openrouter", model: "m1", timestamp: 1000 }),
+			msg({ errorMessage: "403   Key limit   exceeded  ", provider: "openrouter", model: "m1", timestamp: 2000 }),
+			msg({ errorMessage: "403 Key limit exceeded", provider: "openrouter", model: "m2", timestamp: 1500 }),
+			msg({ errorMessage: "Rate limit", provider: "openrouter", model: "m1", timestamp: 500 }),
+			msg({ errorMessage: null, provider: "openrouter", model: "m1", timestamp: 600 }),
+		];
+		const groups = groupErrors(messages, "error");
+		expect(groups.length).toBe(2);
+		const main = groups.find(g => g.signature === "403 Key limit exceeded");
+		expect(main?.count).toBe(3);
+		expect(main?.items.length).toBe(3);
+		// Within group, newest first
+		expect(main?.items[0].timestamp).toBe(2000);
+		expect(groups[0].count).toBeGreaterThanOrEqual(groups[1].count);
+	});
+	it("groupBy provider collapses distinct messages per provider", () => {
+		const messages = [
+			msg({ errorMessage: "A", provider: "openrouter", model: "m1" }),
+			msg({ errorMessage: "B", provider: "openrouter", model: "m1" }),
+			msg({ errorMessage: "C", provider: "anthropic", model: "m1" }),
+		];
+		const groups = groupErrors(messages, "provider");
+		expect(groups.length).toBe(2);
+		const openrouter = groups.find(g => g.signature === "openrouter");
+		expect(openrouter?.count).toBe(2);
+	});
+	it("groupBy model collapses across providers", () => {
+		const messages = [
+			msg({ errorMessage: "Error A", provider: "p1", model: "m1" }),
+			msg({ errorMessage: "Error B", provider: "p2", model: "m1" }),
+			msg({ errorMessage: "Error C", provider: "p1", model: "m2" }),
+		];
+		const groups = groupErrors(messages, "model");
+		expect(groups.length).toBe(2);
+		expect(groups.find(g => g.signature === "m1")?.count).toBe(2);
+	});
+});
+
+describe("sortModelRows", () => {
+	it("sorts by requests desc by default and toggles asc", () => {
+		const rows = buildModelRows([
+			modelStats({ model: "a", provider: "p", totalRequests: 10, totalCost: 5, cacheRate: 0.5, errorRate: 0.01 }),
+			modelStats({ model: "b", provider: "p", totalRequests: 30, totalCost: 1, cacheRate: 0.9, errorRate: 0.2 }),
+			modelStats({ model: "c", provider: "p", totalRequests: 20, totalCost: 10, cacheRate: 0.1, errorRate: 0 }),
+		]);
+		const byReqDesc = sortModelRows(rows, "requests", "desc");
+		expect(byReqDesc.map(r => r.model)).toEqual(["b", "c", "a"]);
+		const byReqAsc = sortModelRows(rows, "requests", "asc");
+		expect(byReqAsc.map(r => r.model)).toEqual(["a", "c", "b"]);
+		expect(sortModelRows(rows, "cost", "desc").map(r => r.model)).toEqual(["c", "a", "b"]);
+		expect(sortModelRows(rows, "cache", "desc").map(r => r.model)).toEqual(["b", "a", "c"]);
+	});
+	it("shares computed correctly", () => {
+		const rows = buildModelRows([
+			modelStats({ model: "a", provider: "p", totalRequests: 3 }),
+			modelStats({ model: "b", provider: "p", totalRequests: 1 }),
+		]);
+		expect(rows.find(r => r.model === "a")?.share).toBeCloseTo(0.75);
+		expect(rows.find(r => r.model === "b")?.share).toBeCloseTo(0.25);
+	});
+});
+
+describe("providerFailureTone", () => {
+	it("returns danger/warning/ok at thresholds", () => {
+		expect(providerFailureTone(0.09)).toBe("danger");
+		expect(providerFailureTone(0.08)).toBe("danger");
+		expect(providerFailureTone(0.05)).toBe("warning");
+		expect(providerFailureTone(0.03)).toBe("warning");
+		expect(providerFailureTone(0.02)).toBe("ok");
+		expect(providerFailureTone(0)).toBe("ok");
+	});
+});
+
+describe("sortProviderRows", () => {
+	it("sorts by failure rate correctly", () => {
+		const rows: ProviderAggregate[] = [
+			{
+				provider: "a",
+				totalRequests: 100,
+				failedRequests: 10,
+				models: 1,
+				totalInputTokens: 0,
+				totalOutputTokens: 0,
+				totalCacheReadTokens: 0,
+				totalCacheWriteTokens: 0,
+				totalTokens: 0,
+				totalCost: 0,
+				unpricedRequests: 0,
+				totalPremiumRequests: 0,
+				avgTokensPerSecond: null,
+			},
+			{
+				provider: "b",
+				totalRequests: 100,
+				failedRequests: 3,
+				models: 1,
+				totalInputTokens: 0,
+				totalOutputTokens: 0,
+				totalCacheReadTokens: 0,
+				totalCacheWriteTokens: 0,
+				totalTokens: 0,
+				totalCost: 0,
+				unpricedRequests: 0,
+				totalPremiumRequests: 0,
+				avgTokensPerSecond: null,
+			},
+			{
+				provider: "c",
+				totalRequests: 100,
+				failedRequests: 0,
+				models: 1,
+				totalInputTokens: 0,
+				totalOutputTokens: 0,
+				totalCacheReadTokens: 0,
+				totalCacheWriteTokens: 0,
+				totalTokens: 0,
+				totalCost: 0,
+				unpricedRequests: 0,
+				totalPremiumRequests: 0,
+				avgTokensPerSecond: null,
+			},
+		];
+		const sorted = sortProviderRows(rows, "failure", "desc");
+		expect(sorted.map(r => r.provider)).toEqual(["a", "b", "c"]);
+	});
+});
+
+describe("sortRequests", () => {
+	it("sorts by tokens and timestamp", () => {
+		const base = [
+			msg({ errorMessage: null, provider: "p", model: "m1", timestamp: 100 }) as MessageStats,
+			msg({ errorMessage: null, provider: "p", model: "m2", timestamp: 200 }) as MessageStats,
+		];
+		// tweak tokens
+		base[0].usage.totalTokens = 50;
+		base[0].usage.cost.total = 1;
+		base[0].duration = 1000;
+		base[1].usage.totalTokens = 200;
+		base[1].usage.cost.total = 5;
+		base[1].duration = 500;
+
+		expect(sortRequests(base, "tokens", "desc").map(m => m.model)).toEqual(["m2", "m1"]);
+		expect(sortRequests(base, "timestamp", "asc").map(m => m.model)).toEqual(["m1", "m2"]);
+		expect(sortRequests(base, "cost", "desc").map(m => m.model)).toEqual(["m2", "m1"]);
+		expect(sortRequests(base, "duration", "asc").map(m => m.model)).toEqual(["m2", "m1"]);
+	});
+});

--- a/packages/stats/test/client-range-today.test.ts
+++ b/packages/stats/test/client-range-today.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import { rangeMeta } from "../src/client/components/range-meta";
+import type { TimeRange } from "../src/client/types";
+
+describe("client range-meta today", () => {
+	it("exposes hourly bucketing like 24h", () => {
+		const today = rangeMeta("today" as TimeRange);
+		const day = rangeMeta("24h");
+		expect(today.bucketMs).toBe(day.bucketMs);
+		expect(today.bucketCount).toBe(24);
+		expect(today.tickFormat).toBe("HH:mm");
+		expect(today.windowLabel).toContain("midnight");
+		expect(today.trendLabel).toBe("Today");
+	});
+
+	it("keeps other ranges intact", () => {
+		expect(rangeMeta("1h").bucketCount).toBe(12);
+		expect(rangeMeta("7d").bucketMs).toBe(24 * 60 * 60 * 1000);
+		expect(rangeMeta("all").windowLabel).toBe("all time");
+	});
+});

--- a/packages/stats/test/dashboard-prefs.test.ts
+++ b/packages/stats/test/dashboard-prefs.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+
+// bun:test has no DOM; install a minimal localStorage before the module under
+// test reads it at import time.
+const backing = new Map<string, string>();
+const storageStub = {
+	getItem: (key: string) => (backing.has(key) ? backing.get(key)! : null),
+	setItem: (key: string, value: string) => void backing.set(key, String(value)),
+	removeItem: (key: string) => void backing.delete(key),
+	clear: () => void backing.clear(),
+};
+Object.defineProperty(globalThis, "localStorage", {
+	configurable: true,
+	value: storageStub,
+});
+
+import type { StatsDashboardPrefs } from "../src/client/data/dashboard-prefs";
+import { DEFAULT_PREFS, dashboardPrefsStore, validatePrefs, WIDGET_META } from "../src/client/data/dashboard-prefs";
+
+const STORAGE_KEY = "omp-stats-dashboard";
+
+afterEach(() => {
+	dashboardPrefsStore.flush();
+	vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+	localStorage.clear();
+	dashboardPrefsStore.reset();
+});
+
+function stored(): StatsDashboardPrefs | null {
+	dashboardPrefsStore.flush();
+	const raw = localStorage.getItem(STORAGE_KEY);
+	return raw === null ? null : (JSON.parse(raw) as StatsDashboardPrefs);
+}
+
+describe("dashboard prefs store", () => {
+	it("persists a visibility toggle and flips the preset to custom", () => {
+		dashboardPrefsStore.setWidgetVisible("feed", false);
+
+		const saved = stored();
+		expect(saved?.preset).toBe("custom");
+		expect(saved?.widgets.find(w => w.id === "feed")?.visible).toBe(false);
+		// Other widgets keep their default visibility.
+		expect(saved?.widgets.find(w => w.id === "throughput")?.visible).toBe(true);
+		// Order is unchanged.
+		expect(saved?.widgets.map(w => w.id)).toEqual(DEFAULT_PREFS.widgets.map(w => w.id));
+	});
+
+	it("reorders via moveWidget and persists explicit array order", () => {
+		dashboardPrefsStore.moveWidget("kpi-secondary", "up");
+
+		const saved = stored();
+		expect(saved?.widgets[0].id).toBe("kpi-secondary");
+		expect(saved?.widgets[1].id).toBe("kpi-primary");
+		expect(stored()?.preset).toBe("custom");
+	});
+
+	it("moveWidget at a list boundary keeps order but still records a manual edit", () => {
+		dashboardPrefsStore.moveWidget("kpi-primary", "up");
+		expect(stored()?.widgets.map(w => w.id)).toEqual(DEFAULT_PREFS.widgets.map(w => w.id));
+		expect(stored()?.preset).toBe("custom");
+	});
+
+	it("changes widget size without touching visibility or order", () => {
+		dashboardPrefsStore.setWidgetSize("agent-tokens", "wide");
+
+		const entry = stored()?.widgets.find(w => w.id === "agent-tokens");
+		expect(entry?.size).toBe("wide");
+		expect(entry?.visible).toBe(true);
+	});
+
+	it("reorderByIds applies a drag-drop permutation and appends unknown ids at the end", () => {
+		const defaults = DEFAULT_PREFS.widgets.map(w => w.id);
+		dashboardPrefsStore.reorderByIds([defaults[2], defaults[0]]);
+
+		const saved = stored();
+		expect(saved?.widgets.slice(0, 2).map(w => w.id)).toEqual([defaults[2], defaults[0]]);
+		expect(saved?.widgets.length).toBe(defaults.length);
+	});
+
+	it("applies a preset by writing its full widget arrangement", () => {
+		dashboardPrefsStore.setPreset("developer");
+
+		const saved = stored();
+		expect(saved?.preset).toBe("developer");
+		expect(saved?.widgets.find(w => w.id === "feed")?.visible).toBe(true);
+		expect(saved?.widgets.find(w => w.id === "feed")?.size).toBe("wide");
+		expect(saved?.widgets.find(w => w.id === "kpi-secondary")?.visible).toBe(false);
+		expect(saved?.widgets.find(w => w.id === "agent-tokens")?.visible).toBe(false);
+	});
+
+	it("selecting Custom keeps the current arrangement untouched", () => {
+		dashboardPrefsStore.setPreset("cost");
+		const costOrder = stored()?.widgets.map(w => w.id);
+
+		dashboardPrefsStore.setPreset("custom");
+
+		expect(stored()?.preset).toBe("custom");
+		expect(stored()?.widgets.map(w => w.id)).toEqual(costOrder);
+		expect(stored()?.preset).not.toBe("cost");
+	});
+
+	it("reset restores the exact default layout after arbitrary edits", () => {
+		dashboardPrefsStore.setPreset("developer");
+		dashboardPrefsStore.setWidgetSize("feed", "small");
+
+		dashboardPrefsStore.reset();
+
+		expect(stored()).toEqual({ version: 1, preset: "default", widgets: DEFAULT_PREFS.widgets });
+	});
+});
+
+describe("stored prefs validation", () => {
+	it("accepts a valid blob and preserves its widget order", () => {
+		const blob = {
+			version: 1,
+			preset: "custom",
+			widgets: [
+				{ id: "throughput", visible: false, size: "wide" },
+				{ id: "feed", visible: true, size: "small" },
+			],
+		};
+
+		const result = validatePrefs(blob);
+
+		expect(result?.preset).toBe("custom");
+		// User order is preserved; remaining default widgets are appended so
+		// an older layout still surfaces newly-added widgets.
+		expect(result?.widgets.slice(0, 2).map(w => w.id)).toEqual(["throughput", "feed"]);
+		expect(result?.widgets.length).toBe(DEFAULT_PREFS.widgets.length);
+	});
+
+	it("rejects non-objects, wrong versions, and unknown presets", () => {
+		expect(validatePrefs("nope")).toBeNull();
+		expect(validatePrefs(null)).toBeNull();
+		expect(validatePrefs([1, 2])).toBeNull();
+		expect(
+			validatePrefs({ version: 99, preset: "default", widgets: [{ id: "feed", visible: true, size: "small" }] }),
+		).toBeNull();
+		expect(
+			validatePrefs({ version: 1, preset: "galaxy-brain", widgets: [{ id: "feed", visible: true, size: "small" }] }),
+		).toBeNull();
+		expect(validatePrefs({ version: 1, preset: "default", widgets: [] })).toBeNull();
+	});
+
+	it("drops unknown widget ids but rejects duplicates and malformed entries", () => {
+		const droppedUnknown = validatePrefs({
+			version: 1,
+			preset: "default",
+			widgets: [
+				{ id: "holo-deck", visible: true, size: "small" },
+				{ id: "feed", visible: true, size: "small" },
+			],
+		});
+		expect(droppedUnknown?.widgets[0].id).toBe("feed");
+		expect(droppedUnknown?.widgets.length).toBe(DEFAULT_PREFS.widgets.length);
+
+		const duplicate = validatePrefs({
+			version: 1,
+			preset: "default",
+			widgets: [
+				{ id: "feed", visible: true, size: "small" },
+				{ id: "feed", visible: false, size: "small" },
+			],
+		});
+		expect(duplicate).toBeNull();
+
+		const badVisible = validatePrefs({
+			version: 1,
+			preset: "default",
+			widgets: [{ id: "feed", visible: "yes", size: "small" }],
+		});
+		expect(badVisible).toBeNull();
+
+		const badSize = validatePrefs({
+			version: 1,
+			preset: "default",
+			widgets: [{ id: "feed", visible: true, size: "gigantic" }],
+		});
+		expect(badSize).toBeNull();
+	});
+
+	it("splices widgets missing from an older layout so upgrades surface them", () => {
+		const result = validatePrefs({
+			version: 1,
+			preset: "default",
+			widgets: [{ id: "throughput", visible: true, size: "medium" }],
+		});
+
+		expect(result?.widgets[0].id).toBe("throughput"); // user order preserved
+		expect(result?.widgets.length).toBe(DEFAULT_PREFS.widgets.length); // rest appended
+	});
+
+	it("exposes display metadata for every widget id", () => {
+		for (const def of DEFAULT_PREFS.widgets) {
+			expect(WIDGET_META[def.id].title.length).toBeGreaterThan(0);
+			expect(WIDGET_META[def.id].description.length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/packages/stats/test/errors-route-range.test.tsx
+++ b/packages/stats/test/errors-route-range.test.tsx
@@ -47,10 +47,11 @@ describe("ErrorsRoute range", () => {
 		installGlobal("Node", domWindow.Node);
 		installGlobal("Element", domWindow.Element);
 		installGlobal("HTMLElement", domWindow.HTMLElement);
+		installGlobal("HTMLSelectElement", Reflect.get(domWindow, "HTMLSelectElement"));
+		installGlobal("HTMLOptionElement", Reflect.get(domWindow, "HTMLOptionElement"));
 		installGlobal("HTMLIFrameElement", domWindow.HTMLIFrameElement);
 		installGlobal("SVGElement", domWindow.SVGElement);
 		installGlobal("IS_REACT_ACT_ENVIRONMENT", true);
-
 		const requestedUrls: string[] = [];
 		const fetchStub = Object.assign(
 			async (input: FetchInput, _init?: FetchInit) => {
@@ -68,14 +69,14 @@ describe("ErrorsRoute range", () => {
 		await act(async () => {
 			root?.render(<ErrorsRoute active range="24h" refreshTrigger={0} onRequestClick={() => {}} />);
 		});
-		expect(requestedUrls).toEqual(["/api/stats/errors?range=24h&limit=50"]);
+		expect(requestedUrls).toEqual(["/api/v1/errors?range=24h&limit=50"]);
 
 		await act(async () => {
 			root?.render(<ErrorsRoute active range="7d" refreshTrigger={0} onRequestClick={() => {}} />);
 		});
 		expect(requestedUrls).toEqual([
-			"/api/stats/errors?range=24h&limit=50",
-			"/api/stats/errors?range=7d&limit=50",
+			"/api/v1/errors?range=24h&limit=50",
+			"/api/v1/errors?range=7d&limit=50",
 		]);
 	});
 });

--- a/packages/stats/test/overview-empty-range.test.tsx
+++ b/packages/stats/test/overview-empty-range.test.tsx
@@ -1,0 +1,380 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { parseHTML } from "@oh-my-pi/pi-utils/dom";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { OverviewRoute } from "../src/client/routes/OverviewRoute";
+import type { OverviewStats } from "../src/client/types";
+
+type FetchInput = string | URL | Request;
+type FetchInit = RequestInit | BunFetchRequestInit;
+
+const originalGlobals = new Map<string, PropertyDescriptor | undefined>();
+let root: Root | null = null;
+
+function installGlobal(name: string, value: unknown): void {
+	originalGlobals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+	Object.defineProperty(globalThis, name, { configurable: true, value, writable: true });
+}
+
+function restoreGlobals(): void {
+	for (const [name, descriptor] of originalGlobals) {
+		if (descriptor) {
+			Object.defineProperty(globalThis, name, descriptor);
+		} else {
+			Reflect.deleteProperty(globalThis, name);
+		}
+	}
+	originalGlobals.clear();
+}
+
+function installFakeDom(): {
+	container: Element;
+	serialize: () => string;
+	window: typeof parseHTML extends (h: string) => infer W ? W : never;
+} {
+	const domWindow = parseHTML('<html><body><div id="root"></div></body></html>').window;
+	installGlobal("window", domWindow);
+	installGlobal("document", domWindow.document);
+	installGlobal("navigator", domWindow.navigator);
+	installGlobal("Node", domWindow.Node);
+	installGlobal("Element", domWindow.Element);
+	installGlobal("HTMLElement", domWindow.HTMLElement);
+	installGlobal("HTMLSelectElement", Reflect.get(domWindow, "HTMLSelectElement"));
+	installGlobal("HTMLOptionElement", Reflect.get(domWindow, "HTMLOptionElement"));
+	installGlobal("HTMLIFrameElement", domWindow.HTMLIFrameElement);
+	installGlobal("SVGElement", domWindow.SVGElement);
+	installGlobal("getComputedStyle", (el: unknown) => domWindow.getComputedStyle(el as never));
+	installGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+	const container = domWindow.document.getElementById("root") as unknown as Element;
+	if (!container) throw new Error("Expected test root");
+	return { container, serialize: () => domWindow.document.body.innerHTML, window: domWindow };
+}
+
+afterEach(async () => {
+	const activeRoot = root;
+	if (activeRoot) {
+		await act(async () => {
+			activeRoot.unmount();
+		});
+		root = null;
+	}
+	vi.restoreAllMocks();
+	restoreGlobals();
+});
+
+function emptyOverview(): OverviewStats {
+	return {
+		overall: {
+			totalRequests: 0,
+			successfulRequests: 0,
+			failedRequests: 0,
+			errorRate: 0,
+			totalInputTokens: 0,
+			totalOutputTokens: 0,
+			totalCacheReadTokens: 0,
+			totalCacheWriteTokens: 0,
+			cacheRate: 0,
+			cacheSavings: 0,
+			totalCost: 0,
+			unpricedRequests: 0,
+			totalPremiumRequests: 0,
+			avgDuration: null,
+			avgTtft: null,
+			avgTokensPerSecond: null,
+			firstTimestamp: 0,
+			lastTimestamp: 0,
+		},
+		byAgentType: [],
+		timeSeries: [],
+	};
+}
+
+const EMPTY_PAYLOADS = {
+	"/api/v1/overview": emptyOverview(),
+	"/api/v1/models": { byModel: [], modelSeries: [], modelPerformanceSeries: [] },
+	"/api/v1/providers": { providers: [], hourly: [], series: [], usageSeries: [], windowInsights: [] },
+	"/api/v1/tools": { byTool: [], byToolModel: [], series: [] },
+	"/api/v1/projects": [],
+	"/api/v1/errors": [],
+	"/api/v1/requests": { requests: [], total: 0 },
+};
+
+const SECTION_TITLES = [
+	"Token breakdown",
+	"Token usage by agent",
+	"Models — share of requests",
+	"Cost and token share",
+	"Calls and error share",
+	"Projects",
+	"Live feed",
+	"Recent requests",
+	"Health · Recent errors",
+];
+
+function routeWithFetchStub(payloads: Record<string, unknown>): (input: FetchInput) => Promise<Response> {
+	return async (input: FetchInput) => {
+		const url = input instanceof Request ? input.url : input.toString();
+		const path = url.split("?")[0];
+		const payload = payloads[path];
+		if (payload === undefined) throw new Error(`Unexpected fetch: ${url}`);
+		return Response.json(payload);
+	};
+}
+
+async function renderOverview(payloads: Record<string, unknown>): Promise<{ serialize: () => string }> {
+	const { container, serialize } = installFakeDom();
+	const fetchStub = Object.assign(routeWithFetchStub(payloads), { preconnect: globalThis.fetch.preconnect });
+	vi.spyOn(globalThis, "fetch").mockImplementation(fetchStub);
+	root = createRoot(container);
+	await act(async () => {
+		root?.render(<OverviewRoute active range="24h" refreshTrigger={0} onRequestClick={() => {}} />);
+	});
+	return { serialize };
+}
+
+describe("OverviewRoute empty sections", () => {
+	it("renders no section chrome when every payload is empty", async () => {
+		const { serialize } = await renderOverview(EMPTY_PAYLOADS);
+		const html = serialize();
+
+		// The hero and the KPI tape are unconditional and must still render.
+		expect(html).toContain("Overview");
+		expect(html).toContain("Key metrics");
+
+		// Data-backed sections must vanish entirely — no headers, no rules, no chrome.
+		for (const title of SECTION_TITLES) {
+			expect(html).not.toContain(title);
+		}
+	});
+
+	it("renders section headers when the same payloads carry data", async () => {
+		const models = {
+			byModel: [
+				{
+					model: "gpt-5.5",
+					provider: "openai-codex",
+					totalRequests: 4,
+					successfulRequests: 4,
+					failedRequests: 0,
+					errorRate: 0,
+					totalInputTokens: 100,
+					totalOutputTokens: 50,
+					totalCacheReadTokens: 0,
+					totalCacheWriteTokens: 0,
+					cacheRate: 0,
+					cacheSavings: 0,
+					totalCost: 0.02,
+					unpricedRequests: 0,
+					totalPremiumRequests: 0,
+					avgDuration: 1000,
+					avgTtft: 100,
+					avgTokensPerSecond: 20,
+					firstTimestamp: 1,
+					lastTimestamp: 2,
+				},
+			],
+			modelSeries: [],
+			modelPerformanceSeries: [],
+		};
+		const overview = emptyOverview();
+		overview.overall.totalInputTokens = 100;
+		overview.overall.totalOutputTokens = 50;
+		overview.byAgentType = [
+			{
+				agentType: "main",
+				totalRequests: 4,
+				totalInputTokens: 100,
+				totalOutputTokens: 50,
+				totalCacheReadTokens: 0,
+				totalCacheWriteTokens: 0,
+				totalCost: 0.02,
+			},
+		];
+		const request = {
+			id: 7,
+			sessionFile: "s.jsonl",
+			entryId: "e1",
+			folder: "/tmp",
+			model: "gpt-5.5",
+			provider: "openai-codex",
+			api: "openai",
+			timestamp: Date.now(),
+			duration: 1000,
+			ttft: 100,
+			stopReason: "end_turn",
+			errorMessage: null,
+			usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, totalTokens: 15, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.001 } },
+		};
+		const { serialize } = await renderOverview({
+			...EMPTY_PAYLOADS,
+			"/api/v1/overview": overview,
+			"/api/v1/models": models,
+			"/api/v1/providers": {
+				providers: [
+					{
+						provider: "openai-codex",
+						totalRequests: 100,
+						failedRequests: 0,
+						models: 1,
+						totalInputTokens: 700,
+						totalOutputTokens: 50,
+						totalCacheReadTokens: 0,
+						totalCacheWriteTokens: 0,
+						totalTokens: 750,
+						totalCost: 1,
+						unpricedRequests: 0,
+						totalPremiumRequests: 0,
+						avgTokensPerSecond: 30,
+					},
+				],
+				hourly: [],
+				series: [],
+				usageSeries: [],
+				windowInsights: [],
+			},
+			"/api/v1/tools": {
+				byTool: [
+					{
+						tool: "bash",
+						calls: 2,
+						errors: 0,
+						argsChars: 10,
+						resultChars: 20,
+						totalTokensShare: 30,
+						outputTokensShare: 10,
+						costShare: 0.001,
+						unpricedRequestsShare: 0,
+						lastUsed: Date.now(),
+					},
+				],
+				byToolModel: [],
+				series: [],
+			},
+			"/api/v1/projects": [
+				{
+					folder: "/tmp/proj",
+					totalRequests: 4,
+					successfulRequests: 4,
+					failedRequests: 0,
+					errorRate: 0,
+					totalInputTokens: 100,
+					totalOutputTokens: 50,
+					totalCacheReadTokens: 0,
+					totalCacheWriteTokens: 0,
+					cacheRate: 0,
+					cacheSavings: 0,
+					totalCost: 0.02,
+					unpricedRequests: 0,
+					totalPremiumRequests: 0,
+					avgDuration: 1000,
+					avgTtft: 100,
+					avgTokensPerSecond: 20,
+					firstTimestamp: 1,
+					lastTimestamp: 2,
+				},
+			],
+			"/api/v1/errors": [request],
+			"/api/v1/requests": { requests: [request], total: 1 },
+		});
+		const html = serialize();
+		for (const title of SECTION_TITLES) {
+			expect(html).toContain(title);
+		}
+	});
+});
+
+describe("OverviewRoute provider share bars", () => {
+	it("sizes each provider bar by its token share of the displayed providers", async () => {
+		const providers = [
+			{
+				provider: "openai-codex",
+				totalRequests: 100,
+				failedRequests: 0,
+				models: 1,
+				totalInputTokens: 700,
+				totalOutputTokens: 50,
+				totalCacheReadTokens: 0,
+				totalCacheWriteTokens: 0,
+				totalTokens: 750,
+				totalCost: 1,
+				unpricedRequests: 0,
+				totalPremiumRequests: 0,
+				avgTokensPerSecond: 30,
+			},
+			{
+				provider: "anthropic",
+				totalRequests: 50,
+				failedRequests: 0,
+				models: 1,
+				totalInputTokens: 200,
+				totalOutputTokens: 50,
+				totalCacheReadTokens: 0,
+				totalCacheWriteTokens: 0,
+				totalTokens: 250,
+				totalCost: 0.5,
+				unpricedRequests: 0,
+				totalPremiumRequests: 0,
+				avgTokensPerSecond: 25,
+			},
+		];
+		const { serialize } = await renderOverview({
+			...EMPTY_PAYLOADS,
+			"/api/v1/providers": { providers, hourly: [], series: [], usageSeries: [], windowInsights: [] },
+		});
+		const html = serialize();
+		// 750 / (750+250) and 250 / (750+250): unequal bars, neither hard-coded 100%.
+		expect(html).toContain('title="75.0% of provider tokens"');
+		expect(html).toContain('title="25.0% of provider tokens"');
+	});
+});
+
+describe("OverviewRoute request row keyboard affordance", () => {
+	it("marks clickable recent-request rows as focusable buttons", async () => {
+		const now = Date.now();
+		const request = {
+			id: 7,
+			sessionFile: "s.jsonl",
+			entryId: "e1",
+			folder: "/tmp",
+			model: "gpt-5.5",
+			provider: "openai-codex",
+			api: "openai",
+			timestamp: now,
+			duration: 1000,
+			ttft: 100,
+			stopReason: "end_turn",
+			errorMessage: null,
+			usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, totalTokens: 15, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.001 } },
+		};
+		const { container, serialize, window: domWindow } = installFakeDom();
+		const fetchStub = Object.assign(
+			routeWithFetchStub({
+				...EMPTY_PAYLOADS,
+				"/api/v1/requests": { requests: [request], total: 1 },
+			}),
+			{ preconnect: globalThis.fetch.preconnect },
+		);
+		vi.spyOn(globalThis, "fetch").mockImplementation(fetchStub);
+		const clicked: number[] = [];
+		root = createRoot(container);
+		await act(async () => {
+			root?.render(<OverviewRoute active range="24h" refreshTrigger={0} onRequestClick={id => clicked.push(id)} />);
+		});
+
+		const html = serialize();
+		expect(html).toContain('role="button"');
+		expect(html).toContain('tabindex="0"');
+
+		// Enter on a live-feed row opens the request drawer.
+		const buttons = container.querySelectorAll('[role="button"]');
+		expect(buttons.length).toBeGreaterThan(0);
+		const liveRow = [...buttons].find(el => el.textContent?.includes("gpt-5.5"));
+		expect(liveRow).toBeDefined();
+		const event = new domWindow.Event("keydown", { bubbles: true, cancelable: true });
+		Object.assign(event, { key: "Enter" });
+		await act(async () => {
+			liveRow?.dispatchEvent(event as Event);
+		});
+		expect(clicked).toEqual([7]);
+	});
+});

--- a/packages/stats/test/overview-prefs.test.ts
+++ b/packages/stats/test/overview-prefs.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test";
+import {
+	activeDaysFromSeries,
+	loadPrefs,
+	nextPrefsOnToggle,
+	PRESET_DEFS,
+	prefsForPreset,
+	SECTION_ORDER,
+	STORAGE_KEY,
+} from "../src/client/data/overview-prefs";
+
+function fakeStorage(initial: Record<string, string> = {}) {
+	const store = new Map(Object.entries(initial));
+	return {
+		getItem: (k: string) => store.get(k) ?? null,
+		setItem: (k: string, v: string) => store.set(k, v),
+		_store: store,
+	};
+}
+
+describe("activeDaysFromSeries", () => {
+	it("counts distinct calendar days with requests", () => {
+		const day = 24 * 60 * 60 * 1000;
+		const now = Date.now();
+		// Normalize to midnight boundaries for determinism
+		const d0 = new Date(now);
+		d0.setHours(0, 0, 0, 0);
+		const t0 = d0.getTime();
+		const series = [
+			{ timestamp: t0 + 1000, requests: 3 },
+			{ timestamp: t0 + day + 1000, requests: 2 },
+			{ timestamp: t0 + day * 2 + 1000, requests: 0 },
+		];
+		expect(activeDaysFromSeries(series)).toBe(2);
+	});
+
+	it("returns 0 for empty or all-zero series", () => {
+		expect(activeDaysFromSeries([])).toBe(0);
+		expect(activeDaysFromSeries([{ timestamp: Date.now(), requests: 0 }])).toBe(0);
+		expect(activeDaysFromSeries(undefined)).toBe(0);
+	});
+});
+
+describe("overview prefs persistence", () => {
+	it("defaults to Default preset when storage empty", () => {
+		const storage = fakeStorage();
+		const prefs = loadPrefs(storage as never);
+		expect(prefs.preset).toBe("default");
+		expect(prefs.visible).toEqual(PRESET_DEFS.default.visible);
+	});
+
+	it("restores persisted visibility and preserves preset", () => {
+		const custom = { preset: "tokens" as const, visible: PRESET_DEFS.tokens.visible };
+		const storage = fakeStorage({ [STORAGE_KEY]: JSON.stringify(custom) });
+		const prefs = loadPrefs(storage as never);
+		expect(prefs).toEqual(custom);
+	});
+
+	it("toggles a section and flips to custom when diverging from preset", () => {
+		const start = prefsForPreset("default");
+		const next = nextPrefsOnToggle(start, "tokens");
+		expect(next.visible.tokens).toBe(false);
+		expect(next.preset).toBe("custom");
+	});
+
+	it("returns to a named preset when toggling back to its exact shape", () => {
+		// Default -> toggle tokens off -> custom -> toggle tokens on -> back to default
+		let prefs = prefsForPreset("default");
+		prefs = nextPrefsOnToggle(prefs, "tokens");
+		expect(prefs.preset).toBe("custom");
+		prefs = nextPrefsOnToggle(prefs, "tokens");
+		expect(prefs.preset).toBe("default");
+		expect(prefs.visible).toEqual(PRESET_DEFS.default.visible);
+	});
+
+	it("prefsForPreset produces an independent copy", () => {
+		const a = prefsForPreset("default");
+		const b = prefsForPreset("default");
+		a.visible.tape = false;
+		expect(b.visible.tape).toBe(true);
+	});
+
+	it("recovers gracefully from corrupt JSON", () => {
+		const storage = fakeStorage({ [STORAGE_KEY]: "{not-json" });
+		const prefs = loadPrefs(storage as never);
+		expect(prefs.preset).toBe("default");
+	});
+
+	it("ignores unknown keys in persisted visible", () => {
+		const storage = fakeStorage({
+			[STORAGE_KEY]: JSON.stringify({ preset: "default", visible: { tape: false, bogus: true } }),
+		});
+		const prefs = loadPrefs(storage as never);
+		expect(prefs.visible.tape).toBe(false);
+		// bogus key should not leak into the returned visible
+		expect((prefs.visible as Record<string, unknown>).bogus).toBeUndefined();
+		// other keys fall back to default
+		for (const k of SECTION_ORDER) if (k !== "tape") expect(prefs.visible[k]).toBe(true);
+	});
+});

--- a/packages/stats/test/overview-prefs.test.ts
+++ b/packages/stats/test/overview-prefs.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import {
 	activeDaysFromSeries,
+	DASHBOARD_STORAGE_KEY,
+	defaultDashboards,
+	loadDashboardState,
 	loadPrefs,
 	nextPrefsOnToggle,
 	PRESET_DEFS,
@@ -96,5 +99,62 @@ describe("overview prefs persistence", () => {
 		expect((prefs.visible as Record<string, unknown>).bogus).toBeUndefined();
 		// other keys fall back to default
 		for (const k of SECTION_ORDER) if (k !== "tape") expect(prefs.visible[k]).toBe(true);
+	});
+
+	it("defaults live feed and recent requests to visible in every section", () => {
+		for (const key of ["liveFeed", "recentRequests"]) {
+			expect(SECTION_ORDER).toContain(key);
+			expect(PRESET_DEFS.default.visible[key as keyof typeof PRESET_DEFS.default.visible]).toBe(true);
+		}
+		// Focus presets intentionally hide the unconditional request panels.
+		expect(PRESET_DEFS.tokens.visible.liveFeed).toBe(false);
+		expect(PRESET_DEFS.tokens.visible.recentRequests).toBe(false);
+	});
+
+	it("migrates legacy prefs missing the new sections to visible", () => {
+		// A record saved before liveFeed/recentRequests existed: only old keys.
+		const legacyVisible: Record<string, boolean> = {};
+		for (const k of SECTION_ORDER) {
+			if (k === "liveFeed" || k === "recentRequests") continue;
+			legacyVisible[k] = k !== "tape";
+		}
+		const storage = fakeStorage({ [STORAGE_KEY]: JSON.stringify({ preset: "custom", visible: legacyVisible }) });
+		const prefs = loadPrefs(storage as never);
+		expect(prefs.visible.tape).toBe(false);
+		expect(prefs.visible.liveFeed).toBe(true);
+		expect(prefs.visible.recentRequests).toBe(true);
+	});
+
+	it("migrates legacy dashboard records missing the new sections to visible", () => {
+		const legacyDash = {
+			id: "custom",
+			name: "My Dashboard",
+			visible: {
+				tape: false,
+				scope: true,
+				models: true,
+				providers: true,
+				tokens: true,
+				agents: true,
+				tools: true,
+				projects: true,
+				errors: true,
+			},
+			createdAt: 42,
+		};
+		const storage = fakeStorage({
+			[DASHBOARD_STORAGE_KEY]: JSON.stringify({ activeId: "custom", dashboards: [legacyDash] }),
+		});
+		const state = loadDashboardState(storage as never);
+		expect(state.dashboards[0].visible.tape).toBe(false);
+		expect(state.dashboards[0].visible.liveFeed).toBe(true);
+		expect(state.dashboards[0].visible.recentRequests).toBe(true);
+	});
+
+	it("default dashboards carry the new sections", () => {
+		for (const dash of defaultDashboards()) {
+			expect(dash.visible.liveFeed).toBeTypeOf("boolean");
+			expect(dash.visible.recentRequests).toBeTypeOf("boolean");
+		}
 	});
 });

--- a/packages/stats/test/time-range-today.test.ts
+++ b/packages/stats/test/time-range-today.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { getTimeRangeConfig } from "@oh-my-pi/omp-stats/aggregator";
+
+describe("getTimeRangeConfig 'today'", () => {
+	it("anchors the cutoff at local midnight with hourly buckets", () => {
+		const config = getTimeRangeConfig("today");
+		const midnight = new Date();
+		midnight.setHours(0, 0, 0, 0);
+
+		expect(config.cutoff).toBe(midnight.getTime());
+		// Hourly bucketing like "24h" — a same-day window still yields an
+		// intra-day series.
+		expect(config.timeSeriesBucketMs).toBe(60 * 60 * 1000);
+	});
+
+	it("is case-insensitive and trims input like other ranges", () => {
+		const config = getTimeRangeConfig("  TODAY ");
+		const midnight = new Date();
+		midnight.setHours(0, 0, 0, 0);
+		expect(config.cutoff).toBe(midnight.getTime());
+	});
+
+	it("keeps rolling-window ranges distinct from today", () => {
+		const rolling = getTimeRangeConfig("24h");
+		const today = getTimeRangeConfig("today");
+		// Rolling cutoff is now-minus-24h; local midnight always falls inside
+		// that window, so today's cutoff must be at or after it.
+		expect(rolling.cutoff).not.toBeNull();
+		expect(today.cutoff).not.toBeNull();
+		expect(today.cutoff!).toBeGreaterThanOrEqual(rolling.cutoff!);
+	});
+
+	it("still resolves the known rolling ranges", () => {
+		expect(getTimeRangeConfig("7d").timeSeriesBucketMs).toBe(24 * 60 * 60 * 1000);
+		expect(getTimeRangeConfig("all").cutoff).toBeNull();
+	});
+});

--- a/packages/stats/test/today-bucket-tz.test.ts
+++ b/packages/stats/test/today-bucket-tz.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test";
+import { getDashboardStats } from "@oh-my-pi/omp-stats/aggregator";
+import { initDb, insertMessageStats } from "@oh-my-pi/omp-stats/db";
+import type { MessageStats } from "@oh-my-pi/omp-stats/types";
+import { installStatsTestIsolation } from "./helpers/temp-agent";
+
+installStatsTestIsolation("@pi-stats-today-origin-");
+
+const HOUR_MS = 60 * 60 * 1000;
+
+function makeMessage(timestamp: number, entryId: string): MessageStats {
+	return {
+		sessionFile: "/tmp/session.jsonl",
+		entryId,
+		folder: "/tmp/project",
+		model: "gpt-5.4",
+		provider: "openai-codex",
+		api: "openai-codex-responses",
+		timestamp,
+		duration: 1000,
+		ttft: 100,
+		stopReason: "stop",
+		errorMessage: null,
+		usage: {
+			input: 1000,
+			output: 500,
+			cacheRead: 200,
+			cacheWrite: 0,
+			totalTokens: 1700,
+			cost: { input: 0.01, output: 0.02, cacheRead: 0.001, cacheWrite: 0, total: 0.031 },
+		},
+		agentType: "main",
+	};
+}
+
+/**
+ * Mirrors the client's `activeDaysFromSeries` (OverviewRoute): distinct local
+ * dates among buckets carrying requests.
+ */
+function activeDaysFromSeries(series: { timestamp: number; requests: number }[]): number {
+	const days = new Set<string>();
+	for (const pt of series) if (pt.requests > 0) days.add(new Date(pt.timestamp).toDateString());
+	return days.size;
+}
+
+describe("today range bucket alignment in fractional-UTC timezone", () => {
+	it("labels just-after-midnight requests in local-midnight-aligned buckets and counts one active day", async () => {
+		// Asia/Kolkata is UTC+05:30: an epoch-aligned hourly bucket at local
+		// 00:10 would be stamped 23:30 of the previous local day, mislabeling
+		// the Today chart and double-counting active days. The today range
+		// must anchor buckets at local midnight instead.
+		const previousTz = process.env.TZ;
+		process.env.TZ = "Asia/Kolkata";
+		try {
+			await initDb();
+			expect(new Date().getTimezoneOffset()).toBe(-330);
+
+			const midnight = new Date();
+			midnight.setHours(0, 0, 0, 0);
+			const early = midnight.getTime() + 10 * 60 * 1000; // local 00:10 today
+			const later = midnight.getTime() + 40 * 60 * 1000; // local 00:40 today
+
+			// Sanity: the fixtures really are just after local midnight in the
+			// test timezone, and epoch-aligned buckets would fall on the
+			// previous local day.
+			expect(early).toBeGreaterThan(midnight.getTime());
+			expect(later).toBeGreaterThan(midnight.getTime());
+			const epochBucket = Math.floor(early / HOUR_MS) * HOUR_MS;
+			expect(new Date(epochBucket).toDateString()).not.toBe(new Date(early).toDateString());
+
+			insertMessageStats([makeMessage(early, "today-early"), makeMessage(later, "today-later")]);
+
+			const stats = await getDashboardStats("today");
+
+			// Buckets are hour-aligned from local midnight (not from the Unix
+			// epoch, whose :30-UTC boundaries would stamp 23:30 here).
+			for (const point of stats.timeSeries) {
+				expect((point.timestamp - midnight.getTime()) % HOUR_MS).toBe(0);
+				expect(new Date(point.timestamp).toDateString()).toBe(new Date(early).toDateString());
+			}
+			// Both requests land in the same local-midnight-aligned bucket
+			// (00:00) and the chart counts exactly one active day.
+			expect(stats.timeSeries).toHaveLength(1);
+			expect(stats.timeSeries[0].requests).toBe(2);
+			expect(stats.timeSeries[0].timestamp).toBeGreaterThanOrEqual(midnight.getTime());
+			expect(activeDaysFromSeries(stats.timeSeries)).toBe(1);
+		} finally {
+			if (previousTz === undefined) delete process.env.TZ;
+			else process.env.TZ = previousTz;
+		}
+	});
+});

--- a/packages/stats/test/today-bucket-tz.test.ts
+++ b/packages/stats/test/today-bucket-tz.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { getDashboardStats } from "@oh-my-pi/omp-stats/aggregator";
-import { initDb, insertMessageStats } from "@oh-my-pi/omp-stats/db";
+import { getBehaviorDashboardStats, getCostDashboardStats, getDashboardStats } from "@oh-my-pi/omp-stats/aggregator";
+import { initDb, insertMessageStats, insertUserMessageStats } from "@oh-my-pi/omp-stats/db";
 import type { MessageStats } from "@oh-my-pi/omp-stats/types";
 import { installStatsTestIsolation } from "./helpers/temp-agent";
 
@@ -84,6 +84,62 @@ describe("today range bucket alignment in fractional-UTC timezone", () => {
 			expect(stats.timeSeries[0].requests).toBe(2);
 			expect(stats.timeSeries[0].timestamp).toBeGreaterThanOrEqual(midnight.getTime());
 			expect(activeDaysFromSeries(stats.timeSeries)).toBe(1);
+		} finally {
+			if (previousTz === undefined) delete process.env.TZ;
+			else process.env.TZ = previousTz;
+		}
+	});
+
+	it("keeps cost and behavior series on the same local-midnight hourly grid", async () => {
+		// The cost and behavior series previously kept a fixed 86400000 ms
+		// bucket width. With a local-midnight origin that stamps fractional-
+		// UTC zones on the wrong grid — and a DST-fallback local day spans 25
+		// elapsed hours, so fixed-width daily buckets split the last hour
+		// into a second, next-day-labeled bucket. Today must pass its hourly
+		// bucket width through to both series.
+		const previousTz = process.env.TZ;
+		process.env.TZ = "Asia/Kolkata";
+		try {
+			await initDb();
+			expect(new Date().getTimezoneOffset()).toBe(-330);
+			const midnight = new Date();
+			midnight.setHours(0, 0, 0, 0);
+			const early = midnight.getTime() + 10 * 60 * 1000; // local 00:10 today
+			insertMessageStats([makeMessage(early, "today-cost-early")]);
+			insertUserMessageStats([
+				{
+					sessionFile: "/tmp/session.jsonl",
+					entryId: "today-behavior-early",
+					folder: "/tmp/project",
+					timestamp: early,
+					model: "gpt-5.4",
+					provider: "openai-codex",
+					chars: 10,
+					words: 2,
+					yelling: 0,
+					profanity: 0,
+					anguish: 0,
+					negation: 0,
+					repetition: 0,
+					blame: 0,
+				},
+			]);
+
+			const [costStats, behaviorStats] = await Promise.all([
+				getCostDashboardStats("today"),
+				getBehaviorDashboardStats("today"),
+			]);
+
+			const midnightDate = new Date(early).toDateString();
+			for (const series of [costStats.costSeries, behaviorStats.behaviorSeries]) {
+				for (const point of series) {
+					// same local calendar day as the request that produced it.
+					expect((point.timestamp - midnight.getTime()) % HOUR_MS).toBe(0);
+					expect(new Date(point.timestamp).toDateString()).toBe(midnightDate);
+				}
+			}
+			expect(costStats.costSeries.length).toBeGreaterThan(0);
+			expect(behaviorStats.behaviorSeries.length).toBeGreaterThan(0);
 		} finally {
 			if (previousTz === undefined) delete process.env.TZ;
 			else process.env.TZ = previousTz;


### PR DESCRIPTION
## What

Supersedes #9681 (rebased onto current main, head branch `stats-dashboard-redesign` replaced by `feat/stats-dashboard` on this fork).

Ground-up rework of the `/stats` overview page as a quiet instrument panel: flat hairline panels, monospace tabular numerals, color reserved for meaning. KPI tape, usage-over-time chart, token/agent/model/provider/tool/project/error sections, live request feed; per-section show/hide persisted in localStorage with presets; a new `today` range (local-midnight cutoff) wired through aggregator, server API, and range picker; plus a versioned public query API (`/api/v1/*`) with a framework-neutral SDK and `omp stats create-site` scaffolding.

## Changes vs #9681 (remaining round-3 findings addressed)

- **KPI tape visibility** — disabling "KPI tape" in Manage now hides the metrics block (`v.tape` gate).
- **Section composition** — Recent errors and Live feed render outside the Usage-over-time gate, so hiding the scope chart no longer hides independently configurable sections.
- **Legacy API pagination** — the v1→legacy fallback fetches `offset + limit` rows; page 2 was previously empty and `total` claimed the fetched prefix length.
- **DST-fallback daily buckets** — `getCostTimeSeries`/`getBehaviorTimeSeries` take a `bucketMs` parameter and the aggregator threads the Today range's hourly width through; a fixed 24h width with a local-midnight origin previously split a 25-hour fallback day into a next-day-labeled second bucket.
- **Day counting** — costs day displays and `buildCostSummary` count distinct local calendar days (`toDateString`), not distinct bucket timestamps (hourly Today buckets would have reported 24 "days").
- Extended `today-bucket-tz.test.ts` regression: cost and behavior series must stay on the local-midnight hourly grid under `Asia/Kolkata`.

Also resolved transplant conflicts: main's Traces styles/route helpers and `getSessionRollups`/`getToolCallCountsBySession` (Traces feature) are preserved alongside the redesign.

## Why

#9681 was held at review:p3; its final round left four blocking contract violations and one should-fix. This branch lands the redesign on current main with those fixed and the Traces-era styles coexisting.

<!-- one sentence in your own words required here per CONTRIBUTING.md -->

## Testing

- `tsgo` clean for the stats package; oxlint/oxfmt clean on changed files.
- 188/189 stats tests pass; the single failure (`fork-dedup` — forked provider-request counting) reproduces identically on pristine `main` and predates this branch.
- `today-bucket-tz.test.ts` extended: the new case inserts both a message and a user message at local 00:10 under `TZ=Asia/Kolkata` and asserts cost + behavior series points land on the local-midnight hourly grid and the same local calendar day.
- Stats client builds (`bun run build.ts`) after the styles merge.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)
