### PR TITLE
docs(hooks): document pre/post discovery location for hook factories

### DIFF
--- a/docs/extension-loading.md
+++ b/docs/extension-loading.md
@@ -44,7 +44,7 @@ Notes:
 
 ### 2) Discovered JS/TS hook factories
 
-After native auto-discovery, `discoverAndLoadExtensions()` also appends JS/TS hook factories from the `hook` capability — any hook whose entry path is a `.ts`/`.js` file — so they load through the same module pipeline.
+After native auto-discovery, `discoverAndLoadExtensions()` also appends JS/TS hook factories from the `hook` capability — any hook whose entry path is a `.ts`/`.js` file — so they load through the same module pipeline. The native provider discovers these under `<cwd>/.omp/hooks/pre|post/` and `<agentDir>/hooks/pre|post/` only; see [Hooks: native discovery location](./hooks.md#native-discovery-location) for the required `pre/`/`post/` layout.
 
 Hook-capability loading already applies its own hook-specific disabled ids, so these paths are not additionally filtered by `disabledExtensions` extension-module names.
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -59,6 +59,15 @@ Default sessions load JS/TS hook factories discovered by `hookCapability` throug
 3. Append plugin extension entry points
 4. Append explicitly configured paths
 
+### Native discovery location
+
+The native provider scans only two subdirectories per config root — a factory placed **directly** in `hooks/` is not discovered:
+
+- Project: `<cwd>/.omp/hooks/pre/*.{ts,js}` and `<cwd>/.omp/hooks/post/*.{ts,js}`
+- User: `<agentDir>/hooks/pre/*.{ts,js}` and `<agentDir>/hooks/post/*.{ts,js}` (default `~/.omp/agent/hooks/...`; profile- and `PI_CODING_AGENT_DIR`-aware)
+
+So `<cwd>/.omp/hooks/psy-guards.ts` (no `pre/`/`post/` subdirectory) loads nothing and reports no error — move it into `pre/` or `post/`, e.g. `<cwd>/.omp/hooks/pre/psy-guards.ts`. This mirrors `.claude/hooks/pre|post/`. Only `.ts`/`.js` factories are appended to the extension pipeline and bound through the extension runner. See [Extension Loading](./extension-loading.md) for the shared module pipeline these factories flow through (native `.omp/extensions/` roots, plugin entries, configured paths, load order, and disable controls).
+
 The legacy `discoverAndLoadHooks(configuredPaths, cwd)` helper still exists and does:
 
 1. Load discovered hooks from capability registry (`loadCapability("hooks")`)

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Documented that native JS/TS hook factories must live in `.omp/hooks/pre/` or `.omp/hooks/post/` (not directly in `.omp/hooks/`), and cross-linked the hooks and extension-loading docs ([#11942](https://github.com/can1357/oh-my-pi/issues/11942)).
+
 ## [18.1.19] - 2026-09-12
 
 - Fixed `--mode json` returning exit 0 on a turn-fatal provider/auth/network error ([#11498](https://github.com/can1357/oh-my-pi/issues/11498)).


### PR DESCRIPTION
## Repro
A reporter placed a JS/TS hook factory at `<project>/.omp/hooks/psy-guards.ts` and it was silently never imported. Driving the production discovery functions a real session uses (native `hookCapability` discovery + `discoverAndLoadExtensions([], cwd)`) against a project containing `.omp/hooks/pre/psy-guards.ts`, `.omp/hooks/psy-direct.ts`, and `.omp/extensions/psy-ext.ts` shows: `.omp/hooks/pre/psy-guards.ts` is discovered, loaded as an extension, and its module-level side effect fires (`module side-effect fired: true`); `.omp/extensions/psy-ext.ts` loads; but `.omp/hooks/psy-direct.ts` (directly under `hooks/`, no `pre/`/`post/` subdir) is absent from both the discovered-hook and loaded-extension lists.

## Cause
The native provider `loadHooks` in `packages/coding-agent/src/discovery/builtin.ts` only walks `<dir>/hooks/pre` and `<dir>/hooks/post` per config root (project `<cwd>/.omp` and user `getAgentDir()`); it does not scan files placed directly in `hooks/`. This mirrors `.claude/hooks/pre|post/`. `docs/hooks.md` never stated this required subdirectory structure or the on-disk discovery roots — the only mention was a lone parenthetical `.omp/hooks/pre/*.ts` — and did not cross-link `docs/extension-loading.md`, so a factory dropped in `.omp/hooks/` loads nothing with no error and the contract is undiscoverable. The documented example itself is correct and was left unchanged.

## Fix
- `docs/hooks.md`: add a `Native discovery location` subsection listing the project (`<cwd>/.omp/hooks/pre|post/`) and user (`<agentDir>/hooks/pre|post/`) roots, stating that files placed directly in `hooks/` are not discovered, and that only `.ts`/`.js` factories bind through the extension runner; cross-link `extension-loading.md`.
- `docs/extension-loading.md`: note the `hooks/pre|post/` discovery roots in the JS/TS hook-factory section and cross-link back to the new hooks anchor.
- `packages/coding-agent/CHANGELOG.md`: add an `[Unreleased]` note.

## Verification
Ran the discovery repro described above through the real production functions (`loadCapability(hookCapability.id)` + `discoverAndLoadExtensions`); confirmed the `pre/` factory loads and fires end-to-end while the direct-`hooks/` file is not discovered. Docs re-read after edit; the new `#native-discovery-location` anchor matches the cross-link. No behavior change — documentation only. Fixes #11942