### PR TITLE
fix(mcp): wait for pending connect on `omp read` of an MCP resource

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Documented that native JS/TS hook factories must live in `.omp/hooks/pre/` or `.omp/hooks/post/` (not directly in `.omp/hooks/`), and cross-linked the hooks and extension-loading docs ([#11942](https://github.com/can1357/oh-my-pi/issues/11942)).
 
+### Fixed
+
+- `omp read <mcp-resource>` now waits for a still-handshaking MCP server to finish connecting instead of reporting `No MCP server has resource` when the connect outlasts the startup race ([#11950](https://github.com/can1357/oh-my-pi/issues/11950)).
+
 ## [18.1.19] - 2026-09-12
 
 - Fixed `--mode json` returning exit 0 on a turn-fatal provider/auth/network error ([#11498](https://github.com/can1357/oh-my-pi/issues/11498)).

--- a/packages/coding-agent/src/internal-urls/mcp-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/mcp-protocol.ts
@@ -126,6 +126,12 @@ export class McpProtocolHandler implements ProtocolHandler {
 		const uri = extractResourceUri(url);
 		let targetServer = resolveTargetServer(mcpManager, uri);
 		if (!targetServer) {
+			// A configured server may still be handshaking when discovery returned
+			// (the `connectServers` startup race deliberately leaves slow servers in
+			// flight). This one-shot read must observe the final attached state
+			// rather than the mid-handshake snapshot, so wait for pending connects
+			// before loading catalogs and retrying.
+			await mcpManager.waitForPendingConnections();
 			await Promise.allSettled(mcpManager.getConnectedServers().map(name => mcpManager.ensureServerResources(name)));
 			targetServer = resolveTargetServer(mcpManager, uri);
 		}

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -986,6 +986,32 @@ export class MCPManager {
 	}
 
 	/**
+	 * Wait for every in-flight connect, tool load, and reconnect to settle.
+	 *
+	 * One-shot callers (e.g. `omp read <mcp-resource>`) discover servers and read
+	 * immediately; a server whose handshake outlasts the {@link connectServers}
+	 * startup race is still tracked in {@link #pendingConnections} /
+	 * {@link #pendingToolLoads} and therefore invisible to
+	 * {@link getConnectedServers}. Awaiting the pending work lets those callers
+	 * observe the final attached/failed state instead of racing mid-handshake.
+	 * Rejections are swallowed — the caller re-reads state afterwards.
+	 */
+	async waitForPendingConnections(): Promise<void> {
+		// A settling tool load can arm a reconnect (startup-timeout retry), so
+		// drain in passes until no work remains. Bounded so a reconnect storm
+		// cannot spin this forever.
+		for (let pass = 0; pass < 8; pass++) {
+			const pending: Promise<unknown>[] = [
+				...this.#pendingConnections.values(),
+				...this.#pendingToolLoads.values(),
+				...this.#pendingReconnections.values(),
+			];
+			if (pending.length === 0) return;
+			await Promise.allSettled(pending);
+		}
+	}
+
+	/**
 	 * Resolve auth and shell-command substitutions in config before connecting.
 	 * Pass `oauth: false` to skip OAuth credential injection (used by reauth's
 	 * unauthenticated probe, which must observe the server's bare 401).

--- a/packages/coding-agent/test/fixtures/resources-no-templates-mcp.ts
+++ b/packages/coding-agent/test/fixtures/resources-no-templates-mcp.ts
@@ -54,9 +54,16 @@ function buildResult(method: string, params?: Record<string, unknown>): Record<s
 	}
 }
 
+/**
+ * Milliseconds to stall the `initialize` reply before responding. Defaults to 0.
+ * `read-cli-mcp-slow-connect.test.ts` sets it above `STARTUP_TIMEOUT_MS` (250 ms)
+ * to force the handshake to outlast the `connectServers` startup race.
+ */
+const HANDSHAKE_DELAY_MS = Number(process.env.FIXTURE_HANDSHAKE_DELAY_MS ?? "0");
+
 function startServer(): void {
 	const rl = readline.createInterface({ input: process.stdin });
-	rl.on("line", line => {
+	rl.on("line", async line => {
 		const trimmed = line.trim();
 		if (trimmed.length === 0) return;
 		let msg: JsonRpcRequest;
@@ -67,6 +74,10 @@ function startServer(): void {
 		}
 		// Notifications (no `id`) get no response.
 		if (msg.id === undefined || msg.id === null) return;
+
+		if (msg.method === "initialize" && HANDSHAKE_DELAY_MS > 0) {
+			await Bun.sleep(HANDSHAKE_DELAY_MS);
+		}
 
 		if (msg.method === "resources/templates/list") {
 			// Optional method this server doesn't implement (or fails, per env).

--- a/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
@@ -16,6 +16,7 @@ function createMockManager(opts: {
 }) {
 	return {
 		getConnectedServers: () => opts.servers ?? [],
+		waitForPendingConnections: async () => {},
 		getServerResources: (name: string) => opts.resources?.get(name),
 		ensureServerResources: async (name: string) => opts.ensureResources?.(name),
 		readServerResource: async (_name: string, _uri: string) => {

--- a/packages/coding-agent/test/read-cli-mcp-slow-connect.test.ts
+++ b/packages/coding-agent/test/read-cli-mcp-slow-connect.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as url from "node:url";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+const CLI_ENTRY = path.join(import.meta.dir, "..", "src", "cli.ts");
+const FIXTURE_PATH = path.join(import.meta.dir, "fixtures", "resources-no-templates-mcp.ts");
+
+// The fixture stalls its `initialize` reply for this long — comfortably past
+// `MCPManager`'s `STARTUP_TIMEOUT_MS` (250 ms) so the server is guaranteed to be
+// still handshaking when `connectServers` returns and the read begins.
+const HANDSHAKE_DELAY_MS = 700;
+
+describe("omp read MCP resource with a slow-connecting server", () => {
+	let root: string;
+	let projectDir: string;
+	let agentDir: string;
+	let probePath: string;
+
+	beforeEach(async () => {
+		root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-read-mcp-slow-"));
+		projectDir = path.join(root, "project");
+		agentDir = path.join(root, "agent");
+		await Promise.all([fs.mkdir(projectDir), fs.mkdir(agentDir)]);
+		await Bun.write(
+			path.join(projectDir, ".mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					fixture: {
+						type: "stdio",
+						command: process.execPath,
+						args: [FIXTURE_PATH],
+						env: { FIXTURE_HANDSHAKE_DELAY_MS: String(HANDSHAKE_DELAY_MS) },
+					},
+				},
+			}),
+		);
+		probePath = path.join(root, "probe.ts");
+		await Bun.write(
+			probePath,
+			[
+				`import { runCli } from ${JSON.stringify(url.pathToFileURL(CLI_ENTRY).href)};`,
+				'await runCli(["read", "test://alpha"]);',
+			].join("\n"),
+		);
+	});
+
+	afterEach(async () => {
+		await removeWithRetries(root);
+	});
+
+	async function runReadProbe(): Promise<{ exitCode: number; output: string; error: string }> {
+		const proc = Bun.spawn([process.execPath, probePath], {
+			cwd: projectDir,
+			stdout: "pipe",
+			stderr: "pipe",
+			env: {
+				...process.env,
+				HOME: root,
+				NO_COLOR: "1",
+				PI_CODING_AGENT_DIR: agentDir,
+			},
+		});
+		const stdout = new Response(proc.stdout).text();
+		const stderr = new Response(proc.stderr).text();
+		const [exitCode, output, error] = await Promise.all([proc.exited, stdout, stderr]);
+		return { exitCode, output, error };
+	}
+
+	it("waits for the pending connect instead of racing the startup deadline", async () => {
+		const { exitCode, output, error } = await runReadProbe();
+
+		expect(error).toBe("");
+		expect(exitCode).toBe(0);
+		expect(output).toContain("fixture content for test://alpha");
+	}, 30_000);
+});


### PR DESCRIPTION
## Repro
A correctly configured stdio MCP server whose handshake outlasts the 250ms `connectServers` startup race is invisible to `omp read <mcp-resource>`, which discovers servers and reads immediately: `omp read test://alpha` exits 1 with `No MCP server has resource "test://alpha"`. Reproduced deterministically with a fixture that stalls its `initialize` reply past `STARTUP_TIMEOUT_MS`: `runCli(["read", "test://alpha"])` against a `.mcp.json` pointing at it fails pre-fix and succeeds post-fix.

## Cause
`McpProtocolHandler.resolve` (`src/internal-urls/mcp-protocol.ts`) resolves the target via `resolveTargetServer`, which iterates `getConnectedServers()` only. A server still handshaking after the startup race lives in `MCPManager`'s `#pendingConnections` / `#pendingToolLoads`, not `#connections`, so it is invisible; the existing fallback calls `ensureServerResources` only on already-connected servers and never awaits the pending connect. The non-blocking startup deadline (`STARTUP_TIMEOUT_MS = 250`, `src/mcp/manager.ts`) is intentional for the TUI, but the one-shot read CLI must observe the final attached state.

## Fix
- Add `MCPManager.waitForPendingConnections()` (`src/mcp/manager.ts`): drains in-flight connects, tool loads, and reconnects in bounded passes (a settling tool load can arm a startup-timeout retry), swallowing rejections so the caller re-reads state.
- In `McpProtocolHandler.resolve`, when the first resolution misses, await `waitForPendingConnections()` before the `ensureServerResources` catalog load and retry — leaving the startup deadline untouched.
- Add an env-gated `initialize` handshake delay to the shared `resources-no-templates-mcp.ts` fixture (default off) so the race is reproducible.

## Verification
`bun test test/read-cli-mcp-slow-connect.test.ts test/read-cli-mcp-resource.test.ts test/internal-urls/mcp-protocol.test.ts test/mcp-resource-templates-missing.test.ts test/mcp-startup-no-block.test.ts test/mcp-startup-events.test.ts test/mcp-incremental-connect.test.ts test/mcp-runtime-snapshot.test.ts` — all pass. New test `read-cli-mcp-slow-connect.test.ts` is red without the fix (`No MCP server has resource`) and green with it. `bun check` passes via the pre-publish gate.

Fixes #11950