### PR TITLE
fix(tui): prevent conpty status-line scroll leaks

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Stopped exact-width live rows from entering native scrollback during ConPTY repaints ([#9783](https://github.com/can1357/oh-my-pi/issues/9783)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2735,7 +2735,7 @@ export class TUI extends Container {
 			buffer += `\x1b[${startTop + 1};1H`;
 			let screenRow = startTop;
 			for (let index = 0; index < preparedHistory.length; index++) {
-				if (screenRow > startTop) buffer += "\r\n";
+				if (screenRow > startTop) buffer += "\n";
 				buffer += this.#lineRewriteSequence(
 					preparedHistory[index] ?? "",
 					width,
@@ -2747,7 +2747,7 @@ export class TUI extends Container {
 				screenRow++;
 			}
 			for (let index = 0; index < rows; index++) {
-				if (screenRow > startTop) buffer += "\r\n";
+				if (screenRow > startTop) buffer += "\n";
 				buffer += this.#lineRewriteSequence(
 					prepared[index] ?? "",
 					width,
@@ -3144,6 +3144,12 @@ export class TUI extends Container {
 		committedTo = -1,
 		spacerGlyphWidth = -1,
 	): string {
+		// End every rewrite at column zero. ConPTY can materialize a pending
+		// wrap before a following cursor-addressing sequence even while DECAWM is
+		// disabled; on the bottom row that becomes an untracked scroll and leaks
+		// live chrome into native history (#9783). The row loops append only LF
+		// because this CR supplies the other half of their explicit CRLF.
+		let rewrite: string;
 		// Reserved lower half of a scaled OSC 66 heading. The glyph re-emitted on
 		// the row above owns columns `[0, spacerGlyphWidth)` here, so preserve
 		// them (any erase there clears the glyph — issue #8318) but still clear
@@ -3151,26 +3157,27 @@ export class TUI extends Container {
 		// spacer, and the glyph write never covers those columns. Leading reset
 		// keeps the erase on the default background (BCE).
 		if (spacerGlyphWidth >= 0) {
-			if (spacerGlyphWidth >= width) return "";
-			return `${SEGMENT_RESET}\x1b[${spacerGlyphWidth}C${ERASE_TO_END_OF_LINE}`;
+			rewrite = spacerGlyphWidth >= width ? "" : `${SEGMENT_RESET}\x1b[${spacerGlyphWidth}C${ERASE_TO_END_OF_LINE}`;
+		} else if (TERMINAL.isImageLine(line)) {
+			rewrite = ERASE_LINE + this.#imageLineSequence(line, screenRow, frameRow, committedTo);
+		} else {
+			const terminalLine = this.#terminalLine(line);
+			const asciiWidth = this.#ansiAsciiLineWidth(line, width);
+			if (asciiWidth !== undefined) {
+				// Exact width model: skip the erase only when the row truly fills
+				// the line (an EL there would eat the last cell via pending-wrap).
+				rewrite = asciiWidth >= width ? terminalLine : terminalLine + ERASE_TO_END_OF_LINE;
+			} else {
+				// Non-ASCII rows: the native measure can over-count combining-heavy
+				// scripts, so a row it calls "full" may render short and leave stale
+				// cells from the previous occupant — which would then scroll into
+				// history baked into the committed row. Erase the line first instead
+				// (rewrites always start at column 1, so EL-to-end clears the whole
+				// row); the leading reset keeps BCE on the default background.
+				rewrite = SEGMENT_RESET + ERASE_TO_END_OF_LINE + terminalLine;
+			}
 		}
-		if (TERMINAL.isImageLine(line)) {
-			return ERASE_LINE + this.#imageLineSequence(line, screenRow, frameRow, committedTo);
-		}
-		const terminalLine = this.#terminalLine(line);
-		const asciiWidth = this.#ansiAsciiLineWidth(line, width);
-		if (asciiWidth !== undefined) {
-			// Exact width model: skip the erase only when the row truly fills
-			// the line (an EL there would eat the last cell via pending-wrap).
-			return asciiWidth >= width ? terminalLine : terminalLine + ERASE_TO_END_OF_LINE;
-		}
-		// Non-ASCII rows: the native measure can over-count combining-heavy
-		// scripts, so a row it calls "full" may render short and leave stale
-		// cells from the previous occupant — which would then scroll into
-		// history baked into the committed row. Erase the line first instead
-		// (rewrites always start at column 1, so EL-to-end clears the whole
-		// row); the leading reset keeps BCE on the default background.
-		return SEGMENT_RESET + ERASE_TO_END_OF_LINE + terminalLine;
+		return `${rewrite}\r`;
 	}
 
 	#targetHardwareCursorState(
@@ -3273,7 +3280,7 @@ export class TUI extends Container {
 		}
 		let buffer = `${this.#paintBeginSequence}\x1b[H`;
 		for (let r = 0; r < height; r++) {
-			if (r > 0) buffer += "\r\n";
+			if (r > 0) buffer += "\n";
 			buffer += this.#lineRewriteSequence(fitted[r], width, r, -1, -1, this.#osc66SpacerGlyphWidth(fitted, r));
 		}
 		buffer += this.#paintEndSequence;

--- a/packages/tui/test/history-frame-plan.test.ts
+++ b/packages/tui/test/history-frame-plan.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
 	type Component,
+	CURSOR_MARKER,
 	type TerminalFramePlan,
 	type TerminalFrameProvider,
 	TUI,
@@ -188,6 +189,24 @@ class TmuxPreservedClearTerminal extends VirtualTerminal {
 		super.write(translated);
 	}
 }
+/**
+ * Models ConPTY materializing a pending wrap before the cursor move that follows
+ * an exact-width bottom-row repaint, as observed in issue #9783's PTY capture.
+ */
+class ConptyPendingWrapTerminal extends VirtualTerminal {
+	override write(data: string): void {
+		const bottom = `\x1b[${this.rows};1H`;
+		const rowStart = data.indexOf(bottom);
+		const remainder = rowStart < 0 ? "" : data.slice(rowStart + bottom.length);
+		const cursorOffset = remainder.search(/\x1b\[\d+;\d+H/);
+		const cursorMove = cursorOffset < 0 ? -1 : rowStart + bottom.length + cursorOffset;
+		if (cursorMove < 0 || data.slice(rowStart + bottom.length, cursorMove).includes("\r")) {
+			super.write(data);
+			return;
+		}
+		super.write(`${data.slice(0, cursorMove)}\r\n${data.slice(cursorMove)}`);
+	}
+}
 
 describe("terminal frame plans", () => {
 	it("appends finalized history once and leaves the requested mutable viewport intact", () => {
@@ -202,6 +221,24 @@ describe("terminal frame plans", () => {
 		expect(provider.acknowledged).toEqual([1]);
 		expect(terminal.getBufferPosition().baseY).toBe(1);
 		expect(terminal.getViewport().map(row => row.trimEnd())).toEqual(["history two", "editor", "status"]);
+		tui.stop();
+	});
+	it("keeps an exact-width live row out of scrollback when ConPTY materializes pending wrap", () => {
+		const terminal = new ConptyPendingWrapTerminal(20, 4);
+		const provider = new Provider({
+			history: { id: 1, rows: ["history one", "history two"] },
+			viewport: [`editor${CURSOR_MARKER}`, "status one".padEnd(20, ".")],
+		});
+		const tui = new TUI(terminal, undefined, { renderScheduler: scheduler });
+		tui.setFrameProvider(provider);
+
+		for (let frame = 2; frame <= 8; frame++) {
+			provider.plan = { viewport: [`editor${CURSOR_MARKER}`, `status ${frame}`.padEnd(20, ".")] };
+			tui.requestRender(true);
+		}
+
+		expect(terminal.getBufferPosition().baseY).toBe(0);
+		expect(plainBuffer(terminal)).toEqual(["history one", "history two", "editor", "status 8............"]);
 		tui.stop();
 	});
 	it("keeps live viewport rows out of tmux-style preserved-clear scrollback on a scrolling append", () => {


### PR DESCRIPTION
## Repro
Replay `capture-18.1.19-resume.bin` through `@xterm/headless` at the capture's exact 134×42 geometry. The 12,142,821-byte stream produces 57,278 CRLFs, zero CUU and zero `ESC[J`, ends with 18,601 native-scrollback rows, and contains repeated DeepSeek status rows in adjacent scrollback runs. A reduced regression repaints an exact-width bottom status row while a ConPTY terminal model materializes pending wrap before the following cursor move; before the fix, seven status ticks add seven scrollback rows.

## Cause
`TUI.#lineRewriteSequence()` could leave the cursor in pending-wrap state after rewriting an exact-width row. ConPTY materializes that wrap before the next absolute cursor move even while DECAWM is disabled. On the bottom row this creates an untracked scroll during a viewport-only diff, so the history-append `pushed`/erase guard never runs and each status animation frame commits another live row. The capture's single-row frames show this directly: bottom-row repaint, synthesized CRLF, then the editor cursor CUP. The reported xterm parse error is separate capture-harness corruption: `Buffer.from(String(chunk), "binary")` truncates the Nerd Font `tool.write` glyph U+EA7F to raw DEL `0x7f`.

## Fix
- End every rewritten terminal row with CR, clearing pending wrap before any cursor-addressing sequence.
- Let multi-row paint loops append LF only, preserving explicit CRLF row advances without adding bytes.
- Add a ConPTY pending-wrap regression that verifies repeated exact-width status repaints keep one live copy and zero native-scrollback growth.
- Document the user-visible fix in the TUI changelog.

## Verification
`bun test` in `packages/tui`: 1,537 passed, 0 failed. `bun run check` in `packages/tui`: oxlint, formatting, and `tsgo --noEmit` passed. The reduced regression failed before the source change with `baseY = 7` and passes after it with `baseY = 0`. Pre-fix replay of the reporter's 18.1.19 capture reproduced the 18,601-row native-scrollback leak at 134×42.

Fixes #9783