### PR TITLE
feat(harness): session identity env, skill tool requirements, structured-result rasterization exemption

### DIFF
--- a/packages/coding-agent/src/capability/skill.ts
+++ b/packages/coding-agent/src/capability/skill.ts
@@ -28,6 +28,14 @@ export interface SkillFrontmatter {
 	 * @see https://agentskills.io/specification
 	 */
 	disableModelInvocation?: boolean;
+	/**
+	 * Agent Skills metadata bag — author-defined keys the spec leaves open.
+	 * `requires` lists tool names the skill's instructions depend on (e.g.
+	 * `[bash]`); the subagent preflight refuses to spawn an agent whose tool
+	 * list lacks one.
+	 * @see https://agentskills.io/specification
+	 */
+	metadata?: { requires?: unknown; [key: string]: unknown };
 	[key: string]: unknown;
 }
 

--- a/packages/coding-agent/src/eval/executor-base.ts
+++ b/packages/coding-agent/src/eval/executor-base.ts
@@ -1,5 +1,6 @@
 import { logger } from "@oh-my-pi/pi-utils";
 import { Settings } from "../config/settings";
+import { OMP_AGENT_ID_ENV, OMP_SESSION_ID_ENV } from "../session/agent-identity-env";
 import { OutputSink } from "../session/streaming-output";
 import type { ToolSession } from "../tools";
 import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "../tools/output-meta";
@@ -282,6 +283,8 @@ export const MANAGED_KERNEL_ENV_KEYS = [
 	"PI_TOOL_BRIDGE_TOKEN",
 	"PI_TOOL_BRIDGE_SESSION",
 	"PI_EVAL_LOCAL_ROOTS",
+	OMP_SESSION_ID_ENV,
+	OMP_AGENT_ID_ENV,
 ] as const;
 
 interface ManagedKernelEnvOptions {
@@ -290,6 +293,10 @@ interface ManagedKernelEnvOptions {
 	bridgeSessionId?: string;
 	bridge?: { url: string; token: string };
 	localRoots?: Record<string, string>;
+	/** Spawning session id, exported so eval `subprocess` children inherit it. */
+	ompSessionId?: string;
+	/** Spawning agent/task id (falls back to the session id upstream). */
+	ompAgentId?: string;
 }
 interface ManagedKernelEnvPolicy {
 	sparse?: boolean;
@@ -315,6 +322,8 @@ export function buildManagedKernelEnvPatch(
 			patch.PI_TOOL_BRIDGE_SESSION = options.bridgeSessionId ?? "";
 		}
 		if (localRoots) patch.PI_EVAL_LOCAL_ROOTS = JSON.stringify(localRoots);
+		if (options.ompSessionId) patch[OMP_SESSION_ID_ENV] = options.ompSessionId;
+		if (options.ompAgentId) patch[OMP_AGENT_ID_ENV] = options.ompAgentId;
 		return patch;
 	}
 	return {
@@ -324,6 +333,8 @@ export function buildManagedKernelEnvPatch(
 		PI_TOOL_BRIDGE_TOKEN: options.bridge?.token ?? null,
 		PI_TOOL_BRIDGE_SESSION: options.bridge && options.bridgeSessionId ? options.bridgeSessionId : null,
 		PI_EVAL_LOCAL_ROOTS: localRoots && Object.keys(localRoots).length > 0 ? JSON.stringify(localRoots) : null,
+		[OMP_SESSION_ID_ENV]: options.ompSessionId ?? null,
+		[OMP_AGENT_ID_ENV]: options.ompAgentId ?? null,
 	};
 }
 

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -99,6 +99,15 @@ export interface PythonExecutorOptions {
 	artifactPath?: string;
 	artifactId?: string;
 	/**
+	 * Harness session id, exported to the kernel as `OMP_SESSION_ID` so
+	 * `subprocess` children of an eval cell can correlate with the agent turn.
+	 * Unrelated to {@link PythonExecutorOptions.sessionId}, which only
+	 * namespaces the retained kernel.
+	 */
+	ompSessionId?: string;
+	/** Harness agent/task id, exported to the kernel as `OMP_AGENT_ID`. */
+	ompAgentId?: string;
+	/**
 	 * On-disk roots the prelude helpers (`read`/`write`) substitute for
 	 * internal-URL schemes (e.g. `{ local: "/…/artifacts/local" }`). Exported to
 	 * the kernel as `PI_EVAL_LOCAL_ROOTS` (JSON) so `write("local://x")` lands

--- a/packages/coding-agent/src/eval/py/index.ts
+++ b/packages/coding-agent/src/eval/py/index.ts
@@ -1,3 +1,4 @@
+import { resolveAgentIdentity } from "../../session/agent-identity-env";
 import type { ToolSession } from "../../tools";
 import {
 	type ExecutorBackend,
@@ -26,18 +27,30 @@ function readInterpreterSetting(session: ToolSession): string | undefined {
 	return sharedReadInterpreterSetting(session, "python.interpreter");
 }
 
-/** Resolve the retained Python kernel identity owned by a tool session. */
+/**
+ * Resolve the retained Python kernel identity owned by a tool session.
+ *
+ * `ompSessionId`/`ompAgentId` are the harness session/agent ids exported into
+ * the kernel process (see `agent-identity-env`), so `subprocess` children of an
+ * eval cell can correlate with the turn that ran them. They are unrelated to
+ * `sessionId`, which namespaces the retained kernel.
+ */
 export function resolvePythonKernelIdentity(session: ToolSession): {
 	cwd: string;
 	sessionId: string;
 	interpreter: string | undefined;
 	kernelOwnerId: string | undefined;
+	ompSessionId: string | undefined;
+	ompAgentId: string | undefined;
 } {
+	const identity = resolveAgentIdentity(session);
 	return {
 		cwd: session.cwd,
 		sessionId: namespaceSessionId(session.getEvalSessionId?.() ?? defaultEvalSessionId(session)),
 		interpreter: readInterpreterSetting(session),
 		kernelOwnerId: session.getEvalKernelOwnerId?.() ?? undefined,
+		ompSessionId: identity.sessionId,
+		ompAgentId: identity.agentId,
 	};
 }
 
@@ -65,6 +78,8 @@ export default {
 			artifactsDir: opts.session.getArtifactsDir?.() ?? undefined,
 			localRoots: resolveEvalUrlRoots(opts.session),
 			kernelOwnerId: identity.kernelOwnerId,
+			ompSessionId: identity.ompSessionId,
+			ompAgentId: identity.ompAgentId,
 			reset: opts.reset,
 			onChunk: opts.onChunk,
 			onStatus: opts.onStatus,

--- a/packages/coding-agent/src/eval/py/runner.py
+++ b/packages/coding-agent/src/eval/py/runner.py
@@ -1903,6 +1903,10 @@ _MANAGED_ENV_KEYS = (
     "PI_TOOL_BRIDGE_TOKEN",
     "PI_TOOL_BRIDGE_SESSION",
     "PI_EVAL_LOCAL_ROOTS",
+    # Harness session/agent identity: inherited by subprocess children so an
+    # external CLI can correlate with the agent turn that ran the cell.
+    "OMP_SESSION_ID",
+    "OMP_AGENT_ID",
 )
 
 

--- a/packages/coding-agent/src/eval/py/runtime.ts
+++ b/packages/coding-agent/src/eval/py/runtime.ts
@@ -105,6 +105,28 @@ function resolvePathKey(env: Record<string, string | undefined>): string {
 	return match ?? "PATH";
 }
 
+/**
+ * The managed venv (`~/.omp/python-env`), second in {@link enumeratePythonRuntimes}'s
+ * priority order.
+ *
+ * The harness never creates it: the eval kernel needs nothing beyond a working
+ * interpreter, so there is no requirements manifest and no provisioning step to
+ * hook. It exists for the case where a cell needs a library the system Python
+ * lacks (`yaml` being the common one) and you want that available for every
+ * project without a local `.venv`:
+ *
+ * ```
+ * uv venv ~/.omp/python-env
+ * uv pip install --python ~/.omp/python-env/bin/python pyyaml
+ * ```
+ *
+ * Once it exists it wins over the system interpreter (but still loses to an
+ * active `$VIRTUAL_ENV`/`$CONDA_PREFIX` or a project `.venv`/`venv`). The
+ * alternatives are `%pip install pyyaml` inside a cell — which installs into
+ * whichever interpreter resolved, so it does not survive a switch — or pointing
+ * the `python.interpreter` setting at an env you control. `omp setup python
+ * --check` reports which interpreter actually resolved.
+ */
 function resolveManagedPythonEnv(): string {
 	return getPythonEnvDir();
 }

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -6,7 +6,7 @@ import {
 	MANAGED_SKILLS_PROVIDER_ID,
 	sanitizeManagedDescription,
 } from "../autolearn/managed-skills";
-import { skillCapability } from "../capability/skill";
+import { skillCapability, type SkillFrontmatter } from "../capability/skill";
 import type { EffectiveExtensionRoots, SourceMeta } from "../capability/types";
 import type { SkillsSettings } from "../config/settings";
 import { type Skill as CapabilitySkill, isUserSourceEnabled, loadCapability } from "../discovery";
@@ -32,8 +32,29 @@ export interface Skill {
 	 * every `skill://` resource access must realpath-resolve within it.
 	 */
 	containRoot?: string;
+	/**
+	 * Tool names the skill declares it needs (`metadata.requires` frontmatter).
+	 * The subagent preflight refuses to spawn an agent whose tool list lacks
+	 * one of these when the assignment references the skill.
+	 */
+	requires?: string[];
 	/** Source metadata for display */
 	_source?: SourceMeta;
+}
+
+/**
+ * Tool names a skill's `metadata.requires` frontmatter declares. `undefined`
+ * when the key is absent or carries nothing usable, so the property stays off
+ * the runtime skill for the overwhelming majority that declare no requirement.
+ */
+export function skillRequiredTools(frontmatter: SkillFrontmatter | undefined): string[] | undefined {
+	const requires = frontmatter?.metadata?.requires;
+	if (!Array.isArray(requires)) return undefined;
+	const tools = requires
+		.filter((tool): tool is string => typeof tool === "string")
+		.map(tool => tool.trim())
+		.filter(tool => tool.length > 0);
+	return tools.length > 0 ? tools : undefined;
 }
 
 export interface SkillWarning {
@@ -111,6 +132,7 @@ export async function loadSkillsFromDir(options: LoadSkillsFromDirOptions): Prom
 			source: options.source,
 			...(capSkill.containRoot !== undefined && { containRoot: capSkill.containRoot }),
 			hide: capSkill.frontmatter?.hide === true || capSkill.frontmatter?.disableModelInvocation === true,
+			requires: skillRequiredTools(capSkill.frontmatter),
 			_source: capSkill._source,
 		})),
 		warnings: (result.warnings ?? []).map(message => ({ skillPath: options.dir, message })),
@@ -255,6 +277,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 				source: `${capSkill._source.provider}:${capSkill.level}`,
 				...(capSkill.containRoot !== undefined && { containRoot: capSkill.containRoot }),
 				hide: capSkill.frontmatter?.hide === true || capSkill.frontmatter?.disableModelInvocation === true,
+				requires: skillRequiredTools(capSkill.frontmatter),
 				_source: capSkill._source,
 			});
 			realPathSet.add(resolvedPath);
@@ -293,6 +316,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 					source: "custom:user",
 					...(capSkill.containRoot !== undefined && { containRoot: capSkill.containRoot }),
 					hide: capSkill.frontmatter?.hide === true || capSkill.frontmatter?.disableModelInvocation === true,
+					requires: skillRequiredTools(capSkill.frontmatter),
 					_source: { ...capSkill._source, providerName: "Custom" },
 				},
 				path: capSkill.path,
@@ -394,6 +418,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 			source: `${capSkill._source.provider}:${capSkill.level}`,
 			...(capSkill.containRoot !== undefined && { containRoot: capSkill.containRoot }),
 			hide: capSkill.frontmatter?.hide === true || capSkill.frontmatter?.disableModelInvocation === true,
+			requires: skillRequiredTools(capSkill.frontmatter),
 			_source: capSkill._source,
 		});
 		realPathSet.add(resolvedPath);

--- a/packages/coding-agent/src/session/agent-identity-env.ts
+++ b/packages/coding-agent/src/session/agent-identity-env.ts
@@ -1,0 +1,68 @@
+/**
+ * Session/agent identity exported into child processes the harness spawns.
+ *
+ * Everything else the harness hands a child (`PI_SESSION_FILE`,
+ * `PI_TOOL_BRIDGE_*`, …) describes a transport. These two variables answer a
+ * different question: *which agent turn am I running inside?* External CLIs use
+ * them to correlate their own side effects (query logs, QA reports, caches)
+ * with the session and subagent that invoked them, which is otherwise
+ * unknowable from a child process.
+ *
+ * Exported by the bash tool (every bash child) and by the managed Python kernel
+ * env (so `subprocess` children of an eval cell inherit it too).
+ */
+
+/** Session id of the turn that spawned the child. */
+export const OMP_SESSION_ID_ENV = "OMP_SESSION_ID";
+/**
+ * Agent/task id of the spawning agent (registry id, e.g. `Main`, `Harness`).
+ * Falls back to the session id so a child always has a usable correlation key.
+ */
+export const OMP_AGENT_ID_ENV = "OMP_AGENT_ID";
+
+/**
+ * Identity accessors a tool session may expose. Structural so advisor-local and
+ * test sessions — which implement only part of `ToolSession` — still work.
+ */
+export interface AgentIdentitySource {
+	sessionManager?: { getSessionId?: () => string | null };
+	getSessionId?: () => string | null;
+	getAgentId?: () => string | null;
+}
+
+export interface AgentIdentity {
+	sessionId?: string;
+	agentId?: string;
+}
+
+function firstNonEmpty(...values: Array<string | null | undefined>): string | undefined {
+	for (const value of values) {
+		const trimmed = value?.trim();
+		if (trimmed) return trimmed;
+	}
+	return undefined;
+}
+
+/**
+ * Resolve the spawning session/agent identity. Prefers the owning journal's
+ * registered id over the tool-state id (advisors carry a local id that is not
+ * the session the user sees).
+ */
+export function resolveAgentIdentity(session: AgentIdentitySource | undefined): AgentIdentity {
+	if (!session) return {};
+	const sessionId = firstNonEmpty(session.sessionManager?.getSessionId?.(), session.getSessionId?.());
+	return { sessionId, agentId: firstNonEmpty(session.getAgentId?.()) ?? sessionId };
+}
+
+/**
+ * Env overlay carrying {@link resolveAgentIdentity} for a child process. Empty
+ * when the session has no identity at all (detached tools, unit tests), so
+ * callers can keep an "no env overlay" fast path.
+ */
+export function agentIdentityEnv(session: AgentIdentitySource | undefined): Record<string, string> {
+	const { sessionId, agentId } = resolveAgentIdentity(session);
+	const env: Record<string, string> = {};
+	if (sessionId) env[OMP_SESSION_ID_ENV] = sessionId;
+	if (agentId) env[OMP_AGENT_ID_ENV] = agentId;
+	return env;
+}

--- a/packages/coding-agent/src/session/snapcompact-inline.ts
+++ b/packages/coding-agent/src/session/snapcompact-inline.ts
@@ -17,6 +17,7 @@
 import { Tokenizer } from "@oh-my-pi/pi-agent-core";
 import type { Context, ImageContent, Model, TextContent, ToolResultMessage, UserMessage } from "@oh-my-pi/pi-ai";
 import * as snapcompact from "@oh-my-pi/snapcompact";
+import { YAML } from "bun";
 import type { SnapcompactFrameSink } from "../blob-broker/service";
 import contextFramesNote from "../prompts/system/snapcompact-context-frames-note.md" with { type: "text" };
 import contextStub from "../prompts/system/snapcompact-context-stub.md" with { type: "text" };
@@ -230,6 +231,51 @@ interface BuiltInlineToolResultCandidate {
 }
 
 /**
+ * Head shape of a structured envelope: an `ok:` YAML envelope, a JSON
+ * object/array, or a YAML document marker.
+ */
+const STRUCTURED_HEAD_PATTERN = /^(?:ok:\s*(?:true|false)|\{|\[|---)/;
+/** Bytes of the head sniffed for a parseable mapping. */
+const STRUCTURED_SNIFF_BYTES = 4096;
+
+/** First line with a non-whitespace character, leading indentation stripped. */
+function firstNonEmptyLine(text: string): string {
+	let start = 0;
+	while (start < text.length) {
+		let end = text.indexOf("\n", start);
+		if (end === -1) end = text.length;
+		const line = text.slice(start, end).trim();
+		if (line.length > 0) return line;
+		start = end + 1;
+	}
+	return "";
+}
+
+/**
+ * Whether a tool result is machine-structured output (a YAML/JSON envelope)
+ * rather than prose.
+ *
+ * Rasterization trades exact glyphs for density, which is a good trade for
+ * prose and a bad one for structured data: an agent re-reads an envelope for
+ * exact ids, keys, and numbers, and an OCR-ambiguous digit is a wrong answer
+ * rather than a slightly worse summary. Structured results therefore always
+ * ship as text.
+ */
+function isStructuredToolResult(text: string): boolean {
+	const head = text.length > STRUCTURED_SNIFF_BYTES ? text.slice(0, STRUCTURED_SNIFF_BYTES) : text;
+	if (STRUCTURED_HEAD_PATTERN.test(firstNonEmptyLine(head))) return true;
+	// Envelope whose first key is not `ok` — still structured if the head
+	// parses as a mapping carrying one. A head cut mid-structure throws, which
+	// is the same answer as "not structured".
+	try {
+		const parsed = YAML.parse(head);
+		return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed) && "ok" in parsed;
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Build the exact same text payload and planning candidate for estimation and
  * live transformation. Image blocks do not suppress co-resident text.
  */
@@ -258,7 +304,13 @@ function buildInlineToolResultCandidate(
 		candidate: {
 			id: toolCallId,
 			textTokens,
-			frames: !isError && textTokens >= MIN_TOOL_RESULT_TOKENS ? snapcompact.frames(text, { shape }) : 0,
+			// `frames: 0` is the single skip signal `planInlineSwaps` honors, so
+			// exempting here keeps the transform and the /context estimate in
+			// agreement automatically — both build candidates through here.
+			frames:
+				!isError && textTokens >= MIN_TOOL_RESULT_TOKENS && !isStructuredToolResult(text)
+					? snapcompact.frames(text, { shape })
+					: 0,
 			isError,
 		},
 		text,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -77,6 +77,7 @@ import { generateTaskLabel } from "./label";
 import { resolveAgentPrewalkDefault } from "./prewalk";
 import { isReadOnlyAgent } from "./read-only-policy";
 import { formatTaskResultSummary } from "./result-summary";
+import { resolveSubagentToolNames } from "./subagent-tools";
 import { subprocessToolRegistry } from "./subprocess-tool-registry";
 import type { WorkPoolYieldItem } from "./workpool-yield";
 import {
@@ -3117,31 +3118,11 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	const atMaxDepth = maxRecursionDepth >= 0 && childDepth >= maxRecursionDepth;
 	const ircEnabled = options.enableIrc !== false && isIrcEnabled(subagentSettings, childDepth);
 
-	// Add tools if specified
-	let toolNames: string[] | undefined;
-	if (agent.tools) {
-		toolNames = agent.tools;
-		// Auto-include task tool if spawns defined but task not in tools
-		if (agent.spawns !== undefined && !toolNames.includes("task") && !atMaxDepth) {
-			toolNames = [...toolNames, "task"];
-		}
-	}
-
-	if (atMaxDepth && toolNames?.includes("task")) {
-		toolNames = toolNames.filter(name => name !== "task");
-	}
-	// Ordinary agents retain the host's always-on collaboration capability.
-	// Restricted sessions must not widen their explicit host tool list with hub.
-	if (toolNames && !options.restrictToolNames && !toolNames.includes("hub")) {
-		toolNames = [...toolNames, "hub"];
-	}
-	if (toolNames?.includes("exec")) {
-		const backends = resolveEvalBackends({ settings } as ToolSession);
-		const expanded = toolNames.filter(name => name !== "exec");
-		if (backends.python || backends.js) expanded.push("eval");
-		expanded.push("bash");
-		toolNames = Array.from(new Set(expanded));
-	}
+	const toolNames = resolveSubagentToolNames(agent, {
+		atMaxDepth,
+		restrictToolNames: options.restrictToolNames,
+		evalBackends: resolveEvalBackends({ settings } as ToolSession),
+	});
 
 	const modelPatterns = normalizeModelPatterns(modelOverride ?? agent.model);
 	const sessionFile = subtaskSessionFile ?? null;

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -21,6 +21,7 @@ import isolationRecoveryHintTemplate from "../prompts/tools/isolation-recovery-h
 import { MAIN_AGENT_ID } from "../registry/agent-registry";
 import type { TaskEffort } from "../thinking";
 import type { ToolSession } from "../tools";
+import { resolveEvalBackends } from "../tools/eval-backends";
 import { isIrcEnabled } from "../tools/hub";
 import { buildOutputValidator } from "../tools/output-schema-validator";
 import { trackLateCleanup } from "../utils/late-cleanup";
@@ -39,6 +40,7 @@ import {
 import { generateTaskName } from "./name-generator";
 import { AgentOutputManager } from "./output-manager";
 import { resolveSpawnPolicy } from "./spawn-policy";
+import { resolveSubagentToolNames } from "./subagent-tools";
 import {
 	type AgentDefinition,
 	type AgentProgress,
@@ -235,6 +237,56 @@ function assertPlanControlsAllowed(request: StructuredSubagentRequest, planMode:
 	}
 }
 
+/**
+ * `skill://<name>` (optionally `skill://<name>/<path>`) references in an
+ * assignment. Skill names are filesystem-derived, so the character class
+ * matches what discovery can produce.
+ */
+const SKILL_URL_PATTERN = /skill:\/\/([A-Za-z0-9][\w.-]*)/g;
+
+/**
+ * Refuse a spawn whose assignment points at a skill the child cannot execute.
+ *
+ * A skill declaring `metadata.requires: [bash]` is unusable to a read-only
+ * profile: the child reads the instructions, discovers it has no way to follow
+ * them, and improvises. Failing here — before any artifact lease or session —
+ * surfaces as an ordinary preflight error the caller can fix by choosing a
+ * different agent.
+ *
+ * Deliberately permissive: an agent with no `tools` key inherits the host's
+ * full set, and an unresolvable skill name is left to `skill://` resolution to
+ * report.
+ */
+function assertSkillToolRequirements(
+	request: StructuredSubagentRequest,
+	agentName: string,
+	agent: AgentDefinition,
+): void {
+	if (!request.assignment.includes("skill://")) return;
+	const skills = request.session.skills;
+	if (!skills?.length) return;
+	// `atMaxDepth`/`restrictToolNames` only ever REMOVE task/hub; assuming the
+	// widest surface keeps this check from failing a spawn that would have
+	// worked.
+	const toolNames = resolveSubagentToolNames(agent, {
+		atMaxDepth: false,
+		evalBackends: resolveEvalBackends({ settings: request.session.settings } as ToolSession),
+	});
+	if (!toolNames) return;
+	const available = new Set(toolNames);
+	for (const [, name] of request.assignment.matchAll(SKILL_URL_PATTERN)) {
+		const required = skills.find(skill => skill.name === name)?.requires;
+		if (!required) continue;
+		for (const tool of required) {
+			if (available.has(tool)) continue;
+			throw new StructuredSubagentError(
+				"preflight",
+				`skill ${name} requires tool ${tool}; agent ${agentName} lacks it`,
+			);
+		}
+	}
+}
+
 function assertDepthAndSpawnAllowed(request: StructuredSubagentRequest, agentName: string): void {
 	const taskDepth = request.session.taskDepth ?? 0;
 	const maxDepth = request.session.settings.get("task.maxRecursionDepth") ?? 2;
@@ -293,6 +345,7 @@ export async function resolveEffectiveSubagentPolicy(
 	}
 
 	const effectiveAgent = planMode ? createPlanModeAgent(agent) : agent;
+	assertSkillToolRequirements(request, agentName, effectiveAgent);
 	const schema = resolveSchema(request, effectiveAgent);
 	if (schema.source === "caller" || (schema.source !== "none" && schema.mode === "strict")) {
 		const { error } = buildOutputValidator(schema.schema);

--- a/packages/coding-agent/src/task/subagent-tools.ts
+++ b/packages/coding-agent/src/task/subagent-tools.ts
@@ -1,0 +1,52 @@
+/**
+ * Effective tool surface of a spawned subagent.
+ *
+ * One source of truth for the executor (which hands the list to the child
+ * session) and the preflight (which must know what the child will be able to
+ * run *before* anything is created).
+ */
+import type { AgentDefinition } from "./types";
+
+export interface SubagentToolContext {
+	/** Max recursion depth reached for the child: `task` is stripped. */
+	atMaxDepth: boolean;
+	/** Restricted sessions keep their explicit host tool list — no `hub`. */
+	restrictToolNames?: boolean;
+	/** Backends that resolve, deciding whether `exec` expands to `eval`. */
+	evalBackends: { python?: boolean; js?: boolean };
+}
+
+/**
+ * Resolve the tool names a spawned agent will actually be given.
+ * `undefined` means the agent declared no `tools` key and therefore inherits
+ * the host's full tool set.
+ */
+export function resolveSubagentToolNames(
+	agent: Pick<AgentDefinition, "tools" | "spawns">,
+	context: SubagentToolContext,
+): string[] | undefined {
+	let toolNames: string[] | undefined;
+	if (agent.tools) {
+		toolNames = agent.tools;
+		// Auto-include task tool if spawns defined but task not in tools
+		if (agent.spawns !== undefined && !toolNames.includes("task") && !context.atMaxDepth) {
+			toolNames = [...toolNames, "task"];
+		}
+	}
+
+	if (context.atMaxDepth && toolNames?.includes("task")) {
+		toolNames = toolNames.filter(name => name !== "task");
+	}
+	// Ordinary agents retain the host's always-on collaboration capability.
+	// Restricted sessions must not widen their explicit host tool list with hub.
+	if (toolNames && !context.restrictToolNames && !toolNames.includes("hub")) {
+		toolNames = [...toolNames, "hub"];
+	}
+	if (toolNames?.includes("exec")) {
+		const expanded = toolNames.filter(name => name !== "exec");
+		if (context.evalBackends.python || context.evalBackends.js) expanded.push("eval");
+		expanded.push("bash");
+		toolNames = Array.from(new Set(expanded));
+	}
+	return toolNames;
+}

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -25,6 +25,7 @@ import { InternalUrlRouter } from "../internal-urls";
 import { truncateToVisualLines } from "../modes/components/visual-truncate";
 import { highlightCode, type Theme } from "../modes/theme/theme";
 import bashDescription from "../prompts/tools/bash.md" with { type: "text" };
+import { agentIdentityEnv, resolveAgentIdentity } from "../session/agent-identity-env";
 import type {
 	ClientBridgeTerminalExitStatus,
 	ClientBridgeTerminalHandle,
@@ -1053,13 +1054,18 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 			command = rewriteGitWorktreeAdd(command, resolveCliEntryCmd());
 		}
 
+		// Session/agent identity: seeded into every bash child so external CLIs
+		// can correlate their side effects with this turn, and reused as the
+		// internal-URL session scope so both read the same id.
+		const identity = resolveAgentIdentity(this.session);
+		const identityEnv = agentIdentityEnv(this.session);
 		const internalUrlOptions: InternalUrlExpansionOptions = {
 			skills: this.session.skills ?? [],
 			attachments: this.session.getImageAttachments?.() ?? [],
 			internalRouter: InternalUrlRouter.instance(),
 			cwd: this.session.cwd,
 			sessionFile: this.session.getSessionFile() ?? undefined,
-			sessionId: this.session.sessionManager?.getSessionId?.() ?? this.session.getSessionId?.() ?? undefined,
+			sessionId: identity.sessionId,
 			agentRegistry: this.session.agentRegistry,
 			rules: this.session.activeRules,
 			localOptions: {
@@ -1068,7 +1074,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 			},
 		};
 		command = await expandInternalUrls(command, { ...internalUrlOptions, ensureLocalParentDirs: true });
-		const resolvedEnv = env
+		const callerEnv = env
 			? Object.fromEntries(
 					await Promise.all(
 						Object.entries(env).map(async ([key, value]) => [
@@ -1082,6 +1088,12 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 					),
 				)
 			: undefined;
+		// Caller-supplied values win: an explicit `env` entry may deliberately
+		// re-point a child's identity. Stays `undefined` when there is nothing
+		// to inject at all (detached tools, unit sessions) so the executor keeps
+		// its no-overlay path.
+		const resolvedEnv: Record<string, string> | undefined =
+			callerEnv || Object.keys(identityEnv).length > 0 ? { ...identityEnv, ...callerEnv } : undefined;
 
 		// Resolve protocol URLs (skill://, agent://, etc.) in extracted cwd.
 		if (cwd?.includes("://") || cwd?.includes("local:/")) {

--- a/packages/coding-agent/test/bash-session-identity-env.test.ts
+++ b/packages/coding-agent/test/bash-session-identity-env.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { BashTool } from "@oh-my-pi/pi-coding-agent/tools/bash";
+
+afterEach(() => {
+	mock.restore();
+});
+
+function makeSession(identity: { sessionId?: string | null; agentId?: string | null } = {}): ToolSession {
+	return {
+		cwd: "/tmp",
+		hasUI: false,
+		skills: [],
+		getSessionFile: () => null,
+		getSessionId: () => identity.sessionId ?? null,
+		getAgentId: () => identity.agentId ?? null,
+		settings: {
+			get(key: string) {
+				if (key === "async.enabled") return false;
+				if (key === "bash.autoBackground.enabled") return false;
+				if (key === "bash.autoBackground.thresholdMs") return 60_000;
+				if (key === "bashInterceptor.enabled") return false;
+				return undefined;
+			},
+			getBashInterceptorRules() {
+				return [];
+			},
+		},
+		getClientBridge: () => undefined,
+	} as unknown as ToolSession;
+}
+
+async function runEcho(session: ToolSession, env?: Record<string, string>): Promise<string> {
+	const tool = new BashTool(session);
+	const result = await tool.execute("call-identity", {
+		command: 'echo "[$OMP_SESSION_ID|$OMP_AGENT_ID]"',
+		...(env ? { env } : {}),
+	});
+	return result.content.find(block => block.type === "text")?.text ?? "";
+}
+
+describe("bash child session identity", () => {
+	it("exports OMP_SESSION_ID and OMP_AGENT_ID to the child", async () => {
+		const text = await runEcho(makeSession({ sessionId: "sess-42", agentId: "Harness" }));
+		expect(text).toContain("[sess-42|Harness]");
+	});
+
+	it("falls back to the session id when the session carries no agent id", async () => {
+		const text = await runEcho(makeSession({ sessionId: "sess-42" }));
+		expect(text).toContain("[sess-42|sess-42]");
+	});
+
+	it("lets caller-supplied env override the injected identity", async () => {
+		const text = await runEcho(makeSession({ sessionId: "sess-42", agentId: "Harness" }), {
+			OMP_AGENT_ID: "Override",
+		});
+		expect(text).toContain("[sess-42|Override]");
+	});
+
+	it("injects nothing when the session has no identity", async () => {
+		const text = await runEcho(makeSession());
+		expect(text).toContain("[|]");
+	});
+});

--- a/packages/coding-agent/test/core/python-kernel-env.test.ts
+++ b/packages/coding-agent/test/core/python-kernel-env.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { executePython } from "@oh-my-pi/pi-coding-agent/eval/py/executor";
 import {
 	enumeratePythonRuntimes,
 	filterEnv,
@@ -157,5 +158,46 @@ describe("enumeratePythonRuntimes", () => {
 
 		expect(enumeratePythonRuntimes(path.join(path.sep, "work"), {})).toEqual([]);
 		expect(() => resolvePythonRuntime(path.join(path.sep, "work"), {})).toThrow("Python executable not found");
+	});
+});
+
+describe("managed kernel session identity", () => {
+	const printIdentity = [
+		"import os, subprocess, sys",
+		"print('kernel', os.environ.get('OMP_SESSION_ID'), os.environ.get('OMP_AGENT_ID'))",
+		"child = subprocess.run([sys.executable, '-c', \"import os; print('child', os.environ.get('OMP_SESSION_ID'), os.environ.get('OMP_AGENT_ID'))\"], capture_output=True, text=True)",
+		"print(child.stdout.strip())",
+	].join("\n");
+
+	// Exercise a real kernel plus a subprocess child, which is what an external
+	// CLI launched from a cell actually sees.
+	it.each(["per-call", "session"] as const)("reaches a %s kernel and its subprocess children", async kernelMode => {
+		const result = await executePython(printIdentity, {
+			cwd: os.tmpdir(),
+			sessionId: `python:identity-${kernelMode}`,
+			kernelMode,
+			ompSessionId: "sess-1",
+			ompAgentId: "Agent-1",
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.output.trim().split("\n")).toEqual(["kernel sess-1 Agent-1", "child sess-1 Agent-1"]);
+	});
+
+	// A retained kernel is shared by every owner on its (session, cwd,
+	// interpreter) tuple, so the identity has to be re-applied per request —
+	// that is the runner's `_MANAGED_ENV_KEYS` half of the contract, and the
+	// only way a stale agent id could leak into a sibling's children.
+	it("re-applies the identity on every request to a retained kernel", async () => {
+		const options = {
+			cwd: os.tmpdir(),
+			sessionId: "python:identity-reuse",
+			kernelMode: "session" as const,
+			ompSessionId: "sess-1",
+		};
+		await executePython(printIdentity, { ...options, ompAgentId: "Agent-1" });
+		const second = await executePython(printIdentity, { ...options, ompAgentId: "Agent-2" });
+
+		expect(second.output.trim().split("\n")).toEqual(["kernel sess-1 Agent-2", "child sess-1 Agent-2"]);
 	});
 });

--- a/packages/coding-agent/test/snapcompact-inline.test.ts
+++ b/packages/coding-agent/test/snapcompact-inline.test.ts
@@ -208,6 +208,41 @@ describe("SnapcompactInlineTransformer", () => {
 		expect((context.messages[0] as { content: string }).content).toBe("first user prompt");
 	});
 
+	it("never images structured envelopes, though prose of the same weight is imaged", async () => {
+		const options = withTestShape({ renderSystemPrompt: "none", renderToolResults: true });
+		const transformer = new SnapcompactInlineTransformer(options);
+		const model = makeModel();
+		// One per detection branch: `ok:` head, JSON head, and a mapping whose
+		// `ok` key only shows up once the head is parsed.
+		const envelopes: Record<string, string> = {
+			yamlOkHead: `ok: true\nschemaVersion: '2'\ndata:\n  text: ${LARGE}`,
+			jsonHead: JSON.stringify({ ok: true, data: { text: LARGE } }),
+			okAfterFirstKey: `schemaVersion: '2'\nok: false\nerror:\n  code: rate_limited\n  message: ${LARGE}`,
+		};
+		for (const [label, envelope] of Object.entries(envelopes)) {
+			const context: Context = {
+				systemPrompt: ["You are a coding agent."],
+				messages: [userMessage("go"), toolResult("call_env", envelope), toolResult("call_last", SMALL)],
+			};
+			const result = await transformer.transform(context, model);
+			expect(imageCount(result), label).toBe(0);
+			expect((result.messages[1] as ToolResultMessage).content, label).toEqual([{ type: "text", text: envelope }]);
+			// The /context estimate must agree with the live transform.
+			expect(
+				estimateInlineSavings({ options, model, systemPrompt: [], messages: context.messages }).toolResults
+					?.swapped,
+				label,
+			).toBe(0);
+		}
+
+		// Control: identical position and size, prose instead of an envelope.
+		const prose: Context = {
+			systemPrompt: ["You are a coding agent."],
+			messages: [userMessage("go"), toolResult("call_env", LARGE), toolResult("call_last", SMALL)],
+		};
+		expect(imageCount(await transformer.transform(prose, model))).toBeGreaterThan(0);
+	});
+
 	it("compacts text in mixed tool results while preserving every source image and the input context", async () => {
 		const options = withTestShape({ renderSystemPrompt: "all", renderToolResults: true });
 		const renderedTexts: string[] = [];

--- a/packages/coding-agent/test/task/structured-subagent.test.ts
+++ b/packages/coding-agent/test/task/structured-subagent.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { loadSkillsFromDir, type Skill } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
 import {
 	artifactsDirsFromRegistry,
 	resetRegisteredArtifactDirsForTests,
@@ -42,10 +43,12 @@ function session(
 		isolationApply?: boolean;
 		modelRoles?: Record<string, string>;
 		agentServiceTierOverrides?: Record<string, string>;
+		skills?: Skill[];
 	} = {},
 ): ToolSession {
 	return {
 		cwd: options.cwd ?? "/tmp",
+		skills: options.skills ?? [],
 		hasUI: false,
 		outputSchema: options.outputSchema,
 		settings:
@@ -129,6 +132,44 @@ describe("structured subagent primitive", () => {
 		inheritedSession.outputSchemaMode = "strict";
 		const inherited = await resolveEffectiveSubagentPolicy(request({ session: inheritedSession }));
 		expect(inherited.schema).toMatchObject({ source: "session", mode: "strict", outputSchemaOverridesAgent: false });
+	});
+
+	it("refuses a spawn when an assignment's skill requires a tool the agent lacks", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-skill-requires-"));
+		try {
+			await fs.mkdir(path.join(dir, "shipit"), { recursive: true });
+			await fs.writeFile(
+				path.join(dir, "shipit", "SKILL.md"),
+				"---\nname: shipit\ndescription: Ship the build\nmetadata:\n  requires:\n    - bash\n---\n\nRun the deploy script.\n",
+			);
+			const { skills } = await loadSkillsFromDir({ dir, source: "custom:user" });
+			expect(skills.map(skill => skill.requires)).toEqual([["bash"]]);
+
+			const skillRequest = request({
+				session: session({ skills }),
+				assignment: "Follow skill://shipit exactly, then report.",
+			});
+
+			// AGENT declares read/write/ast_grep — no bash.
+			mockDiscovery();
+			await expect(resolveEffectiveSubagentPolicy(skillRequest)).rejects.toThrow(
+				"skill shipit requires tool bash; agent worker lacks it",
+			);
+
+			// Unreferenced skills never gate a spawn.
+			vi.restoreAllMocks();
+			mockDiscovery();
+			await expect(
+				resolveEffectiveSubagentPolicy(request({ session: session({ skills }), assignment: "Just look around." })),
+			).resolves.toMatchObject({ agentName: "worker" });
+
+			// `exec` expands to bash, so the requirement is satisfied.
+			vi.restoreAllMocks();
+			mockDiscovery({ ...AGENT, tools: ["read", "exec"] });
+			await expect(resolveEffectiveSubagentPolicy(skillRequest)).resolves.toMatchObject({ agentName: "worker" });
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
 	});
 
 	it("gives task and eval invocations identical blocked-agent preflight errors", async () => {


### PR DESCRIPTION
## Why

An audit of 40 September sessions that used the twitter CLI found three harness-side failure modes: five sessions assigned a CLI-backed skill to a shell-less profile (scout/analyst), which then silently substituted web search and shipped false negatives; four sessions had 13-24 KB YAML tool results rasterized into PNG frames, making post ids uncopyable; and no external process can attribute its work to a session, which blocks the CLI-side query log that replaces transcript mining as the benchmark label source.

## What

Three independent changes, each small:

- Bash children and python kernels receive `OMP_SESSION_ID` and `OMP_AGENT_ID` (`agent-identity-env.ts`, `bash.ts` resolvedEnv, `executor-base.ts` MANAGED_KERNEL_ENV_KEYS, `runner.py`). Caller-supplied env still wins. The kernel keys are refreshed per request because the runner pops unknown keys, so a retained kernel would otherwise keep a stale agent id.
- Skill frontmatter `metadata.requires: [tool...]` is carried on the runtime `Skill` (`skillRequiredTools`) and checked in `resolveEffectiveSubagentPolicy` via `assertSkillToolRequirements`: an assignment that references `skill://<name>` fails preflight with `skill X requires tool bash; agent Y lacks it`. Tool resolution is shared with the executor through `subagent-tools.ts` so preflight and spawn cannot disagree; it assumes the widest surface, so it never rejects a spawn that would have worked.
- `isStructuredToolResult` in `snapcompact-inline.ts` forces `frames = 0` for text whose head is an `ok:`/JSON/YAML mapping envelope; the savings estimate and the transform share the predicate.

Non-goal: the managed python venv is documented on `resolveManagedPythonEnv`, not created here.

## Verification

`bun test` on the four touched test files: 74 pass, including a real 4-process kernel test proving the identity survives kernel reuse and a `subprocess` grandchild; `check:types` clean. Counterfactual checked: removing the two keys from `runner.py` fails the reuse test.

## Rollback

Each change is one module; revert independently. The env vars are additive and unread by anything in this repo.
